### PR TITLE
Fix permission check when dispatching commands

### DIFF
--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -106,7 +106,7 @@ class CommandBusServiceProvider implements ServiceProviderInterface
                 return new LazyLoadingCommandBus(
                     new ValidatingCommandBusDecorator(
                         new ContextDecoratedCommandBus(
-                            new SimpleCommandBus(),
+                            $app['authorized_command_bus'],
                             $app
                         ),
                         $app['event_command_validator']

--- a/app/ErrorHandlerProvider.php
+++ b/app/ErrorHandlerProvider.php
@@ -6,6 +6,7 @@ use Crell\ApiProblem\ApiProblem;
 use CultuurNet\Deserializer\DataValidationException;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\HttpFoundation\Response\ApiProblemJsonResponse;
+use CultuurNet\UDB3\Security\CommandAuthorizationException;
 use CultuurNet\UDB3\Variations\Command\ValidationException;
 use Respect\Validation\Exceptions\GroupedValidationException;
 use Silex\Application;
@@ -45,6 +46,14 @@ class ErrorHandlerProvider implements ServiceProviderInterface
         $app->error(
             function (EntityNotFoundException $e) {
                 $problem = $this->createNewApiProblem($e);
+                return new ApiProblemJsonResponse($problem);
+            }
+        );
+
+        $app->error(
+            function (CommandAuthorizationException $e) {
+                $problem = $this->createNewApiProblem($e);
+                $problem->setStatus(401);
                 return new ApiProblemJsonResponse($problem);
             }
         );


### PR DESCRIPTION
### Fixed

- Permissions are now checked again when dispatching a command

### Changed

- Unauthorized commands now return a `401` status code instead of a `400`