### PR TITLE
Apply UiTPAS labels to events based on active card systems

### DIFF
--- a/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
+++ b/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
@@ -84,7 +84,6 @@ class UiTPASIncomingEventServicesProvider implements ServiceProviderInterface
         $app['uitpas_event_process_manager'] = $app->share(
             function (Application $app) {
                 return new EventProcessManager(
-                    $app['event_jsonld_repository'],
                     $app['event_command_bus'],
                     $app['uitpas_label_repository'],
                     $app['uitpas_logger']

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -7,20 +7,15 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListenerInterface;
 use CultuurNet\UDB3\Event\Commands\AddLabel;
 use CultuurNet\UDB3\Event\Commands\RemoveLabel;
-use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Offer\Commands\AbstractLabelCommand;
+use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use CultuurNet\UDB3\UiTPAS\Event\Event\EventCardSystemsUpdated;
 use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepository;
 use Psr\Log\LoggerInterface;
 
 class EventProcessManager implements EventListenerInterface
 {
-    /**
-     * @var DocumentRepositoryInterface
-     */
-    private $eventDocumentRepository;
-
     /**
      * @var CommandBusInterface
      */
@@ -37,18 +32,15 @@ class EventProcessManager implements EventListenerInterface
     private $logger;
 
     /**
-     * @param DocumentRepositoryInterface $eventDocumentRepository
      * @param CommandBusInterface $commandBus
      * @param UiTPASLabelsRepository $uitpasLabelsRepository
      * @param LoggerInterface $logger
      */
     public function __construct(
-        DocumentRepositoryInterface $eventDocumentRepository,
         CommandBusInterface $commandBus,
         UiTPASLabelsRepository $uitpasLabelsRepository,
         LoggerInterface $logger
     ) {
-        $this->eventDocumentRepository = $eventDocumentRepository;
         $this->commandBus = $commandBus;
         $this->uitpasLabelsRepository = $uitpasLabelsRepository;
         $this->logger = $logger;
@@ -82,21 +74,51 @@ class EventProcessManager implements EventListenerInterface
 
         $this->logger->info('Handling updated card systems message for event ' . $eventId);
 
-        $uitpasLabels = $this->uitpasLabelsRepository->loadAll();
+        $uitPasLabels = $this->uitpasLabelsRepository->loadAll();
 
-        // Simply remove all UiTPAS labels from the event, even if they're
-        // found on the JSON-LD or not. This is the best way to make sure
-        // there are no UiTPAS labels on the event, and the aggregate will
-        // just ignore the commands if the labels are not present anyway.
-        // Even if the UiTPAS labels are added again from the organizer.
-        // Otherwise we would have to check the event has UiTPAS labels
-        // which are not present on the organizer.
-        $this->logger->info('Removing all UiTPAS labels from event ' . $eventId);
-        $this->removeLabelsFromEvent($eventId, $uitpasLabels);
+        $expectedUitPasLabelsForEvent = array_map(
+            function (CardSystem $cardSystem) use ($uitPasLabels, $eventId) {
+                $id = $cardSystem->getId()->toNative();
+
+                if (isset($uitPasLabels[$id])) {
+                    return $uitPasLabels[$id];
+                } else {
+                    $this->logger->warning(
+                        'Could not find UiTPAS label for card system ' . $id . ' on event ' . $eventId
+                    );
+                    return null;
+                }
+            },
+            $eventCardSystemsUpdated->getCardSystems()->toArray()
+        );
+        $expectedUitPasLabelsForEvent = array_filter($expectedUitPasLabelsForEvent);
+
+        $uitPasLabelsToRemoveIfApplied = [];
+        foreach ($uitPasLabels as $uitPasLabel) {
+            $remove = true;
+
+            foreach ($expectedUitPasLabelsForEvent as $expectedUitPasLabelForEvent) {
+                if ($uitPasLabel->equals($expectedUitPasLabelForEvent)) {
+                    $remove = false;
+                    break;
+                }
+            }
+
+            if ($remove) {
+                $uitPasLabelsToRemoveIfApplied[] = $uitPasLabel;
+            }
+        }
+
+        $this->logger->info(
+            'Removing UiTPAS labels for irrelevant card systems from event ' . $eventId . ' (if applied)'
+        );
+        $this->removeLabelsFromEvent($eventId, $uitPasLabelsToRemoveIfApplied);
 
         if ($eventCardSystemsUpdated->getCardSystems()->length() > 0) {
-            $this->logger->info('Inheriting UiTPAS labels from organizer on event ' . $eventId);
-            $this->copyMatchingLabelsFromOrganizerToEvent($eventId, $uitpasLabels);
+            $this->logger->info(
+                'Adding UiTPAS labels for active card systems on event ' . $eventId . '(if not applied yet)'
+            );
+            $this->addLabelsToEvent($eventId, $expectedUitPasLabelsForEvent);
         }
     }
 
@@ -121,76 +143,18 @@ class EventProcessManager implements EventListenerInterface
 
     /**
      * @param string $eventId
-     * @param Label[] $potentialLabelsToCopy
+     * @param Label[] $labels
      */
-    private function copyMatchingLabelsFromOrganizerToEvent($eventId, array $potentialLabelsToCopy)
+    private function addLabelsToEvent($eventId, array $labels)
     {
-        $eventDocument = $this->eventDocumentRepository->get($eventId);
-        if (!$eventDocument) {
-            $this->logger->error('Event with id ' . $eventId . ' not found in injected DocumentRepository!');
-            return;
-        }
-
-        $jsonLD = $eventDocument->getBody();
-        if (!isset($jsonLD->organizer)) {
-            $this->logger->error('Found no organizer on event ' . $eventId);
-            return;
-        }
-
-        $organizerLabels = array_map(
-            function (string $labelName) {
-                return new Label($labelName);
-            },
-            isset($jsonLD->organizer->labels) ? $jsonLD->organizer->labels : []
-        );
-        $this->logger->info(
-            'Found organizer labels on event ' . $eventId . ': ' . implode(', ', $organizerLabels)
-        );
-
-        $hiddenOrganizerLabels = array_map(
-            function (string $labelName) {
-                return new Label($labelName, false);
-            },
-            isset($jsonLD->organizer->hiddenLabels) ? $jsonLD->organizer->hiddenLabels : []
-        );
-        $this->logger->info(
-            'Found hidden organizer labels on event ' . $eventId . ': ' . implode(', ', $hiddenOrganizerLabels)
-        );
-
-        $this->addIntersectingLabelsToEvent($eventId, $potentialLabelsToCopy, $organizerLabels, true);
-        $this->addIntersectingLabelsToEvent($eventId, $potentialLabelsToCopy, $hiddenOrganizerLabels, false);
-    }
-
-    /**
-     * @param string $eventId
-     * @param Label[] $labels1
-     * @param Label[] $labels2
-     * @param bool $visible
-     */
-    private function addIntersectingLabelsToEvent($eventId, array $labels1, array $labels2, $visible)
-    {
-        $labelsToAdd = [];
-        foreach ($labels1 as $label1) {
-            foreach ($labels2 as $label2) {
-                if ($label1->equals($label2)) {
-                    $labelsToAdd[] = new Label((string) $label1, $visible);
-                    break;
-                }
-            }
-        }
-
-        $this->logger->info(
-            'Found uitpas organizer labels on event ' . $eventId . ': ' . implode(', ', $labelsToAdd)
-        );
-
         $commands = array_map(
-            function (Label $labelToAdd) use ($eventId) {
+            function (Label $label) use ($eventId) {
                 return new AddLabel(
                     $eventId,
-                    $labelToAdd
+                    $label
                 );
             },
-            $labelsToAdd
+            $labels
         );
 
         $this->dispatchCommands($commands);

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -114,7 +114,7 @@ class EventProcessManager implements EventListenerInterface
         );
         $this->removeLabelsFromEvent($eventId, $uitPasLabelsToRemoveIfApplied);
 
-        if ($eventCardSystemsUpdated->getCardSystems()->length() > 0) {
+        if (count($expectedUitPasLabelsForEvent) > 0) {
             $this->logger->info(
                 'Adding UiTPAS labels for active card systems on event ' . $eventId . '(if not applied yet)'
             );

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -108,14 +108,14 @@ class EventProcessManager implements EventListenerInterface
         $convertCardSystemToLabel = function (CardSystem $cardSystem) use ($uitPasLabels) {
             $cardSystemId = $cardSystem->getId()->toNative();
 
-            if (isset($uitPasLabels[$cardSystemId])) {
-                return $uitPasLabels[$cardSystemId];
-            } else {
+            if (!isset($uitPasLabels[$cardSystemId])) {
                 $this->logger->warning(
                     'Could not find UiTPAS label for card system ' . $cardSystemId
                 );
                 return null;
             }
+
+            return $uitPasLabels[$cardSystemId];
         };
 
         return array_filter(

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Offer\Commands\AbstractLabelCommand;
 use CultuurNet\UDB3\UiTPAS\Event\Event\EventCardSystemsUpdated;
-use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepositoryInterface;
+use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepository;
 use Psr\Log\LoggerInterface;
 
 class EventProcessManager implements EventListenerInterface
@@ -27,7 +27,7 @@ class EventProcessManager implements EventListenerInterface
     private $commandBus;
 
     /**
-     * @var UiTPASLabelsRepositoryInterface
+     * @var UiTPASLabelsRepository
      */
     private $uitpasLabelsRepository;
 
@@ -39,13 +39,13 @@ class EventProcessManager implements EventListenerInterface
     /**
      * @param DocumentRepositoryInterface $eventDocumentRepository
      * @param CommandBusInterface $commandBus
-     * @param UiTPASLabelsRepositoryInterface $uitpasLabelsRepository
+     * @param UiTPASLabelsRepository $uitpasLabelsRepository
      * @param LoggerInterface $logger
      */
     public function __construct(
         DocumentRepositoryInterface $eventDocumentRepository,
         CommandBusInterface $commandBus,
-        UiTPASLabelsRepositoryInterface $uitpasLabelsRepository,
+        UiTPASLabelsRepository $uitpasLabelsRepository,
         LoggerInterface $logger
     ) {
         $this->eventDocumentRepository = $eventDocumentRepository;

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -25,7 +25,7 @@ class EventProcessManager implements EventListenerInterface
     /**
      * @var UiTPASLabelsRepository
      */
-    private $uitpasLabelsRepository;
+    private $uitPasLabelsRepository;
 
     /**
      * @var LoggerInterface
@@ -34,16 +34,16 @@ class EventProcessManager implements EventListenerInterface
 
     /**
      * @param CommandBusInterface $commandBus
-     * @param UiTPASLabelsRepository $uitpasLabelsRepository
+     * @param UiTPASLabelsRepository $uitPasLabelsRepository
      * @param LoggerInterface $logger
      */
     public function __construct(
         CommandBusInterface $commandBus,
-        UiTPASLabelsRepository $uitpasLabelsRepository,
+        UiTPASLabelsRepository $uitPasLabelsRepository,
         LoggerInterface $logger
     ) {
         $this->commandBus = $commandBus;
-        $this->uitpasLabelsRepository = $uitpasLabelsRepository;
+        $this->uitPasLabelsRepository = $uitPasLabelsRepository;
         $this->logger = $logger;
     }
 
@@ -75,7 +75,7 @@ class EventProcessManager implements EventListenerInterface
 
         $this->logger->info('Handling updated card systems message for event ' . $eventId);
 
-        $uitPasLabels = $this->uitpasLabelsRepository->loadAll();
+        $uitPasLabels = $this->uitPasLabelsRepository->loadAll();
 
         $applicableLabelsForEvent = $this->determineApplicableLabelsForEvent(
             $eventCardSystemsUpdated->getCardSystems(),

--- a/src/UiTPAS/Label/HttpUiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/HttpUiTPASLabelsRepository.php
@@ -5,7 +5,7 @@ namespace CultuurNet\UDB3\UiTPAS\Label;
 use CultuurNet\UDB3\Label;
 use Guzzle\Http\Client;
 
-class HttpUiTPASLabelsRepository implements UiTPASLabelsRepositoryInterface
+class HttpUiTPASLabelsRepository implements UiTPASLabelsRepository
 {
     /**
      * @var Client

--- a/src/UiTPAS/Label/HttpUiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/HttpUiTPASLabelsRepository.php
@@ -30,17 +30,17 @@ class HttpUiTPASLabelsRepository implements UiTPASLabelsRepositoryInterface
         $this->endpoint = (string) $endpoint;
     }
 
-    public function loadAll()
+    public function loadAll(): array
     {
         $response = $this->httpClient->get($this->endpoint)->send();
         $content = $response->getBody();
-        $data = json_decode($content, true);
-        $strings = array_values($data);
+        $labels = json_decode($content, true);
+
         return array_map(
-            function ($labelString) {
-                return new Label($labelString);
+            function (string $label) {
+                return new Label($label);
             },
-            $strings
+            $labels
         );
     }
 }

--- a/src/UiTPAS/Label/UiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/UiTPASLabelsRepository.php
@@ -4,7 +4,7 @@ namespace CultuurNet\UDB3\UiTPAS\Label;
 
 use CultuurNet\UDB3\Label;
 
-interface UiTPASLabelsRepositoryInterface
+interface UiTPASLabelsRepository
 {
     /**
      * @return Label[]

--- a/src/UiTPAS/Label/UiTPASLabelsRepositoryInterface.php
+++ b/src/UiTPAS/Label/UiTPASLabelsRepositoryInterface.php
@@ -8,6 +8,7 @@ interface UiTPASLabelsRepositoryInterface
 {
     /**
      * @return Label[]
+     *   Associative array of card system ids as keys and corresponding Label objects as values.
      */
-    public function loadAll();
+    public function loadAll(): array;
 }

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -229,7 +229,12 @@ class EventProcessManagerTest extends TestCase
         $this->eventProcessManager->handle($domainMessage);
 
         $this->assertContains(
-            'Could not find UiTPAS label for card system 7 on event cbee7413-ac1e-4dfb-8004-34767eafb8b7',
+            'Handling updated card systems message for event cbee7413-ac1e-4dfb-8004-34767eafb8b7',
+            $this->infoLogs
+        );
+
+        $this->assertContains(
+            'Could not find UiTPAS label for card system 7',
             $this->warningLogs
         );
     }

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -22,11 +22,6 @@ use ValueObjects\StringLiteral\StringLiteral;
 class EventProcessManagerTest extends TestCase
 {
     /**
-     * @var DocumentRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $eventDocumentRepository;
-
-    /**
      * @var CommandBusInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $commandBus;
@@ -59,7 +54,7 @@ class EventProcessManagerTest extends TestCase
     /**
      * @var array
      */
-    private $errorLogs;
+    private $warningLogs;
 
     /**
      * @var array
@@ -68,29 +63,27 @@ class EventProcessManagerTest extends TestCase
 
     public function setUp()
     {
-        $this->eventDocumentRepository = $this->createMock(DocumentRepositoryInterface::class);
         $this->commandBus = $this->createMock(CommandBusInterface::class);
         $this->uitpasLabelsRepository = $this->createMock(UiTPASLabelsRepository::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->eventProcessManager = new EventProcessManager(
-            $this->eventDocumentRepository,
             $this->commandBus,
             $this->uitpasLabelsRepository,
             $this->logger
         );
 
         $this->uitpasLabels = [
-            new Label('Paspartoe'),
-            new Label('UiTPAS'),
-            new Label('UiTPAS Gent'),
-            new Label('UiTPAS Oostende'),
-            new Label('UiTPAS regio Aalst'),
-            new Label('UiTPAS Dender'),
-            new Label('UiTPAS Zuidwest'),
-            new Label('UiTPAS Mechelen'),
-            new Label('UiTPAS Kempen'),
-            new Label('UiTPAS Maasmechelen'),
+            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label('Paspartoe'),
+            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label('UiTPAS'),
+            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label('UiTPAS Gent'),
+            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label('UiTPAS Oostende'),
+            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label('UiTPAS regio Aalst'),
+            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label('UiTPAS Dender'),
+            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label('UiTPAS Zuidwest'),
+            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label('UiTPAS Mechelen'),
+            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label('UiTPAS Kempen'),
+            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new Label('UiTPAS Maasmechelen'),
         ];
 
         $this->uitpasLabelsRepository->expects($this->any())
@@ -108,10 +101,10 @@ class EventProcessManagerTest extends TestCase
             );
 
         $this->logger->expects($this->any())
-            ->method('error')
+            ->method('warning')
             ->willReturnCallback(
                 function ($msg) {
-                    $this->errorLogs[] = $msg;
+                    $this->warningLogs[] = $msg;
                 }
             );
 
@@ -141,81 +134,17 @@ class EventProcessManagerTest extends TestCase
             $cardSystemsUpdated
         );
 
-        $expectedCommands = array_map(
-            function (Label $label) use ($eventId) {
-                return new RemoveLabel(
-                    $eventId->toNative(),
-                    $label
-                );
-            },
-            $this->uitpasLabels
-        );
-
-        $this->eventProcessManager->handle($domainMessage);
-
-        $actualCommands = $this->tracedCommands;
-
-        // Check the count manually just in case both our $actualCommands and
-        // $expectedCommands would have the wrong count.
-        $this->assertCount(10, $actualCommands);
-        $this->assertEquals($expectedCommands, $actualCommands);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_copy_visible_organizer_uitpas_labels_to_an_updated_event_with_card_systems()
-    {
-        $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
-        $cardSystems = (new CardSystems())
-            ->withKey(7, new CardSystem(new Id('7'), new StringLiteral('Mock CS')));
-
-        $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
-
-        $domainMessage = DomainMessage::recordNow(
-            $eventId->toNative(),
-            8,
-            new Metadata([]),
-            $cardSystemsUpdated
-        );
-
-        $eventLd = json_encode(
-            [
-                '@id' => 'http://udb3.dev/event/cbee7413-ac1e-4dfb-8004-34767eafb8b7',
-                '@type' => 'Event',
-                'organizer' => [
-                    'labels' => [
-                        'Foo',
-                        'Paspartoe',
-                        'Bar',
-                        'uitpas gent',
-                        'UiTPAS Oostende',
-                    ],
-                ],
-            ]
-        );
-
-        $eventDocument = new JsonDocument($eventId->toNative(), $eventLd);
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventDocument->getId())
-            ->willReturn($eventDocument);
-
         $expectedCommands = [
-            new RemoveLabel($eventId->toNative(), new Label('Paspartoe')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Gent')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Oostende')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS regio Aalst')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Dender')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Zuidwest')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Mechelen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Kempen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Maasmechelen')),
-            new AddLabel($eventId->toNative(), new Label('Paspartoe', true)),
-            new AddLabel($eventId->toNative(), new Label('UiTPAS Gent', true)),
-            new AddLabel($eventId->toNative(), new Label('UiTPAS Oostende', true)),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('Paspartoe')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Gent')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Oostende')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS regio Aalst')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Dender')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Zuidwest')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Mechelen')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Kempen')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Maasmechelen')),
         ];
 
         $this->eventProcessManager->handle($domainMessage);
@@ -226,11 +155,31 @@ class EventProcessManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_copy_hidden_organizer_uitpas_labels_to_an_updated_event_with_card_systems()
+    public function it_should_add_uitpas_labels_for_active_card_systems_to_an_updated_event_with_card_systems()
     {
         $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
         $cardSystems = (new CardSystems())
-            ->withKey(7, new CardSystem(new Id('7'), new StringLiteral('Mock CS')));
+            ->withKey(
+                'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa',
+                new CardSystem(
+                    new Id('c73d78b7-95a7-45b3-bde5-5b2ec7b13afa'),
+                    new StringLiteral('Mock CS Paspartoe')
+                )
+            )
+            ->withKey(
+                'f23ccb75-190a-4814-945e-c95e83101cc5',
+                new CardSystem(
+                    new Id('f23ccb75-190a-4814-945e-c95e83101cc5'),
+                    new StringLiteral('Mock CS UiTPAS Gent')
+                )
+            )
+            ->withKey(
+                '98ce6fbc-fb68-4efc-b8c7-95763cb967dd',
+                new CardSystem(
+                    new Id('98ce6fbc-fb68-4efc-b8c7-95763cb967dd'),
+                    new StringLiteral('Mock CS UiTPAS Oostende')
+                )
+            );
 
         $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
 
@@ -241,41 +190,17 @@ class EventProcessManagerTest extends TestCase
             $cardSystemsUpdated
         );
 
-        $eventLd = json_encode(
-            [
-                '@id' => 'http://udb3.dev/event/cbee7413-ac1e-4dfb-8004-34767eafb8b7',
-                '@type' => 'Event',
-                'organizer' => [
-                    'hiddenLabels' => [
-                        'Foo',
-                        'Paspartoe',
-                        'Bar',
-                        'UiTPAS Oostende',
-                    ],
-                ],
-            ]
-        );
-
-        $eventDocument = new JsonDocument($eventId->toNative(), $eventLd);
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventDocument->getId())
-            ->willReturn($eventDocument);
-
         $expectedCommands = [
-            new RemoveLabel($eventId->toNative(), new Label('Paspartoe')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Gent')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Oostende')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS regio Aalst')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Dender')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Zuidwest')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Mechelen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Kempen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Maasmechelen')),
-            new AddLabel($eventId->toNative(), new Label('Paspartoe', false)),
-            new AddLabel($eventId->toNative(), new Label('UiTPAS Oostende', false)),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS regio Aalst')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Dender')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Zuidwest')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Mechelen')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Kempen')),
+            new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Maasmechelen')),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('Paspartoe', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Gent', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Oostende', true)),
         ];
 
         $this->eventProcessManager->handle($domainMessage);
@@ -286,7 +211,7 @@ class EventProcessManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_copy_visible_and_hidden_organizer_uitpas_labels_to_an_updated_event_with_card_systems()
+    public function it_should_log_a_warning_if_no_label_can_be_found_for_an_active_card_system()
     {
         $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
         $cardSystems = (new CardSystems())
@@ -300,177 +225,12 @@ class EventProcessManagerTest extends TestCase
             new Metadata([]),
             $cardSystemsUpdated
         );
-
-        $eventLd = json_encode(
-            [
-                '@id' => 'http://udb3.dev/event/cbee7413-ac1e-4dfb-8004-34767eafb8b7',
-                '@type' => 'Event',
-                'organizer' => [
-                    'labels' => [
-                        'Foo',
-                        'Paspartoe',
-                    ],
-                    'hiddenLabels' => [
-                        'Bar',
-                        'uitpas gent',
-                        'UiTPAS Oostende',
-                    ],
-                ],
-            ]
-        );
-
-        $eventDocument = new JsonDocument($eventId->toNative(), $eventLd);
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventDocument->getId())
-            ->willReturn($eventDocument);
-
-        $expectedCommands = [
-            new RemoveLabel($eventId->toNative(), new Label('Paspartoe')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Gent')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Oostende')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS regio Aalst')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Dender')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Zuidwest')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Mechelen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Kempen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Maasmechelen')),
-            new AddLabel($eventId->toNative(), new Label('Paspartoe', true)),
-            new AddLabel($eventId->toNative(), new Label('UiTPAS Gent', false)),
-            new AddLabel($eventId->toNative(), new Label('UiTPAS Oostende', false)),
-        ];
-
-        $this->eventProcessManager->handle($domainMessage);
-
-        $this->assertEquals($expectedCommands, $this->tracedCommands);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_copy_no_labels_if_the_event_organizer_has_no_uitpas_labels()
-    {
-        $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
-        $cardSystems = (new CardSystems())
-            ->withKey(7, new CardSystem(new Id('7'), new StringLiteral('Mock CS')));
-
-        $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
-
-        $domainMessage = DomainMessage::recordNow(
-            $eventId->toNative(),
-            8,
-            new Metadata([]),
-            $cardSystemsUpdated
-        );
-
-        $eventLd = json_encode(
-            [
-                '@id' => 'http://udb3.dev/event/cbee7413-ac1e-4dfb-8004-34767eafb8b7',
-                '@type' => 'Event',
-                'organizer' => [
-                    'labels' => [
-                        'Foo',
-                        'Bar',
-                    ],
-                ],
-            ]
-        );
-
-        $eventDocument = new JsonDocument($eventId->toNative(), $eventLd);
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventDocument->getId())
-            ->willReturn($eventDocument);
-
-        $expectedCommands = [
-            new RemoveLabel($eventId->toNative(), new Label('Paspartoe')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Gent')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Oostende')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS regio Aalst')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Dender')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Zuidwest')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Mechelen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Kempen')),
-            new RemoveLabel($eventId->toNative(), new Label('UiTPAS Maasmechelen')),
-        ];
-
-        $this->eventProcessManager->handle($domainMessage);
-
-        $this->assertEquals($expectedCommands, $this->tracedCommands);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_log_an_error_if_no_organizer_can_be_found_for_an_event()
-    {
-        $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
-        $cardSystems = (new CardSystems())
-            ->withKey(7, new CardSystem(new Id('7'), new StringLiteral('Mock CS')));
-
-        $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
-
-        $domainMessage = DomainMessage::recordNow(
-            $eventId->toNative(),
-            8,
-            new Metadata([]),
-            $cardSystemsUpdated
-        );
-
-        $eventLd = json_encode(
-            [
-                '@id' => 'http://udb3.dev/event/cbee7413-ac1e-4dfb-8004-34767eafb8b7',
-                '@type' => 'Event',
-            ]
-        );
-
-        $eventDocument = new JsonDocument($eventId->toNative(), $eventLd);
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventDocument->getId())
-            ->willReturn($eventDocument);
 
         $this->eventProcessManager->handle($domainMessage);
 
         $this->assertContains(
-            'Found no organizer on event ' . $eventId->toNative(),
-            $this->errorLogs
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_log_an_error_if_no_event_json_ld_can_be_found()
-    {
-        $eventId = new Id('cbee7413-ac1e-4dfb-8004-34767eafb8b7');
-        $cardSystems = (new CardSystems())
-            ->withKey(7, new CardSystem(new Id('7'), new StringLiteral('Mock CS')));
-
-        $cardSystemsUpdated = new EventCardSystemsUpdated($eventId, $cardSystems);
-
-        $domainMessage = DomainMessage::recordNow(
-            $eventId->toNative(),
-            8,
-            new Metadata([]),
-            $cardSystemsUpdated
-        );
-
-        $this->eventDocumentRepository->expects($this->once())
-            ->method('get')
-            ->with($eventId->toNative())
-            ->willReturn(null);
-
-        $this->eventProcessManager->handle($domainMessage);
-
-        $this->assertContains(
-            'Event with id ' . $eventId->toNative() . ' not found in injected DocumentRepository!',
-            $this->errorLogs
+            'Could not find UiTPAS label for card system 7 on event cbee7413-ac1e-4dfb-8004-34767eafb8b7',
+            $this->warningLogs
         );
     }
 }

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystems;
 use CultuurNet\UDB3\UiTPAS\Event\Event\EventCardSystemsUpdated;
-use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepositoryInterface;
+use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepository;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -32,7 +32,7 @@ class EventProcessManagerTest extends TestCase
     private $commandBus;
 
     /**
-     * @var UiTPASLabelsRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UiTPASLabelsRepository|\PHPUnit_Framework_MockObject_MockObject
      */
     private $uitpasLabelsRepository;
 
@@ -70,7 +70,7 @@ class EventProcessManagerTest extends TestCase
     {
         $this->eventDocumentRepository = $this->createMock(DocumentRepositoryInterface::class);
         $this->commandBus = $this->createMock(CommandBusInterface::class);
-        $this->uitpasLabelsRepository = $this->createMock(UiTPASLabelsRepositoryInterface::class);
+        $this->uitpasLabelsRepository = $this->createMock(UiTPASLabelsRepository::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->eventProcessManager = new EventProcessManager(

--- a/tests/UiTPAS/Label/HttpUiTPASLabelsRepositoryTest.php
+++ b/tests/UiTPAS/Label/HttpUiTPASLabelsRepositoryTest.php
@@ -38,31 +38,32 @@ class HttpUiTPASLabelsRepositoryTest extends TestCase
      */
     public function it_should_return_an_array_of_uitpas_labels()
     {
+        // Note that these are just example card system ids.
         $expected = [
-            new Label('Paspartoe'),
-            new Label('UiTPAS'),
-            new Label('UiTPAS Gent'),
-            new Label('UiTPAS Oostende'),
-            new Label('UiTPAS regio Aalst'),
-            new Label('UiTPAS Dender'),
-            new Label('UiTPAS Zuidwest'),
-            new Label('UiTPAS Mechelen'),
-            new Label('UiTPAS Kempen'),
-            new Label('UiTPAS Maasmechelen'),
+            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label('Paspartoe'),
+            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label('UiTPAS'),
+            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label('UiTPAS Gent'),
+            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label('UiTPAS Oostende'),
+            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label('UiTPAS regio Aalst'),
+            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label('UiTPAS Dender'),
+            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label('UiTPAS Zuidwest'),
+            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label('UiTPAS Mechelen'),
+            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label('UiTPAS Kempen'),
+            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new Label('UiTPAS Maasmechelen'),
         ];
 
         $json = '
         {
-          "PASPARTOE": "Paspartoe",
-          "UITPAS": "UiTPAS",
-          "UITPAS_GENT": "UiTPAS Gent",
-          "UITPAS_OOSTENDE": "UiTPAS Oostende",
-          "UITPAS_REGIO_AALST": "UiTPAS regio Aalst",
-          "UITPAS_DENDER": "UiTPAS Dender",
-          "UITPAS_ZUIDWEST": "UiTPAS Zuidwest",
-          "UITPAS_MECHELEN": "UiTPAS Mechelen",
-          "UITPAS_KEMPEN": "UiTPAS Kempen",
-          "UITPAS_MAASMECHELEN": "UiTPAS Maasmechelen"
+          "c73d78b7-95a7-45b3-bde5-5b2ec7b13afa": "Paspartoe",
+          "ebd91df0-8ed7-4522-8401-ef5508ad1426": "UiTPAS",
+          "f23ccb75-190a-4814-945e-c95e83101cc5": "UiTPAS Gent",
+          "98ce6fbc-fb68-4efc-b8c7-95763cb967dd": "UiTPAS Oostende",
+          "68f849c0-bf55-4f73-b0f4-e0683bf0c807": "UiTPAS regio Aalst",
+          "cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8": "UiTPAS Dender",
+          "d9cf96b6-1256-4760-b66b-1c31152d7db4": "UiTPAS Zuidwest",
+          "aaf3a58e-2aac-45b3-a9e9-3f3ebf467681": "UiTPAS Mechelen",
+          "47256d4c-47e8-4046-b9bb-acb166920f76": "UiTPAS Kempen",
+          "54b5273e-5e0b-4c1e-b33f-93eca55eb472": "UiTPAS Maasmechelen"
         }';
 
         $request = $this->createMock(Request::class);


### PR DESCRIPTION
### Changed

- UiTPAS labels are now applied to events based on the active card systems of the event, and no longer based on the UiTPAS labels on the organizer.
- Removing irrelevant UiTPAS labels is now a bit smarter, the process manager no longer removes an UiTPAS label to re-add it later again.

---
Ticket: https://jira.uitdatabank.be/browse/III-2668

---

Note that the list of labels in the [`uitpas-service` configuration](https://github.com/cultuurnet/udb3-uitpas-service/blob/master/config.dist.yml#L4-L14) will need to be updated to add the correct card system ids instead of those (currently unused) label keys. Will also mention this in the ticket.
