### PR TITLE
III-3037 - Publisher name should be case insensitive

### DIFF
--- a/src/Curators/LabelFactory.php
+++ b/src/Curators/LabelFactory.php
@@ -19,13 +19,12 @@ class LabelFactory
 
     public function forPublisher(PublisherName $publisher): Label
     {
-        if (!array_key_exists($publisher->toString(), $this->labelMapping)) {
-            throw new InvalidArgumentException('No label defined for publisher ' . $publisher->toString());
+        foreach (array_keys($this->labelMapping) as $key) {
+            if ($publisher->equals(new PublisherName($key))) {
+                return new Label($this->labelMapping[$key], false);
+            }
         }
 
-        return new Label(
-            $this->labelMapping[$publisher->toString()],
-            false
-        );
+        throw new InvalidArgumentException('No label defined for publisher ' . $publisher->toString());
     }
 }

--- a/src/Curators/PublisherName.php
+++ b/src/Curators/PublisherName.php
@@ -16,7 +16,7 @@ final class PublisherName
         if (!self::isValid($name)) {
             throw new InvalidArgumentException('Invalid publisher: ' . $name);
         }
-        $this->name = strtolower($name);
+        $this->name = $name;
     }
 
     private static function isValid(string $name): bool
@@ -27,5 +27,10 @@ final class PublisherName
     public function toString(): string
     {
         return $this->name;
+    }
+
+    public function equals(PublisherName $other): bool
+    {
+        return mb_strtolower($this->name) === mb_strtolower($other->name);
     }
 }

--- a/src/Curators/PublisherName.php
+++ b/src/Curators/PublisherName.php
@@ -16,7 +16,7 @@ final class PublisherName
         if (!self::isValid($name)) {
             throw new InvalidArgumentException('Invalid publisher: ' . $name);
         }
-        $this->name = $name;
+        $this->name = strtolower($name);
     }
 
     private static function isValid(string $name): bool

--- a/tests/Curators/LabelFactoryTest.php
+++ b/tests/Curators/LabelFactoryTest.php
@@ -27,6 +27,22 @@ class LabelFactoryTest extends TestCase
     /**
      * @test
      */
+    public function it_will_create_label_for_known_publishers_case_insensitively()
+    {
+        $labelFactory = new LabelFactory(
+            [
+                'bruzz' => 'BRUZZ-redactioneel',
+            ]
+        );
+        $expected = new Label('BRUZZ-redactioneel', false);
+        $label = $labelFactory->forPublisher(new PublisherName('Bruzz'));
+
+        $this->assertEquals($expected, $label);
+    }
+
+    /**
+     * @test
+     */
     public function it_will_throw_an_exception_for_unknown_publishers()
     {
         $labelFactory = new LabelFactory(

--- a/tests/Curators/PublisherNameTest.php
+++ b/tests/Curators/PublisherNameTest.php
@@ -15,4 +15,13 @@ class PublisherNameTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         new PublisherName('');
     }
+
+    /**
+     * @test
+     */
+    public function it_is_case_insensitive(): void
+    {
+        $publisher = new PublisherName('Bruzz');
+        $this->assertEquals('bruzz', $publisher->toString());
+    }
 }

--- a/tests/Curators/PublisherNameTest.php
+++ b/tests/Curators/PublisherNameTest.php
@@ -22,6 +22,7 @@ class PublisherNameTest extends TestCase
     public function it_is_case_insensitive(): void
     {
         $publisher = new PublisherName('Bruzz');
-        $this->assertEquals('bruzz', $publisher->toString());
+        $otherPublisher = new PublisherName('bruzz');
+        $this->assertTrue($publisher->equals($otherPublisher));
     }
 }

--- a/tests/Curators/PublisherNameTest.php
+++ b/tests/Curators/PublisherNameTest.php
@@ -5,7 +5,7 @@ namespace CultuurNet\UDB3\Curators;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-class PublisherTest extends TestCase
+class PublisherNameTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
### Changed
- `PublisherName` VO now always works with lowercase so `Bruzz` will match `bruzz` in the configuration

---
Ticket: https://jira.uitdatabank.be/browse/III-3037
