### PR TITLE
III-3045 - Add CLI command to mark place as duplicate

### DIFF
--- a/app/Console/MarkPlaceAsDuplicateCommand.php
+++ b/app/Console/MarkPlaceAsDuplicateCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use CultuurNet\UDB3\Place\CannotMarkPlaceAsCanonical;
+use CultuurNet\UDB3\Place\CannotMarkPlaceAsDuplicate;
+use CultuurNet\UDB3\Place\Commands\MarkAsDuplicate;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MarkPlaceAsDuplicateCommand extends AbstractCommand
+{
+    private const DUPLICATE_PLACE_ID_ARGUMENT = 'duplicate_place_id';
+    private const CANONICAL_PLACE_ID_ARGUMENT = 'canonical_place_id';
+
+    public function configure()
+    {
+        $this->setName('place:mark-as-duplicate');
+        $this->setDescription('Marks a Place as duplicate of another one, implicitly making that a canonical');
+        $this->addArgument(self::DUPLICATE_PLACE_ID_ARGUMENT, InputArgument::REQUIRED, 'uuid of the duplicate place');
+        $this->addArgument(self::CANONICAL_PLACE_ID_ARGUMENT, InputArgument::REQUIRED, 'uuid of the canonical place');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $this->getCommandBus()->dispatch(
+                new MarkAsDuplicate(
+                    $input->getArgument(self::DUPLICATE_PLACE_ID_ARGUMENT),
+                    $input->getArgument(self::CANONICAL_PLACE_ID_ARGUMENT)
+                )
+            );
+            $output->writeln('Successfully marked place as duplicate');
+        } catch (CannotMarkPlaceAsCanonical | CannotMarkPlaceAsDuplicate $e) {
+            $output->writeln($e->getMessage());
+        }
+    }
+}

--- a/app/Event/EventEditingServiceProvider.php
+++ b/app/Event/EventEditingServiceProvider.php
@@ -6,6 +6,7 @@ use Broadway\UuidGenerator\Rfc4122\Version4Generator;
 use CultuurNet\UDB3\Event\Commands\EventCommandFactory;
 use CultuurNet\UDB3\Event\EventEditingService;
 use CultuurNet\UDB3\Event\EventOrganizerRelationService;
+use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -36,6 +37,15 @@ class EventEditingServiceProvider implements ServiceProviderInterface
                 return new EventOrganizerRelationService(
                     $app['event_editor'],
                     $app['event_relations_repository']
+                );
+            }
+        );
+
+        $app[LocationMarkedAsDuplicateProcessManager::class] = $app->share(
+            function ($app) {
+                return new LocationMarkedAsDuplicateProcessManager(
+                    $app['event_relations_repository'],
+                    $app['event_command_bus']
                 );
             }
         );

--- a/app/Place/PlaceEditingServiceProvider.php
+++ b/app/Place/PlaceEditingServiceProvider.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3\Silex\Place;
 
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
+use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use CultuurNet\UDB3\Offer\OfferEditingServiceWithLabelMemory;
 use CultuurNet\UDB3\Place\Commands\PlaceCommandFactory;
 use CultuurNet\UDB3\Place\DefaultPlaceEditingService;
@@ -35,6 +36,15 @@ class PlaceEditingServiceProvider implements ServiceProviderInterface
                 return new PlaceOrganizerRelationService(
                     $app['place_editing_service'],
                     $app['place_relations_repository']
+                );
+            }
+        );
+
+        $app[LocationMarkedAsDuplicateProcessManager::class] = $app->share(
+            function ($app) {
+                return new LocationMarkedAsDuplicateProcessManager(
+                    $app['event_relations_repository'],
+                    $app['event_command_bus']
                 );
             }
         );

--- a/app/Place/PlaceEditingServiceProvider.php
+++ b/app/Place/PlaceEditingServiceProvider.php
@@ -4,7 +4,6 @@ namespace CultuurNet\UDB3\Silex\Place;
 
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
 use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
-use CultuurNet\UDB3\Offer\OfferEditingServiceWithLabelMemory;
 use CultuurNet\UDB3\Place\Commands\PlaceCommandFactory;
 use CultuurNet\UDB3\Place\DefaultPlaceEditingService;
 use CultuurNet\UDB3\Place\PlaceOrganizerRelationService;

--- a/app/Place/PlaceEditingServiceProvider.php
+++ b/app/Place/PlaceEditingServiceProvider.php
@@ -3,7 +3,6 @@
 namespace CultuurNet\UDB3\Silex\Place;
 
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
-use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use CultuurNet\UDB3\Place\Commands\PlaceCommandFactory;
 use CultuurNet\UDB3\Place\DefaultPlaceEditingService;
 use CultuurNet\UDB3\Place\PlaceOrganizerRelationService;
@@ -35,15 +34,6 @@ class PlaceEditingServiceProvider implements ServiceProviderInterface
                 return new PlaceOrganizerRelationService(
                     $app['place_editing_service'],
                     $app['place_relations_repository']
-                );
-            }
-        );
-
-        $app[LocationMarkedAsDuplicateProcessManager::class] = $app->share(
-            function ($app) {
-                return new LocationMarkedAsDuplicateProcessManager(
-                    $app['event_relations_repository'],
-                    $app['event_command_bus']
                 );
             }
         );

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Silex\Console\GeocodePlaceCommand;
 use CultuurNet\UDB3\Silex\Console\ImportEventCdbXmlCommand;
 use CultuurNet\UDB3\Silex\Console\ImportRoleConstraintsCommand;
 use CultuurNet\UDB3\Silex\Console\ImportSavedSearchesCommand;
+use CultuurNet\UDB3\Silex\Console\MarkPlaceAsDuplicateCommand;
 use CultuurNet\UDB3\Silex\Console\PermissionCommand;
 use CultuurNet\UDB3\Silex\Console\PurgeModelCommand;
 use CultuurNet\UDB3\Silex\Console\ReplayCommand;
@@ -85,5 +86,6 @@ $consoleApp->add(new ImportSavedSearchesCommand());
 $consoleApp->add(new ImportRoleConstraintsCommand());
 $consoleApp->add(new ImportEventCdbXmlCommand());
 $consoleApp->add(new ValidatePlaceJsonLdCommand());
+$consoleApp->add(new MarkPlaceAsDuplicateCommand());
 
 $consoleApp->run();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,6 +7,7 @@ use CultuurNet\Broadway\EventHandling\ReplayFlaggingEventBus;
 use CultuurNet\SymfonySecurityJwt\Authentication\JwtUserToken;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Event\ExternalEventService;
+use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
@@ -530,6 +531,7 @@ $app['event_bus'] = function ($app) {
             'event_geocoordinates_process_manager',
             'uitpas_event_process_manager',
             'curators_news_article_process_manager',
+            LocationMarkedAsDuplicateProcessManager::class,
         ];
 
         $initialSubscribersCount = count($subscribers);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Offer\OfferLocator;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUniqueConstraintService;
+use CultuurNet\UDB3\Place\MarkAsDuplicateCommandHandler;
 use CultuurNet\UDB3\Silex\AggregateType;
 use CultuurNet\UDB3\Silex\CommandHandling\LazyLoadingCommandBus;
 use CultuurNet\UDB3\Silex\CultureFeed\CultureFeedServiceProvider;
@@ -745,6 +746,8 @@ $subscribeCoreCommandHandlers = function (CommandBusInterface $commandBus, Appli
                 $app['media_manager']
             )
         );
+
+        $commandBus->subscribe(new MarkAsDuplicateCommandHandler($app['place_repository']));
 
         $commandBus->subscribe(
             (new \CultuurNet\UDB3\Organizer\OrganizerCommandHandler(

--- a/composer.lock
+++ b/composer.lock
@@ -1504,12 +1504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "a965fa9634268ccc7eb82582c0a1c6878269e325"
+                "reference": "3bc119a51903a14f4872958e14c748755a81a479"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/a965fa9634268ccc7eb82582c0a1c6878269e325",
-                "reference": "a965fa9634268ccc7eb82582c0a1c6878269e325",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/3bc119a51903a14f4872958e14c748755a81a479",
+                "reference": "3bc119a51903a14f4872958e14c748755a81a479",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-08-22 11:24:53"
+            "time": "2019-08-24 19:46:27"
         },
         {
             "name": "cultuurnet/udb3-api-guard",

--- a/tests/Http/Jobs/ReadRestControllerTest.php
+++ b/tests/Http/Jobs/ReadRestControllerTest.php
@@ -19,7 +19,7 @@ class ReadRestControllerTest extends TestCase
     /**
      * @var ReadRestController
      */
-    private $readRestConstroller;
+    private $readRestController;
 
     protected function setUp()
     {
@@ -27,7 +27,7 @@ class ReadRestControllerTest extends TestCase
             JobsStatusFactoryInterface::class
         );
 
-        $this->readRestConstroller = new ReadRestController(
+        $this->readRestController = new ReadRestController(
             $this->jobsStatusFactory
         );
     }
@@ -40,7 +40,7 @@ class ReadRestControllerTest extends TestCase
         $jobStatus = JobStatus::RUNNING();
         $this->mockCreateFromJobId($jobStatus);
 
-        $response = $this->readRestConstroller->get('jobId');
+        $response = $this->readRestController->get('jobId');
 
         $expectedResponse = new JsonResponse($jobStatus->toNative());
 
@@ -54,7 +54,7 @@ class ReadRestControllerTest extends TestCase
     {
         $this->mockCreateFromJobId(null);
 
-        $response = $this->readRestConstroller->get('jobId');
+        $response = $this->readRestController->get('jobId');
 
         $apiProblem = new ApiProblem('No status for job with id: jobId');
         $apiProblem->setStatus(Response::HTTP_BAD_REQUEST);

--- a/tests/Http/Jobs/ReadRestControllerTest.php
+++ b/tests/Http/Jobs/ReadRestControllerTest.php
@@ -44,7 +44,7 @@ class ReadRestControllerTest extends TestCase
 
         $expectedResponse = new JsonResponse($jobStatus->toNative());
 
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertEquals($expectedResponse->getContent(), $response->getContent());
     }
 
     /**


### PR DESCRIPTION
### Added
- CLI command to mark place as duplicate
- Configured `MarkAsDuplicateCommandHandler` on the command bus.
- Configured `LocationMarkedAsDuplicateProcessManager` on the event bus

### Changed
- Updated `cultuurnet/udb3` to latest version

### Removed
- A non-existing class that was imported in a service provider

---
Ticket: https://jira.uitdatabank.be/browse/III-3045
