### PR TITLE
III-2917 Change constraint_query column to longtext

### DIFF
--- a/src/Migrations/Version20190509112328.php
+++ b/src/Migrations/Version20190509112328.php
@@ -19,10 +19,13 @@ class Version20190509112328 extends AbstractMigration
     {
         $table = $schema->getTable('roles_search_v3');
 
-        $table->changeColumn('constraint_query', [
-            'type' => Type::getType(Type::TEXT),
-            'length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT + 1,
-        ]);
+        $table->changeColumn(
+            'constraint_query',
+            [
+                'type' => Type::getType(Type::TEXT),
+                'length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT + 1,
+            ]
+        );
     }
 
     /**
@@ -32,9 +35,12 @@ class Version20190509112328 extends AbstractMigration
     {
         $table = $schema->getTable('roles_search_v3');
 
-        $table->changeColumn('constraint_query', [
-            'type' => Type::getType(Type::STRING),
-            'length' => 255,
-        ]);
+        $table->changeColumn(
+            'constraint_query',
+            [
+                'type' => Type::getType(Type::STRING),
+                'length' => 255,
+            ]
+        );
     }
 }

--- a/src/Migrations/Version20190509112328.php
+++ b/src/Migrations/Version20190509112328.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190509112328 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $table = $schema->getTable('roles_search_v3');
+
+        $table->changeColumn('constraint_query', [
+            'type' => Type::getType(Type::TEXT),
+            'length' => MySqlPlatform::LENGTH_LIMIT_MEDIUMTEXT + 1,
+        ]);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $table = $schema->getTable('roles_search_v3');
+
+        $table->changeColumn('constraint_query', [
+            'type' => Type::getType(Type::STRING),
+            'length' => 255,
+        ]);
+    }
+}


### PR DESCRIPTION
This will make sure the columns becomes `longtext` on both existing and new installations since we're using migrations to setup new installations since https://bitbucket.org/cultuurnet/udb3-vagrant/pull-requests/60/install-the-silex-database-using/diff