### PR TITLE
III-3002 Fix exports crashing on the backend

### DIFF
--- a/app/Export/ExportServiceProvider.php
+++ b/app/Export/ExportServiceProvider.php
@@ -25,7 +25,7 @@ class ExportServiceProvider implements ServiceProviderInterface
         $app['event_export_twig_environment'] = $app->share(
             function ($app) {
                 $loader = new \Twig_Loader_Filesystem(
-                    __DIR__ . '/../../vendor/cultuurnet/udb3-export/src/Format/HTML/templates'
+                    __DIR__ . '/../../src/EventExport/Format/HTML/templates'
                 );
 
                 $twig = new Twig_Environment($loader);


### PR DESCRIPTION
### Fixed

- Fixed an incorrect path to the HTML templates for the PDF exports, which caused every export to crash (even for the other types because this code was bootstrapped regardless of the export type).

---
Ticket: https://jira.uitdatabank.be/browse/III-3002
