### PR TITLE
III-3047 - Wire up Process Manager to relocate events

### DIFF
--- a/app/Event/EventEditingServiceProvider.php
+++ b/app/Event/EventEditingServiceProvider.php
@@ -7,6 +7,8 @@ use CultuurNet\UDB3\Event\Commands\EventCommandFactory;
 use CultuurNet\UDB3\Event\EventEditingService;
 use CultuurNet\UDB3\Event\EventOrganizerRelationService;
 use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
+use CultuurNet\UDB3\Event\RelocateEventToCanonicalPlace;
+use CultuurNet\UDB3\Place\CanonicalPlaceRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -46,6 +48,15 @@ class EventEditingServiceProvider implements ServiceProviderInterface
                 return new LocationMarkedAsDuplicateProcessManager(
                     $app['event_relations_repository'],
                     $app['event_command_bus']
+                );
+            }
+        );
+
+        $app[RelocateEventToCanonicalPlace::class] = $app->share(
+            function ($app) {
+                return new RelocateEventToCanonicalPlace(
+                    $app['event_command_bus'],
+                    new CanonicalPlaceRepository($app['place_repository'])
                 );
             }
         );

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,6 +8,7 @@ use CultuurNet\SymfonySecurityJwt\Authentication\JwtUserToken;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Event\ExternalEventService;
 use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
+use CultuurNet\UDB3\Event\RelocateEventToCanonicalPlace;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
@@ -532,6 +533,7 @@ $app['event_bus'] = function ($app) {
             'uitpas_event_process_manager',
             'curators_news_article_process_manager',
             LocationMarkedAsDuplicateProcessManager::class,
+            RelocateEventToCanonicalPlace::class,
         ];
 
         $initialSubscribersCount = count($subscribers);

--- a/composer.lock
+++ b/composer.lock
@@ -1504,12 +1504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "3bc119a51903a14f4872958e14c748755a81a479"
+                "reference": "f52c149f167ed8b0a9891677b889850939d6644c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/3bc119a51903a14f4872958e14c748755a81a479",
-                "reference": "3bc119a51903a14f4872958e14c748755a81a479",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/f52c149f167ed8b0a9891677b889850939d6644c",
+                "reference": "f52c149f167ed8b0a9891677b889850939d6644c",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-08-24 19:46:27"
+            "time": "2019-08-27 10:00:21"
         },
         {
             "name": "cultuurnet/udb3-api-guard",


### PR DESCRIPTION
### Added
- Service provisioning for `RelocateEventToCanonicalPlace` process manager
- `RelocateEventToCanonicalPlace` is now configured as an event listener

### Changed
- `udb3-silex` is now using the latest version of `cultuurnet/udb3`

---
Ticket: https://jira.uitdatabank.be/browse/III-3047
