### PR TITLE
Fix migration crashing on existing index

### DIFF
--- a/src/Migrations/Version20170731151814.php
+++ b/src/Migrations/Version20170731151814.php
@@ -18,9 +18,6 @@ class Version20170731151814 extends AbstractMigration
     public function up(Schema $schema)
     {
         $this->getIndexTable($schema)
-            ->setPrimaryKey(['entity_id']);
-
-        $this->getIndexTable($schema)
             ->changeColumn(
                 'zip',
                 [


### PR DESCRIPTION
As discussed with @willaerk , we're going to remove the custom `install` command and setup the application using the doctrine migrations instead. However one of these crashes on an existing index when running all migrations from start to end. This PR fixes that.