### PR TITLE
Fix issues with src -> app rename in tooling config

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="UDB3-Silex" default="test">
     <fileset id="php" dir=".">
+        <include name="app/**/*.php"/>
         <include name="src/**/*.php"/>
     </fileset>
 

--- a/migrations.yml
+++ b/migrations.yml
@@ -1,4 +1,4 @@
 name: UDB3 Migrations
 migrations_namespace: CultuurNet\UDB3\Silex\Migrations
 table_name: doctrine_migration_versions
-migrations_directory: src/Migrations
+migrations_directory: app/Migrations


### PR DESCRIPTION
### Fixed

- Updated the path to the migration classes to `app`
- Included the `app` directory in the `phing` tasks (e.g. linting, coding standards, ...)