### PR TITLE
Backfill migrations to create clean migration path

### DIFF
--- a/src/Migrations/Version19700101000000.php
+++ b/src/Migrations/Version19700101000000.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Creates the event store.
+ */
+class Version19700101000000 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // @see \Broadway\EventStore\DBALEventStore
+        $table = $schema->createTable('events');
+
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
+        $table->addColumn('uuid', 'guid', array('length' => 36));
+        $table->addColumn('playhead', 'integer', array('unsigned' => true));
+        $table->addColumn('payload', 'text');
+        $table->addColumn('metadata', 'text');
+        $table->addColumn('recorded_on', 'string', array('length' => 32));
+        $table->addColumn('type', 'text');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('uuid', 'playhead'));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $schema->dropTable('events');
+    }
+}

--- a/src/Migrations/Version19700101000001.php
+++ b/src/Migrations/Version19700101000001.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Creates the organizer store.
+ */
+class Version19700101000001 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // @see \Broadway\EventStore\DBALEventStore
+        $table = $schema->createTable('organizers');
+
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
+        $table->addColumn('uuid', 'guid', array('length' => 36));
+        $table->addColumn('playhead', 'integer', array('unsigned' => true));
+        $table->addColumn('payload', 'text');
+        $table->addColumn('metadata', 'text');
+        $table->addColumn('recorded_on', 'string', array('length' => 32));
+        $table->addColumn('type', 'text');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('uuid', 'playhead'));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $schema->dropTable('organizers');
+    }
+}

--- a/src/Migrations/Version19700101000002.php
+++ b/src/Migrations/Version19700101000002.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Creates the places store.
+ */
+class Version19700101000002 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // @see \Broadway\EventStore\DBALEventStore
+        $table = $schema->createTable('places');
+
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
+        $table->addColumn('uuid', 'guid', array('length' => 36));
+        $table->addColumn('playhead', 'integer', array('unsigned' => true));
+        $table->addColumn('payload', 'text');
+        $table->addColumn('metadata', 'text');
+        $table->addColumn('recorded_on', 'string', array('length' => 32));
+        $table->addColumn('type', 'text');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('uuid', 'playhead'));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $schema->dropTable('places');
+    }
+}

--- a/src/Migrations/Version19700101000003.php
+++ b/src/Migrations/Version19700101000003.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Creates the event_relations table.
+ */
+class Version19700101000003 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // @see \CultuurNet\UDB3\Event\ReadModel\Relations\Doctrine\DBALRepository
+        $table = $schema->createTable('event_relations');
+
+        $table->addColumn(
+            'event',
+            'string',
+            array('length' => 32, 'notnull' => false)
+        );
+        $table->addColumn(
+            'organizer',
+            'string',
+            array('length' => 32, 'notnull' => false)
+        );
+        $table->addColumn(
+            'place',
+            'string',
+            array('length' => 32, 'notnull' => false)
+        );
+
+        $table->setPrimaryKey(array('event'));
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $schema->dropTable('event_relations');
+    }
+}


### PR DESCRIPTION
In order to create a clean migration path from an empty database
to the latest schema version, a number of missing migrations have
been added here. This makes the database population through migrations
equivalent to the method via the DatabaseSchemaInstaller class.

Database migrations have been numbered starting from epoch (01/01/1970)
for lack of availability of a more accurate timestamp. This will
ensure they're processed first.