### PR TITLE
Only show location name for dummy locations in PDF exports

### DIFF
--- a/src/EventExport/Format/HTML/HTMLEventFormatter.php
+++ b/src/EventExport/Format/HTML/HTMLEventFormatter.php
@@ -156,6 +156,11 @@ class HTMLEventFormatter
                     'longitude' => $event->location->geo->longitude,
                 ];
             }
+
+            $address['isDummyAddress'] = false;
+            if (isset($event->location->isDummyPlaceForEducationEvents)) {
+                $address['isDummyAddress'] = (bool) $event->location->isDummyPlaceForEducationEvents;
+            }
         }
 
         if (!empty($address)) {

--- a/src/EventExport/Format/HTML/templates/export.map.activities.html.twig
+++ b/src/EventExport/Format/HTML/templates/export.map.activities.html.twig
@@ -70,7 +70,11 @@
                             <i class="fa fa-map-marker"></i>&nbsp;
                         </td>
                         <td>
-                            {{ event.address.name }}, {{ event.address.street }}, {{ event.address.postcode }} {{ event.address.municipality }}
+                            {{ event.address.name }}
+                            {%-  if not event.address.isDummyAddress -%}
+                                , {{ event.address.street }}, {{ event.address.postcode }} {{ event.address.municipality }}
+                            {%- endif %}
+
                         </td>
                     </tr>
                     <tr>

--- a/src/EventExport/Format/HTML/templates/export.tips.html.twig
+++ b/src/EventExport/Format/HTML/templates/export.tips.html.twig
@@ -76,9 +76,13 @@
                                     <i class="fa fa-map-marker"></i>&nbsp;
                                 </td>
                                 <td>
-                                    {{ event.address.name }}<br />
+                                    {{ event.address.name }}
+                                    {%-  if not event.address.isDummyAddress -%}
+                                    <br />
                                     {{ event.address.street }}<br />
                                     {{ event.address.postcode }} {{ event.address.municipality }}
+                                    {%- endif %}
+
                                 </td>
                             </tr>
                             <tr>

--- a/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
+++ b/tests/EventExport/Format/HTML/HTMLEventFormatterTest.php
@@ -89,6 +89,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Tienen',
                 'country' => 'BE',
                 'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => false,
             ],
             'type' => 'Cursus of workshop',
             'price' => 'Gratis',
@@ -101,6 +102,33 @@ class HTMLEventFormatterTest extends TestCase
         $expectedFormattedPricedEvent = $expectedFormattedFreeEvent;
         $expectedFormattedPricedEvent['price'] = '10,5';
         $this->assertEventFormatting($expectedFormattedPricedEvent, $pricedEvent);
+    }
+
+    /**
+     * @test
+     */
+    public function it_marks_the_address_as_dummy_if_the_location_is_a_dummy_for_bookable_education_events()
+    {
+        $freeEvent = $this->getFormattedEventFromJSONFile('event_with_dummy_location.json');
+        $expectedFormattedFreeEvent = [
+            'title' => 'Koran, kaliefen en kruistochten - De fundamenten van de islam',
+            'image' => 'http://media.uitdatabank.be/20141211/558bb7cf-5ff8-40b4-872b-5f5b46bb16c2.jpg',
+            'description' => 'De islam is niet meer weg te denken uit onze maatschappij. '.'Aan de hand van boeiende anekdotes doet Urbain Vermeulen de ontstaansgeschiedenis '.'van de godsdienst uit de doeken...',
+            'address' => [
+                'name' => 'Cultuurcentrum De Kruisboog',
+                'street' => 'Sint-Jorisplein 20 ',
+                'postcode' => '3300',
+                'municipality' => 'Tienen',
+                'country' => 'BE',
+                'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => true,
+            ],
+            'type' => 'Cursus of workshop',
+            'price' => 'Gratis',
+            'brands' => array(),
+            'dates' => 'ma 02/03/15 van 13:30 tot 16:30  ma 09/03/15 van 13:30 tot 16:30  '.'ma 16/03/15 van 13:30 tot 16:30  ma 23/03/15 van 13:30 tot 16:30  ma 30/03/15 van 13:30 tot 16:30 ',
+        ];
+        $this->assertEventFormatting($expectedFormattedFreeEvent, $freeEvent);
     }
 
     /**
@@ -121,6 +149,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Herent',
                 'country' => 'BE',
                 'concatenated' => 'Schoolstraat 15 3020 Herent BE',
+                'isDummyAddress' => false,
             ],
             'price' => 'Niet ingevoerd',
             'brands' => array(),
@@ -145,6 +174,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Tienen',
                 'country' => 'BE',
                 'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => false,
             ],
             'price' => 'Gratis',
             'brands' => array(),
@@ -170,6 +200,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Tienen',
                 'country' => 'BE',
                 'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => false,
             ],
             'price' => 'Niet ingevoerd',
             'brands' => array(),
@@ -199,6 +230,7 @@ class HTMLEventFormatterTest extends TestCase
                 $expectedFormattedEvent + [
                     'address' => [
                         'name' => 'Cultuurcentrum De Kruisboog',
+                        'isDummyAddress' => false,
                     ]
                 ]
             ],
@@ -211,6 +243,7 @@ class HTMLEventFormatterTest extends TestCase
                         'municipality' => 'Tienen',
                         'country' => 'BE',
                         'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                        'isDummyAddress' => false,
                     ]
                 ]
             ],
@@ -220,6 +253,7 @@ class HTMLEventFormatterTest extends TestCase
                     'address' => [
                         'latitude' => '50.804739',
                         'longitude' => '4.936491',
+                        'isDummyAddress' => false,
                     ]
                 ]
             ]
@@ -256,6 +290,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Tienen',
                 'country' => 'BE',
                 'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => false,
             ],
             'price' => 'Gratis',
             'brands' => array(),
@@ -367,9 +402,7 @@ class HTMLEventFormatterTest extends TestCase
     {
         $eventWithoutImage = $this->getJSONEventFromFile('event_without_image.json');
 
-        /**
- * @var EventInfoServiceInterface|MockObject $uitpas
-*/
+        /* @var EventInfoServiceInterface|MockObject $uitpas */
         $uitpas = $this->createMock(EventInfoServiceInterface::class);
 
         $prices = $priceData['original'];
@@ -411,6 +444,7 @@ class HTMLEventFormatterTest extends TestCase
                 'municipality' => 'Tienen',
                 'country' => 'BE',
                 'concatenated' => 'Sint-Jorisplein 20  3300 Tienen BE',
+                'isDummyAddress' => false,
             ],
             'price' => 'Niet ingevoerd',
             'brands' => array(),

--- a/tests/EventExport/samples/event_with_dummy_location.json
+++ b/tests/EventExport/samples/event_with_dummy_location.json
@@ -1,0 +1,82 @@
+{
+  "@id": "http:\/\/culudb-silex.dev:8080\/event\/d1f0e71d-a9a8-4069-81fb-530134502c58",
+  "@context": "\/api\/1.0\/event.jsonld",
+  "name": {"nl": "Koran, kaliefen en kruistochten - De fundamenten van de islam"},
+  "description": {"nl": "De islam is niet meer weg te denken uit onze maatschappij. Aan de hand van boeiende anekdotes doet Urbain Vermeulen de ontstaansgeschiedenis van de godsdienst uit de doeken. Hij verklaart hoe de islam zich verhoudt tot de andere wereldgodsdiensten en legt de oorsprong van de fundamentalistische strekkingen bloot. Dit historische perspectief helpt u om actuele ontwikkelingen beter te begrijpen."},
+  "image": "http:\/\/media.uitdatabank.be\/20141211\/558bb7cf-5ff8-40b4-872b-5f5b46bb16c2.jpg",
+  "calendarSummary": "ma 02\/03\/15 van 13:30 tot 16:30  ma 09\/03\/15 van 13:30 tot 16:30  ma 16\/03\/15 van 13:30 tot 16:30  ma 23\/03\/15 van 13:30 tot 16:30  ma 30\/03\/15 van 13:30 tot 16:30 ",
+  "location": {
+    "@type": "Place",
+    "@id": "http:\/\/culudb-silex.dev:8080\/place\/A871DB85-01DB-DBD3-DAF62CDB2DD7B871",
+    "@context": "\/api\/1.0\/place.jsonld",
+    "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
+    "name": {"nl": "Cultuurcentrum De Kruisboog"},
+    "address": {
+      "addressCountry": "BE",
+      "addressLocality": "Tienen",
+      "postalCode": "3300",
+      "streetAddress": "Sint-Jorisplein 20 "
+    },
+    "isDummyPlaceForEducationEvents": true
+  },
+  "priceInfo": [
+    {
+      "category": "base",
+      "name": "Basistarief",
+      "price": 0,
+      "priceCurrency": "EUR"
+    }
+  ],
+  "organizer": {
+    "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
+    "@context": "\/api\/1.0\/organizer.jsonld",
+    "name": "Davidsfonds Academie",
+    "addresses": [
+      {
+        "addressCountry": "BE",
+        "addressLocality": "Leuven",
+        "postalCode": "3000",
+        "streetAddress": "Blijde-Inkomststraat 77"
+      }
+    ],
+    "email": ["academie@davidsfonds.be"],
+    "phone": [
+      "+32 16 310670",
+      "+32 16 310608"
+    ]
+  },
+  "terms": [
+    {
+      "label": "Geschiedenis",
+      "domain": "theme",
+      "id": "1.11.0.0.0"
+    },
+    {
+      "label": "Regionaal",
+      "domain": "publicscope",
+      "id": "6.2.0.0.0"
+    },
+    {
+      "label": "Hageland",
+      "domain": "flanderstouristregion",
+      "id": "reg.360"
+    },
+    {
+      "label": "Cursus of workshop",
+      "domain": "eventtype",
+      "id": "0.3.1.0.0"
+    },
+    {
+      "label": "3300 Tienen",
+      "domain": "flandersregion",
+      "id": "reg.704"
+    }
+  ],
+  "creator": "mieke.gielis@davidsfonds.be",
+  "created": "2014-12-11T17:30:54+01:00",
+  "publisher": "Invoerders Algemeen ",
+  "endDate": "2015-03-30T16:30:00+02:00",
+  "startDate": "2015-03-02T13:30:00+01:00",
+  "calendarType": "multiple",
+  "sameAs": ["http:\/\/www.uitinvlaanderen.be\/agenda\/e\/koran-kaliefen-en-kruistochten-de-fundamenten-van\/d1f0e71d-a9a8-4069-81fb-530134502c58"]
+}


### PR DESCRIPTION
### Changed

- When exporting an event with a dummy location, it will only show the location name and not the full address.

---
Ticket: https://jira.uitdatabank.be/browse/III-3012
