### PR TITLE
III-3054 Set audienceType to education when importing event with dummy location

### DIFF
--- a/app/UDB2IncomingEventServicesProvider.php
+++ b/app/UDB2IncomingEventServicesProvider.php
@@ -246,7 +246,8 @@ class UDB2IncomingEventServicesProvider implements ServiceProviderInterface
                     new Any(),
                     $app['event_repository'],
                     $app['udb2_media_importer'],
-                    $app['related_udb3_labels_applier']
+                    $app['related_udb3_labels_applier'],
+                    $app['udb2_event_cdbid_extractor']
                 );
 
                 $logger = new Logger('udb2-events-to-udb3-event-applier');


### PR DESCRIPTION
### Changed

- When importing an event via cdbxml the audienceType of that event is automatically set to education if it has a dummy location meant for bookable education events.

---

Ticket: https://jira.uitdatabank.be/browse/III-3054
