### PR TITLE
III-331: Removed duplicate saved searches provider registration

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -649,7 +649,6 @@ $app->get(
 );
 
 $app->mount('saved-searches', new \CultuurNet\UDB3\Silex\SavedSearchesControllerProvider());
-$app->register(new \CultuurNet\UDB3\Silex\SavedSearchesServiceProvider());
 
 $app->mount('variations', new \CultuurNet\UDB3\Silex\VariationsControllerProvider());
 


### PR DESCRIPTION
The service is registered in bootstrap.php and was registered a second time in index.php.