### PR TITLE
Clean up some low hanging fruit

### DIFF
--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -3,7 +3,6 @@
 
 namespace CultuurNet\UDB3\Silex\Authentication;
 
-use CultuurNet\UDB3\ApiGuard\ApiKey\AllowAnyAuthenticator;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CompositeApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CustomHeaderApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\QueryParameterApiKeyReader;
@@ -13,7 +12,6 @@ use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedApiKeyAuthenticator;
 use CultuurNet\UDB3\ApiGuard\Request\ApiKeyRequestAuthenticator;
 use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
-use CultuurNet\UDB3\Silex\Impersonator;
 use Qandidate\Toggle\ToggleManager;
 use Silex\Application;
 use Silex\ServiceProviderInterface;

--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\Silex\CommandHandling;
 
-use Broadway\CommandHandling\SimpleCommandBus;
 use CultuurNet\Broadway\CommandHandling\Validation\CompositeCommandValidator;
 use CultuurNet\Broadway\CommandHandling\Validation\ValidatingCommandBusDecorator;
 use CultuurNet\UDB3\CommandHandling\AuthorizedCommandBus;

--- a/app/Console/AbstractFireProjectedToJSONLDCommand.php
+++ b/app/Console/AbstractFireProjectedToJSONLDCommand.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use CultuurNet\UDB3\Silex\Organizer\OrganizerJSONLDServiceProvider;
 use CultuurNet\UDB3\Silex\Place\PlaceJSONLDServiceProvider;
-use CultuurNet\UDB3\SimpleEventBus;
 use Knp\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/app/Console/EventCdbXmlCommand.php
+++ b/app/Console/EventCdbXmlCommand.php
@@ -5,7 +5,6 @@
 
 namespace CultuurNet\UDB3\Silex\Console;
 
-use CultuurNet\UDB3\Event\Events\EventCdbXMLInterface;
 use CultuurNet\UDB3\UDB2\EventCdbXmlServiceInterface;
 use Knp\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/app/Console/ImportRoleConstraintsCommand.php
+++ b/app/Console/ImportRoleConstraintsCommand.php
@@ -7,7 +7,6 @@ use CultuurNet\UDB3\Role\Commands\AddConstraint;
 use CultuurNet\UDB3\Role\Commands\UpdateConstraint;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use CultuurNet\UDB3\ValueObject\SapiVersion;
-use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;

--- a/app/Console/PurgeModelCommand.php
+++ b/app/Console/PurgeModelCommand.php
@@ -6,7 +6,6 @@ use CultuurNet\UDB3\Silex\PurgeServiceProvider;
 use CultuurNet\UDB3\Storage\PurgeServiceInterface;
 use CultuurNet\UDB3\Storage\PurgeServiceManager;
 use Knp\Command\Command;
-use Silex\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/app/Console/SearchCacheWarmCommand.php
+++ b/app/Console/SearchCacheWarmCommand.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\Silex\Console;
 
-use CultuurNet\UDB3\Search\Cache\CacheManager;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Input\InputInterface;

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -2,9 +2,7 @@
 
 namespace CultuurNet\UDB3\Silex\Labels;
 
-use Broadway\Serializer\SimpleInterfaceSerializer;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
-use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
 use CultuurNet\UDB3\Label\CommandHandler;
 use CultuurNet\UDB3\Label\ConstraintAwareLabelService;

--- a/app/Media/MediaServiceProvider.php
+++ b/app/Media/MediaServiceProvider.php
@@ -2,9 +2,7 @@
 
 namespace CultuurNet\UDB3\Silex\Media;
 
-use Broadway\Serializer\SimpleInterfaceSerializer;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
-use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Media\ImageUploaderService;
 use CultuurNet\UDB3\Media\MediaManager;

--- a/app/Role/RoleReadingServiceProvider.php
+++ b/app/Role/RoleReadingServiceProvider.php
@@ -5,7 +5,6 @@ namespace CultuurNet\UDB3\Silex\Role;
 use CultuurNet\UDB3\Role\Services\LocalRoleReadingService;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class RoleReadingServiceProvider implements ServiceProviderInterface
 {

--- a/app/SavedSearches/SavedSearchesServiceProvider.php
+++ b/app/SavedSearches/SavedSearchesServiceProvider.php
@@ -4,7 +4,6 @@ namespace CultuurNet\UDB3\Silex\SavedSearches;
 
 use CultuurNet\UDB3\SavedSearches\CombinedSavedSearchRepository;
 use CultuurNet\UDB3\SavedSearches\FixedSavedSearchRepository;
-use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
 use CultuurNet\UDB3\SavedSearches\Sapi3FixedSavedSearchRepository;
 use CultuurNet\UDB3\SavedSearches\SavedSearchReadRepositoryCollection;
 use CultuurNet\UDB3\SavedSearches\SavedSearchWriteRepositoryCollection;

--- a/app/Search/SAPISearchControllerProvider.php
+++ b/app/Search/SAPISearchControllerProvider.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Http\Search\SearchController;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 class SAPISearchControllerProvider implements ControllerProviderInterface
 {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -36,7 +36,6 @@ use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Qandidate\Toggle\ToggleManager;
 use Silex\Application;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use ValueObjects\Number\Natural;
 use ValueObjects\StringLiteral\StringLiteral;
 
 date_default_timezone_set('Europe/Brussels');

--- a/src/EventExport/EventExportServiceInterface.php
+++ b/src/EventExport/EventExportServiceInterface.php
@@ -2,10 +2,8 @@
 
 namespace CultuurNet\UDB3\EventExport;
 
-use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use Psr\Log\LoggerInterface;
 use ValueObjects\Web\EmailAddress;
-use ValueObjects\Web\Url;
 
 interface EventExportServiceInterface
 {

--- a/src/EventExport/Format/HTML/Uitpas/Promotion/EventOrganizerPromotionQueryFactory.php
+++ b/src/EventExport/Format/HTML/Uitpas/Promotion/EventOrganizerPromotionQueryFactory.php
@@ -4,7 +4,6 @@
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\Promotion;
 
 use CultureFeed_Uitpas_Event_CultureEvent;
-use CultureFeed_Uitpas_Passholder_Query_SearchPromotionPointsOptions;
 use CultureFeed_Uitpas_Calendar;
 use CultureFeed_Uitpas_Calendar_Period;
 use CultuurNet\Clock\Clock;

--- a/src/Http/CommandDeserializerController.php
+++ b/src/Http/CommandDeserializerController.php
@@ -6,7 +6,6 @@ use Broadway\CommandHandling\CommandBusInterface;
 use CultuurNet\Deserializer\DeserializerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * Creates a command by deserializing the body of a request using the injected

--- a/src/Http/Deserializer/Place/MajorInfo.php
+++ b/src/Http/Deserializer/Place/MajorInfo.php
@@ -5,7 +5,6 @@ namespace CultuurNet\UDB3\Http\Deserializer\Place;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Event\EventType;
-use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 

--- a/src/Http/Event/EditEventRestController.php
+++ b/src/Http/Event/EditEventRestController.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\Http\Event;
 
-use CultuurNet\Deserializer\DataValidationException;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;

--- a/src/Http/Label/CommandType.php
+++ b/src/Http/Label/CommandType.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\Http\Label;
 
-use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Enum\Enum;
 
 /**

--- a/src/Http/User/UserIdentityController.php
+++ b/src/Http/User/UserIdentityController.php
@@ -5,8 +5,6 @@ namespace CultuurNet\UDB3\Http\User;
 use Crell\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\HttpFoundation\ApiProblemJsonResponse;
 use CultuurNet\UDB3\Http\JsonLdResponse;
-use CultuurNet\UDB3\UiTID\UsersInterface;
-use CultuurNet\UDB3\User\CultureFeedUserIdentityDetailsFactoryInterface;
 use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolverInterface;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -25,7 +25,6 @@ use CultuurNet\UDB3\Event\Commands\UpdateType;
 use CultuurNet\UDB3\Event\Commands\UpdateTypicalAgeRange;
 use CultuurNet\UDB3\Event\Event as EventAggregate;
 use CultuurNet\UDB3\Event\ValueObjects\Audience;
-use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\Event\Event;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;

--- a/src/Model/Import/Event/Udb3ModelToLegacyEventAdapter.php
+++ b/src/Model/Import/Event/Udb3ModelToLegacyEventAdapter.php
@@ -45,12 +45,4 @@ class Udb3ModelToLegacyEventAdapter extends Udb3ModelToLegacyOfferAdapter implem
         $audienceType = $this->event->getAudienceType();
         return AudienceType::fromNative($audienceType->toString());
     }
-
-    /**
-     * @return string
-     */
-    private function getPlaceId()
-    {
-        return $this->place->getId()->toString();
-    }
 }

--- a/src/Model/Import/Organizer/OrganizerDocumentImporter.php
+++ b/src/Model/Import/Organizer/OrganizerDocumentImporter.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\Organizer\Organizer;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Organizer\Commands\ImportLabels;
 use CultuurNet\UDB3\Organizer\Commands\UpdateAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;

--- a/src/Model/Import/Place/PlaceDocumentImporter.php
+++ b/src/Model/Import/Place/PlaceDocumentImporter.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Import\MediaObject\ImageCollectionFactory;
 use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\Place\Place;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Place\Commands\ImportLabels;
 use CultuurNet\UDB3\Place\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Place\Commands\DeleteTypicalAgeRange;

--- a/src/UDB2/Label/LabelImporter.php
+++ b/src/UDB2/Label/LabelImporter.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
 use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
-use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\LabelCollection;

--- a/tests/EventExport/EventExportServiceTest.php
+++ b/tests/EventExport/EventExportServiceTest.php
@@ -68,11 +68,6 @@ class EventExportServiceTest extends TestCase
     protected $searchResults;
 
     /**
-     * @var IriOfferIdentifier[]
-     */
-    private $offerIdentifiers;
-
-    /**
      * @var array
      */
     protected $searchResultsDetails;

--- a/tests/EventExport/EventExportServiceTest.php
+++ b/tests/EventExport/EventExportServiceTest.php
@@ -183,13 +183,6 @@ class EventExportServiceTest extends TestCase
                 }
             );
 
-        $offerIdentifiers = array_filter(
-            $this->searchResults,
-            function ($offerIdentifier) use ($unavailableEventIds) {
-                return !in_array($offerIdentifier->getId(), $unavailableEventIds);
-            }
-        );
-
         $this->resultsGenerator->expects($this->any())
             ->method('search')
             ->willReturn(new ArrayIterator($this->searchResults));

--- a/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
@@ -5,7 +5,6 @@
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML;
 
-use CultuurNet\UDB3\Event\ReadModel\Calendar\CalendarRepositoryInterface;
 use CultuurNet\UDB3\EventExport\CalendarSummary\CalendarSummaryRepositoryInterface;
 use CultuurNet\UDB3\EventExport\CalendarSummary\ContentType;
 use CultuurNet\UDB3\EventExport\CalendarSummary\Format;
@@ -15,7 +14,6 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfo;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfoServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class HTMLEventFormatterTest extends TestCase
 {

--- a/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLFileWriterTest.php
@@ -2,9 +2,7 @@
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML;
 
-use CultuurNet\UDB3\EventExport\Format\HTML\Twig\GoogleMapUrlGenerator;
 use PHPUnit\Framework\TestCase;
-use Twig_Environment;
 
 class HTMLFileWriterTest extends TestCase
 {

--- a/tests/EventExport/Format/HTML/Properties/TitleTest.php
+++ b/tests/EventExport/Format/HTML/Properties/TitleTest.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Properties;
 
-use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
 use \InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/EventExport/Format/HTML/Zipped/ZippedWebArchiveFileWriterTest.php
+++ b/tests/EventExport/Format/HTML/Zipped/ZippedWebArchiveFileWriterTest.php
@@ -7,8 +7,6 @@ namespace CultuurNet\UDB3\EventExport\Format\HTML\Zipped;
 
 use Alchemy\Zippy\Zippy;
 use CultuurNet\UDB3\EventExport\Format\HTML\HTMLFileWriter;
-use CultuurNet\UDB3\EventExport\Format\HTML\Zipped\ZippedWebArchiveFileWriter;
-
 use PHPUnit\Framework\TestCase;
 use \Twig_Environment;
 use \Twig_Loader_Filesystem;

--- a/tests/Http/CommandDeserializerControllerTest.php
+++ b/tests/Http/CommandDeserializerControllerTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Http;
 
 use Broadway\CommandHandling\CommandBusInterface;
 use CultuurNet\Deserializer\DeserializerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,12 +13,12 @@ use ValueObjects\StringLiteral\StringLiteral;
 class CommandDeserializerControllerTest extends TestCase
 {
     /**
-     * @var DeserializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerInterface|MockObject
      */
     private $deserializer;
 
     /**
-     * @var CommandBusInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBusInterface|MockObject
      */
     private $commandBus;
 

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
 use ValueObjects\DateTime\Minute;
@@ -17,7 +18,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class CalendarJSONDeserializerTest extends TestCase
 {
     /**
-     * @var DataValidatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DataValidatorInterface|MockObject
      */
     private $calendarDataValidator;
 

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -6,7 +6,6 @@ use CultuurNet\UDB3\Calendar\DayOfWeek;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
 use CultuurNet\UDB3\Calendar\OpeningTime;
-use CultuurNet\UDB3\Timestamp;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
 use ValueObjects\DateTime\Minute;

--- a/tests/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializerTest.php
@@ -3,7 +3,6 @@
 namespace CultuurNet\UDB3\Http\Deserializer\PriceInfo;
 
 use CultuurNet\Deserializer\DataValidationException;
-use CultuurNet\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;

--- a/tests/Http/Event/EditEventRestControllerTest.php
+++ b/tests/Http/Event/EditEventRestControllerTest.php
@@ -19,8 +19,8 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Event\Location\LocationNotFound;
 use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use ValueObjects\Identity\UUID;
@@ -33,17 +33,17 @@ class EditEventRestControllerTest extends TestCase
     private $controller;
 
     /**
-     * @var EventEditingServiceInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var EventEditingServiceInterface|MockObject
      */
     private $eventEditor;
 
     /**
-     * @var MediaManagerInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var MediaManagerInterface|MockObject
      */
     private $mediaManager;
 
     /**
-     * @var IriGeneratorInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var IriGeneratorInterface|MockObject
      */
     private $iriGenerator;
 
@@ -63,12 +63,12 @@ class EditEventRestControllerTest extends TestCase
     private $apiKey;
 
     /**
-     * @var ConsumerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerInterface|\MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerSpecificationInterface|MockObject
      */
     private $shouldApprove;
 

--- a/tests/Http/Import/ImportRestControllerTest.php
+++ b/tests/Http/Import/ImportRestControllerTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,17 +33,17 @@ class ImportRestControllerTest extends TestCase
     private $apiKey;
 
     /**
-     * @var ConsumerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerInterface|MockObject
      */
     private $consumer;
 
     /**
-     * @var DocumentImporterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentImporterInterface|MockObject
      */
     private $importer;
 
     /**
-     * @var UuidGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UuidGeneratorInterface|MockObject
      */
     private $uuidGenerator;
 

--- a/tests/Http/Jobs/ReadRestControllerTest.php
+++ b/tests/Http/Jobs/ReadRestControllerTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Http\Jobs;
 
 use Crell\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\HttpFoundation\ApiProblemJsonResponse;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 class ReadRestControllerTest extends TestCase
 {
     /**
-     * @var JobsStatusFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var JobsStatusFactoryInterface|MockObject
      */
     private $jobsStatusFactory;
 

--- a/tests/Http/Label/EditRestControllerTest.php
+++ b/tests/Http/Label/EditRestControllerTest.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Label\Services\WriteServiceInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Identity\UUID;
@@ -19,7 +20,7 @@ class EditRestControllerTest extends TestCase
     private $uuid;
 
     /**
-     * @var WriteServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var WriteServiceInterface|MockObject
      */
     private $writeService;
 

--- a/tests/Http/Label/Query/QueryFactoryTest.php
+++ b/tests/Http/Label/Query/QueryFactoryTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Http\Label\Query;
 
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Http\Management\User\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Number\Natural;
@@ -17,7 +18,7 @@ class QueryFactoryTest extends TestCase
     const LIMIT_VALUE = 10;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 

--- a/tests/Http/Label/ReadRestControllerTest.php
+++ b/tests/Http/Label/ReadRestControllerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Http\Label\Query\QueryFactory;
 use CultuurNet\UDB3\Http\Label\Query\QueryFactoryInterface;
 use CultuurNet\UDB3\Http\Management\User\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,17 +37,17 @@ class ReadRestControllerTest extends TestCase
     private $query;
 
     /**
-     * @var ReadServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ReadServiceInterface|MockObject
      */
     private $readService;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var QueryFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var QueryFactoryInterface|MockObject
      */
     private $queryFactory;
 

--- a/tests/Http/Management/TokenMockingTrait.php
+++ b/tests/Http/Management/TokenMockingTrait.php
@@ -5,20 +5,21 @@ namespace CultuurNet\UDB3\Http\Management;
 use CultuurNet\SymfonySecurityJwt\Authentication\JwtUserToken;
 use Lcobucci\JWT\Claim\Basic as BasicClaim;
 use Lcobucci\JWT\Token as JwtToken;
+use PHPUnit\Framework\MockObject\MockObject;
 
 trait TokenMockingTrait
 {
     /**
      * @param string $userId
      *
-     * @return JwtUserToken|\PHPUnit_Framework_MockObject_MockObject
+     * @return JwtUserToken|MockObject
      */
     private function createMockToken($userId)
     {
         /** @var \PHPUnit_Framework_MockObject_MockBuilder $mockBuilder */
         $mockBuilder = $this->getMockBuilder(JwtUserToken::class);
 
-        /** @var JwtUserToken|\PHPUnit_Framework_MockObject_MockObject $token */
+        /** @var JwtUserToken|MockObject $token */
         $token = $mockBuilder
             ->setMethods(['isAuthenticated', 'getCredentials'])
             ->setMockClassName('JwtUserToken')

--- a/tests/Http/Management/TokenMockingTrait.php
+++ b/tests/Http/Management/TokenMockingTrait.php
@@ -5,6 +5,7 @@ namespace CultuurNet\UDB3\Http\Management;
 use CultuurNet\SymfonySecurityJwt\Authentication\JwtUserToken;
 use Lcobucci\JWT\Claim\Basic as BasicClaim;
 use Lcobucci\JWT\Token as JwtToken;
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 
 trait TokenMockingTrait
@@ -16,7 +17,7 @@ trait TokenMockingTrait
      */
     private function createMockToken($userId)
     {
-        /** @var \PHPUnit_Framework_MockObject_MockBuilder $mockBuilder */
+        /** @var MockBuilder $mockBuilder */
         $mockBuilder = $this->getMockBuilder(JwtUserToken::class);
 
         /** @var JwtUserToken|MockObject $token */

--- a/tests/Http/Management/UserPermissionsVoterTest.php
+++ b/tests/Http/Management/UserPermissionsVoterTest.php
@@ -4,8 +4,8 @@ namespace CultuurNet\UDB3\Http\Management;
 
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use ValueObjects\Identity\UUID;
@@ -15,7 +15,7 @@ class UserPermissionsVoterTest extends TestCase
     use TokenMockingTrait;
 
     /**
-     * @var UserPermissionsReadRepositoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var UserPermissionsReadRepositoryInterface|MockObject
      */
     protected $permissionRepository;
 

--- a/tests/Http/Media/EditMediaRestControllerTest.php
+++ b/tests/Http/Media/EditMediaRestControllerTest.php
@@ -3,9 +3,8 @@
 namespace CultuurNet\UDB3\Http\Media;
 
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
-use CultuurNet\UDB3\Media\ImageUploadResult;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,7 +14,7 @@ use ValueObjects\Identity\UUID;
 class EditMediaRestControllerTest extends TestCase
 {
     /**
-     * @var ImageUploaderInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var ImageUploaderInterface|MockObject
      */
     protected $imageUploader;
 

--- a/tests/Http/Offer/EditOfferRestControllerTest.php
+++ b/tests/Http/Offer/EditOfferRestControllerTest.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\Http\Deserializer\PriceInfo\PriceInfoJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\TitleJSONDeserializer;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Money\Currency;
@@ -30,12 +31,12 @@ use ValueObjects\StringLiteral\StringLiteral;
 class EditOfferRestControllerTest extends TestCase
 {
     /**
-     * @var OfferEditingServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var OfferEditingServiceInterface|MockObject
      */
     private $editService;
 
     /**
-     * @var MainLanguageQueryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var MainLanguageQueryInterface|MockObject
      */
     private $mainLanguageQuery;
 
@@ -65,12 +66,12 @@ class EditOfferRestControllerTest extends TestCase
     private $calendarDeserializer;
 
     /**
-     * @var DataValidatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DataValidatorInterface|MockObject
      */
     private $calendarDataValidator;
 
     /**
-     * @var DeserializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DeserializerInterface|MockObject
      */
     private $facilitiesJSONDeserializer;
 

--- a/tests/Http/Offer/OfferPermissionControllerTest.php
+++ b/tests/Http/Offer/OfferPermissionControllerTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use CultuurNet\UDB3\Offer\Security\Permission\PermissionVoterInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -16,7 +17,7 @@ class OfferPermissionControllerTest extends TestCase
     private $permission;
 
     /**
-     * @var PermissionVoterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PermissionVoterInterface|MockObject
      */
     private $voter;
 

--- a/tests/Http/Offer/OfferPermissionsControllerTest.php
+++ b/tests/Http/Offer/OfferPermissionsControllerTest.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Offer\Security\Permission\PermissionVoterInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Http\Assert\JsonEquals;
 use GuzzleHttp\Tests\Psr7\Str;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -18,7 +19,7 @@ class OfferPermissionsControllerTest extends TestCase
     private $permissions;
 
     /**
-     * @var PermissionVoterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PermissionVoterInterface|MockObject
      */
     private $voter;
 

--- a/tests/Http/Offer/OfferPermissionsControllerTest.php
+++ b/tests/Http/Offer/OfferPermissionsControllerTest.php
@@ -70,11 +70,7 @@ class OfferPermissionsControllerTest extends TestCase
      */
     public function it_returns_an_array_of_permissions_for_the_current_user()
     {
-        foreach ($this->permissions as $permission) {
-            $this->voter
-                ->method('isAllowed')
-                ->willReturn(true);
-        }
+        $this->voter->method('isAllowed')->willReturn(true);
 
         $actualResponse = $this->controllerWithUser
             ->getPermissionsForCurrentUser('b06a4ab4-a75b-49d1-b4ab-1992c1db908a');
@@ -95,11 +91,7 @@ class OfferPermissionsControllerTest extends TestCase
      */
     public function it_returns_an_array_of_permissions_for_a_given_user()
     {
-        foreach ($this->permissions as $permission) {
-            $this->voter
-                ->method('isAllowed')
-                ->willReturn(true);
-        }
+        $this->voter->method('isAllowed')->willReturn(true);
 
         $actualResponse = $this->controllerWithUser
             ->getPermissionsForGivenUser(

--- a/tests/Http/Offer/PatchOfferRestControllerTest.php
+++ b/tests/Http/Offer/PatchOfferRestControllerTest.php
@@ -15,15 +15,15 @@ use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsInappropriate as FlagAsInapp
 use CultuurNet\UDB3\Place\Commands\Moderation\Reject as RejectPlace;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
 use CultuurNet\UDB3\Offer\OfferType;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\StringLiteral\StringLiteral;
 
 class PatchOfferRestControllerTest extends TestCase
 {
     /**
-     * @var CommandBusInterface | PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBusInterface | MockObject
      */
     private $commandBus;
 

--- a/tests/Http/OfferRestBaseControllerTest.php
+++ b/tests/Http/OfferRestBaseControllerTest.php
@@ -8,25 +8,25 @@ use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\Offer\OfferEditingServiceInterface;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\StringLiteral\StringLiteral;
 
 class OfferRestBaseControllerTest extends TestCase
 {
     /**
-     * @var OfferEditingServiceInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var OfferEditingServiceInterface|MockObject
      */
     private $offerEditingService;
 
     /**
-     * @var MediaManagerInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var MediaManagerInterface|MockObject
      */
     private $mediaManager;
 
     /**
-     * @var OfferRestBaseController|PHPUnit_Framework_MockObject_MockObject
+     * @var OfferRestBaseController|MockObject
      */
     private $offerRestBaseController;
 

--- a/tests/Http/Organizer/EditOrganizerRestControllerTest.php
+++ b/tests/Http/Organizer/EditOrganizerRestControllerTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Organizer\OrganizerEditingServiceInterface;
 use CultuurNet\UDB3\Title;
 use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Geography\Country;
@@ -23,12 +24,12 @@ use ValueObjects\Web\Url;
 class EditOrganizerRestControllerTest extends TestCase
 {
     /**
-     * @var OrganizerEditingServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var OrganizerEditingServiceInterface|MockObject
      */
     private $editService;
 
     /**
-     * @var IriGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var IriGeneratorInterface|MockObject
      */
     private $iriGenerator;
 

--- a/tests/Http/Organizer/ReadOrganizerRestControllerTest.php
+++ b/tests/Http/Organizer/ReadOrganizerRestControllerTest.php
@@ -5,6 +5,7 @@ namespace CultuurNet\UDB3\Http\Organizer;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,7 +16,7 @@ class ReadOrganizerRestControllerTest extends TestCase
     const REMOVED_ID = 'removedId';
 
     /**
-     * @var EntityServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var EntityServiceInterface|MockObject
      */
     private $service;
 

--- a/tests/Http/Place/EditPlaceRestControllerTest.php
+++ b/tests/Http/Place/EditPlaceRestControllerTest.php
@@ -18,8 +18,8 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Place\PlaceEditingServiceInterface;
 use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Geography\Country;
 use ValueObjects\Identity\UUID;
@@ -32,22 +32,22 @@ class EditPlaceRestControllerTest extends TestCase
     private $placeRestController;
 
     /**
-     * @var PlaceEditingServiceInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var PlaceEditingServiceInterface|MockObject
      */
     private $placeEditingService;
 
     /**
-     * @var RepositoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|MockObject
      */
     private $relationsRepository;
 
     /**
-     * @var MediaManagerInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var MediaManagerInterface|MockObject
      */
     private $mediaManager;
 
     /**
-     * @var IriGeneratorInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var IriGeneratorInterface|MockObject
      */
     private $iriGenerator;
 
@@ -67,12 +67,12 @@ class EditPlaceRestControllerTest extends TestCase
     private $apiKey;
 
     /**
-     * @var ConsumerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerInterface|\MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerSpecificationInterface|\MockObject
      */
     private $shouldApprove;
 

--- a/tests/Http/Place/FacilitiesJSONDeserializerTest.php
+++ b/tests/Http/Place/FacilitiesJSONDeserializerTest.php
@@ -6,13 +6,14 @@ use CultuurNet\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Place\PlaceFacilityResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
 class FacilitiesJSONDeserializerTest extends TestCase
 {
     /**
-     * @var OfferFacilityResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var OfferFacilityResolverInterface|MockObject
      */
     private $facilityResolver;
 

--- a/tests/Http/Proxy/FilterPathMethodProxyTest.php
+++ b/tests/Http/Proxy/FilterPathMethodProxyTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Http\Proxy;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
@@ -25,7 +26,7 @@ class FilterPathMethodProxyTest extends TestCase
     private $request;
 
     /**
-     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ClientInterface|MockObject
      */
     private $client;
 

--- a/tests/Http/Proxy/ProxyTest.php
+++ b/tests/Http/Proxy/ProxyTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
@@ -17,27 +18,27 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 class ProxyTest extends TestCase
 {
     /**
-     * @var FilterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var FilterInterface|MockObject
      */
     private $filter;
 
     /**
-     * @var RequestTransformerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RequestTransformerInterface|MockObject
      */
     private $requestTransformer;
 
     /**
-     * @var DiactorosFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var DiactorosFactory|MockObject
      */
     private $diactorosFactory;
 
     /**
-     * @var HttpFoundationFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var HttpFoundationFactory|MockObject
      */
     private $httpFoundationFactory;
 
     /**
-     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ClientInterface|MockObject
      */
     private $client;
 

--- a/tests/Http/Role/EditRoleRestControllerTest.php
+++ b/tests/Http/Role/EditRoleRestControllerTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Http\Deserializer\Role\QueryJSONDeserializer;
 use CultuurNet\UDB3\Http\HttpFoundation\ApiProblemJsonResponse;
 use CultuurNet\UDB3\ValueObject\SapiVersion;
 use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Identity\UUID;
@@ -34,27 +35,27 @@ class EditRoleRestControllerTest extends TestCase
     private $labelId;
 
     /**
-     * @var RoleEditingServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RoleEditingServiceInterface|MockObject
      */
     private $editService;
 
     /**
-     * @var CommandBusInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBusInterface|MockObject
      */
     private $commandBus;
 
     /**
-     * @var UpdateRoleRequestDeserializer|\PHPUnit_Framework_MockObject_MockObject
+     * @var UpdateRoleRequestDeserializer|MockObject
      */
     private $updateRoleRequestDeserializer;
 
     /**
-     * @var QueryJSONDeserializer|\PHPUnit_Framework_MockObject_MockObject
+     * @var QueryJSONDeserializer|MockObject
      */
     private $queryJsonDeserializer;
 
     /**
-     * @var ReadServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ReadServiceInterface|MockObject
      */
     private $labelService;
 

--- a/tests/Http/Role/ReadRoleRestControllerTest.php
+++ b/tests/Http/Role/ReadRoleRestControllerTest.php
@@ -10,9 +10,9 @@ use CultuurNet\UDB3\Role\ReadModel\Search\RepositoryInterface;
 use CultuurNet\UDB3\Role\ReadModel\Search\Results;
 use CultuurNet\UDB3\Role\Services\RoleReadingServiceInterface;
 use CultuurNet\UDB3\Http\Assert\JsonEquals;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\HttpFoundation\Response;
 use ValueObjects\Identity\UUID;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -30,7 +30,7 @@ class ReadRoleRestControllerTest extends TestCase
     private $roleRestController;
 
     /**
-     * @var RoleReadingServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RoleReadingServiceInterface|MockObject
      */
     private $roleService;
 
@@ -40,7 +40,7 @@ class ReadRoleRestControllerTest extends TestCase
     private $jsonDocument;
 
     /**
-     * @var RepositoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|MockObject
      */
     private $roleSearchRepository;
 
@@ -60,7 +60,7 @@ class ReadRoleRestControllerTest extends TestCase
     private $authorizationList;
 
     /**
-     * @var UserPermissionsReadRepositoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var UserPermissionsReadRepositoryInterface|MockObject
      */
     private $permissionsRepository;
 
@@ -71,7 +71,7 @@ class ReadRoleRestControllerTest extends TestCase
     {
         $this->jsonDocument = new JsonDocument('id', 'role');
 
-        /** @var EntityServiceInterface|\PHPUnit_Framework_MockObject_MockObject $entityServiceInterface */
+        /** @var EntityServiceInterface|MockObject $entityServiceInterface */
         $entityServiceInterface = $this->createMock(EntityServiceInterface::class);
 
         $this->roleService = $this->createMock(RoleReadingServiceInterface::class);

--- a/tests/Http/SavedSearches/ReadSavedSearchesControllerTest.php
+++ b/tests/Http/SavedSearches/ReadSavedSearchesControllerTest.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
 use CultuurNet\UDB3\SavedSearches\SavedSearchReadRepositoryCollection;
 use CultuurNet\UDB3\ValueObject\SapiVersion;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -14,7 +15,7 @@ use ValueObjects\StringLiteral\StringLiteral;
 class ReadSavedSearchesControllerTest extends TestCase
 {
     /**
-     * @var SavedSearchRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SavedSearchRepositoryInterface|MockObject
      */
     private $savedSearchRepository;
 

--- a/tests/Http/User/SearchUserControllerTest.php
+++ b/tests/Http/User/SearchUserControllerTest.php
@@ -4,13 +4,14 @@ namespace CultuurNet\UDB3\Http\User;
 
 use CultuurNet\UDB3\Http\Assert\JsonEquals;
 use CultuurNet\UDB3\User\CultureFeedUserIdentityDetailsFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class SearchUserControllerTest extends TestCase
 {
     /**
-     * @var \ICultureFeed|\PHPUnit_Framework_MockObject_MockObject
+     * @var \ICultureFeed|MockObject
      */
     private $cultureFeed;
 

--- a/tests/Model/Import/Command/HttpImportCommandHandlerTest.php
+++ b/tests/Model/Import/Command/HttpImportCommandHandlerTest.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Message\RequestInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -22,7 +23,7 @@ class HttpImportCommandHandlerTest extends TestCase
     private $iriGenerator;
 
     /**
-     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ClientInterface|MockObject
      */
     private $httpClient;
 

--- a/tests/Model/Import/Event/EventDocumentImporterTest.php
+++ b/tests/Model/Import/Event/EventDocumentImporterTest.php
@@ -64,6 +64,7 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Timestamp;
 use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use ValueObjects\Identity\UUID;
@@ -74,7 +75,7 @@ use ValueObjects\Web\Url;
 class EventDocumentImporterTest extends TestCase
 {
     /**
-     * @var RepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|MockObject
      */
     private $repository;
 
@@ -84,7 +85,7 @@ class EventDocumentImporterTest extends TestCase
     private $denormalizer;
 
     /**
-     * @var ImageCollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var ImageCollectionFactory|MockObject
      */
     private $imageCollectionFactory;
 
@@ -94,17 +95,17 @@ class EventDocumentImporterTest extends TestCase
     private $commandBus;
 
     /**
-     * @var ConsumerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerInterface|MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerSpecificationInterface|MockObject
      */
     private $shouldApprove;
 
     /**
-     * @var LockedLabelRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LockedLabelRepository|MockObject
      */
     private $lockedLabelRepository;
 

--- a/tests/Model/Import/Event/Udb3ModelToLegacyEventAdapterTest.php
+++ b/tests/Model/Import/Event/Udb3ModelToLegacyEventAdapterTest.php
@@ -26,8 +26,6 @@ use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Geography\Country;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class Udb3ModelToLegacyEventAdapterTest extends TestCase
 {

--- a/tests/Model/Import/MediaObject/MediaManagerImageCollectionFactoryTest.php
+++ b/tests/Model/Import/MediaObject/MediaManagerImageCollectionFactoryTest.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\MediaObjectType;
 use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID as Udb3UUID;
 use ValueObjects\Web\Url as Udb3Url;
@@ -27,7 +28,7 @@ use ValueObjects\Web\Url as Udb3Url;
 class MediaManagerImageCollectionFactoryTest extends TestCase
 {
     /**
-     * @var MediaManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var MediaManagerInterface|MockObject
      */
     private $mediaManager;
 

--- a/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
+++ b/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
@@ -24,7 +24,6 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
-use CultuurNet\UDB3\Organizer\Commands\CreateOrganizer;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
+++ b/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\Organizer\Commands\CreateOrganizer;
 use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Geography\Country;
 use ValueObjects\Web\Url;
@@ -33,7 +34,7 @@ use ValueObjects\Web\Url;
 class OrganizerDocumentImporterTest extends TestCase
 {
     /**
-     * @var RepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|MockObject
      */
     private $repository;
 
@@ -48,7 +49,7 @@ class OrganizerDocumentImporterTest extends TestCase
     private $commandBus;
 
     /**
-     * @var LockedLabelRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LockedLabelRepository|MockObject
      */
     private $lockedLabelRepository;
 

--- a/tests/Model/Import/Place/PlaceDocumentImporterTest.php
+++ b/tests/Model/Import/Place/PlaceDocumentImporterTest.php
@@ -58,6 +58,7 @@ use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Geography\Country;
 use ValueObjects\Geography\CountryCode;
@@ -69,7 +70,7 @@ use ValueObjects\Web\Url;
 class PlaceDocumentImporterTest extends TestCase
 {
     /**
-     * @var RepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RepositoryInterface|MockObject
      */
     private $repository;
 
@@ -79,7 +80,7 @@ class PlaceDocumentImporterTest extends TestCase
     private $denormalizer;
 
     /**
-     * @var ImageCollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var ImageCollectionFactory|MockObject
      */
     private $imageCollectionFactory;
 
@@ -89,17 +90,17 @@ class PlaceDocumentImporterTest extends TestCase
     private $commandBus;
 
     /**
-     * @var ConsumerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerInterface|MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConsumerSpecificationInterface|MockObject
      */
     private $shouldApprove;
 
     /**
-     * @var LockedLabelRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LockedLabelRepository|MockObject
      */
     private $lockedLabelRepository;
 

--- a/tests/Model/Import/PreProcessing/LabelPreProcessingDocumentImporterTest.php
+++ b/tests/Model/Import/PreProcessing/LabelPreProcessingDocumentImporterTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -20,22 +21,22 @@ use ValueObjects\StringLiteral\StringLiteral;
 class LabelPreProcessingDocumentImporterTest extends TestCase
 {
     /**
-     * @var DocumentImporterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentImporterInterface|MockObject
      */
     private $importer;
 
     /**
-     * @var LabelRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 
     /**
-     * @var LabelServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelServiceInterface|MockObject
      */
     private $labelService;
 

--- a/tests/Model/Import/PreProcessing/LocationPreProcessingDocumentImporterTest.php
+++ b/tests/Model/Import/PreProcessing/LocationPreProcessingDocumentImporterTest.php
@@ -8,12 +8,13 @@ use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Place\PlaceIDParser;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class LocationPreProcessingDocumentImporterTest extends TestCase
 {
     /**
-     * @var DocumentImporterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentImporterInterface|MockObject
      */
     private $importer;
 
@@ -23,7 +24,7 @@ class LocationPreProcessingDocumentImporterTest extends TestCase
     private $placeIdParser;
 
     /**
-     * @var DocumentRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentRepositoryInterface|MockObject
      */
     private $placeDocumentRepository;
 

--- a/tests/Model/Import/PreProcessing/TermPreProcessingDocumentImporterTest.php
+++ b/tests/Model/Import/PreProcessing/TermPreProcessingDocumentImporterTest.php
@@ -5,12 +5,13 @@ namespace CultuurNet\UDB3\Model\Import\PreProcessing;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Import\Event\EventLegacyBridgeCategoryResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class TermPreProcessingDocumentImporterTest extends TestCase
 {
     /**
-     * @var DocumentImporterInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentImporterInterface|MockObject
      */
     private $importer;
 

--- a/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
+++ b/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
@@ -11,13 +11,14 @@ use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 
 final class RelationshipModelLockedLabelRepositoryTest extends TestCase
 {
     /**
-     * @var ReadRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ReadRepositoryInterface|MockObject
      */
     private $relationshipsRepository;
 

--- a/tests/Model/Import/Validation/Event/EventImportValidatorTest.php
+++ b/tests/Model/Import/Validation/Event/EventImportValidatorTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use CultuurNet\UDB3\Model\Validation\Event\EventValidator;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\Security\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class EventImportValidatorTest extends TestCase
@@ -23,17 +24,17 @@ class EventImportValidatorTest extends TestCase
     private $uuidParser;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var LabelsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelsRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 

--- a/tests/Model/Import/Validation/MediaObject/MediaObjectsExistValidatorTest.php
+++ b/tests/Model/Import/Validation/MediaObject/MediaObjectsExistValidatorTest.php
@@ -5,13 +5,14 @@ namespace CultuurNet\UDB3\Model\Import\Validation\MediaObject;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
 use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
 use CultuurNet\UDB3\MediaObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\GroupedValidationException;
 
 class MediaObjectsExistValidatorTest extends TestCase
 {
     /**
-     * @var MediaManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var MediaManagerInterface|MockObject
      */
     private $mediaManager;
 

--- a/tests/Model/Import/Validation/Organizer/OrganizerHasUniqueUrlValidatorTest.php
+++ b/tests/Model/Import/Validation/Organizer/OrganizerHasUniqueUrlValidatorTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Model\Import\Validation\Organizer;
 
 use CultuurNet\UDB3\Model\Organizer\OrganizerIDParser;
 use CultuurNet\UDB3\Organizer\WebsiteLookupServiceInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\CallbackException;
 use ValueObjects\Web\Url;
@@ -11,7 +12,7 @@ use ValueObjects\Web\Url;
 class OrganizerHasUniqueUrlValidatorTest extends TestCase
 {
     /**
-     * @var WebsiteLookupServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var WebsiteLookupServiceInterface|MockObject
      */
     private $lookupService;
 

--- a/tests/Model/Import/Validation/Organizer/OrganizerImportValidatorTest.php
+++ b/tests/Model/Import/Validation/Organizer/OrganizerImportValidatorTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Model\Validation\Organizer\OrganizerValidator;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\Organizer\WebsiteLookupServiceInterface;
 use CultuurNet\UDB3\Security\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class OrganizerImportValidatorTest extends TestCase
@@ -18,22 +19,22 @@ class OrganizerImportValidatorTest extends TestCase
     private $uuidParser;
 
     /**
-     * @var WebsiteLookupServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var WebsiteLookupServiceInterface|MockObject
      */
     private $websiteLookupService;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var LabelsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelsRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 

--- a/tests/Model/Import/Validation/Place/PlaceImportValidatorTest.php
+++ b/tests/Model/Import/Validation/Place/PlaceImportValidatorTest.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterfac
 use CultuurNet\UDB3\Model\Validation\Place\PlaceValidator;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\Security\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PlaceImportValidatorTest extends TestCase
@@ -17,17 +18,17 @@ class PlaceImportValidatorTest extends TestCase
     private $uuidParser;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var LabelsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelsRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 

--- a/tests/Model/Import/Validation/Place/PlaceReferenceExistsValidatorTest.php
+++ b/tests/Model/Import/Validation/Place/PlaceReferenceExistsValidatorTest.php
@@ -6,13 +6,14 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use CultuurNet\UDB3\Model\Place\PlaceIDParser;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\GroupedValidationException;
 
 class PlaceReferenceExistsValidatorTest extends TestCase
 {
     /**
-     * @var DocumentRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DocumentRepositoryInterface|MockObject
      */
     private $repository;
 

--- a/tests/Model/Import/Validation/Taxonomy/Label/DocumentLabelPermissionRuleTest.php
+++ b/tests/Model/Import/Validation/Taxonomy/Label/DocumentLabelPermissionRuleTest.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface as 
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface as LabelRelationsRepository;
 use CultuurNet\UDB3\Model\Event\EventIDParser;
 use CultuurNet\UDB3\Security\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -18,17 +19,17 @@ class DocumentLabelPermissionRuleTest extends TestCase
     private $uuidParser;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var LabelsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelsRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 

--- a/tests/Model/Import/Validation/Taxonomy/Label/LabelPermissionRuleTest.php
+++ b/tests/Model/Import/Validation/Taxonomy/Label/LabelPermissionRuleTest.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterfac
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Security\UserIdentificationInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -20,17 +21,17 @@ class LabelPermissionRuleTest extends TestCase
     private $documentId;
 
     /**
-     * @var UserIdentificationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UserIdentificationInterface|MockObject
      */
     private $userIdentification;
 
     /**
-     * @var LabelsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelsRepository|MockObject
      */
     private $labelsRepository;
 
     /**
-     * @var LabelRelationsRepository|\PHPUnit_Framework_MockObject_MockObject
+     * @var LabelRelationsRepository|MockObject
      */
     private $labelRelationsRepository;
 

--- a/tests/UDB2/Media/ImageCollectionFactoryTest.php
+++ b/tests/UDB2/Media/ImageCollectionFactoryTest.php
@@ -2,8 +2,6 @@
 
 namespace CultuurNet\UDB3\UDB2\Media;
 
-use CultureFeed_Cdb_Data_Media;
-use CultureFeed_Cdb_Item_Base;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Image;

--- a/tests/UDB2/Media/ImageCollectionFactoryTest.php
+++ b/tests/UDB2/Media/ImageCollectionFactoryTest.php
@@ -129,18 +129,4 @@ class ImageCollectionFactoryTest extends TestCase
         $images = $factory->fromUdb2Item($event);
         $this->assertEquals($expectedImages, $images);
     }
-
-    /**
-     * @param CultureFeed_Cdb_Item_Base $cdbItem
-     * @return CultureFeed_Cdb_Data_Media
-     */
-    private function getMedia(CultureFeed_Cdb_Item_Base $cdbItem)
-    {
-        $details = $cdbItem->getDetails();
-        $details->rewind();
-
-        return $details
-            ->current()
-            ->getMedia();
-    }
 }

--- a/tests/UDB2/Media/MediaImporterTest.php
+++ b/tests/UDB2/Media/MediaImporterTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Url;
 
 class MediaImporterTest extends TestCase


### PR DESCRIPTION
### Changed
- All tests now use properly namespaced `PHPUnit` classes instead of the old `PHPUnit_...`

### Removed
- A bunch of dead code (unused imports, unused private methods, unused variables)
