### PR TITLE
Use latest version for api guard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "cultuurnet/silex-service-provider-jwt": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
     "cultuurnet/udb3": "~0.1",
-    "cultuurnet/udb3-api-guard": "dev-master#205a569b46e0d59485e86eaa93f0db50e3fd96ce as 0.1",
+    "cultuurnet/udb3-api-guard": "~0.1",
     "cultuurnet/udb3-doctrine": "~0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",
     "cultuurnet/udb3-models": "~0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d20b129d2df2c33727f3e34a63f4452f",
+    "content-hash": "1b428d4b75e1f3e1d90bab1658df7b49",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -54,7 +54,7 @@
                 }
             ],
             "description": " Library for creating collection classes with strict typing.",
-            "time": "2015-12-16T09:28:40+00:00"
+            "time": "2015-12-16 09:28:40"
         },
         {
             "name": "2dotstwice/silex-feature-toggles-provider",
@@ -96,7 +96,7 @@
                 "MIT"
             ],
             "description": "Feature toggles for Silex",
-            "time": "2017-07-03T14:15:24+00:00"
+            "time": "2017-07-03 14:15:24"
         },
         {
             "name": "2dotstwice/value-objects",
@@ -644,7 +644,7 @@
                 "Apache-2.0"
             ],
             "description": "Authentication service for CultuurNet web services",
-            "time": "2015-08-24T20:22:37+00:00"
+            "time": "2015-08-24 20:22:37"
         },
         {
             "name": "cultuurnet/broadway-amqp",
@@ -691,7 +691,7 @@
                 "Apache-2.0"
             ],
             "description": "AMQP integration for Broadway library",
-            "time": "2018-06-29T14:20:00+00:00"
+            "time": "2018-06-29 14:20:00"
         },
         {
             "name": "cultuurnet/broadway-tools",
@@ -732,7 +732,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-09-28T12:46:42+00:00"
+            "time": "2018-09-28 12:46:42"
         },
         {
             "name": "cultuurnet/calendar-summary",
@@ -836,7 +836,7 @@
                 }
             ],
             "description": "Library to convert cultuurnet dates to a readable summary",
-            "time": "2019-03-13T16:49:38+00:00"
+            "time": "2019-03-13 16:49:38"
         },
         {
             "name": "cultuurnet/cdb",
@@ -874,7 +874,7 @@
                 "Apache-2.0"
             ],
             "description": "PHP library for hydrating/manipulating CultuurNet's Cdb XML documents",
-            "time": "2018-10-17T12:47:54+00:00"
+            "time": "2018-10-17 12:47:54"
         },
         {
             "name": "cultuurnet/clock",
@@ -915,7 +915,7 @@
                 }
             ],
             "description": "Clock abstraction library",
-            "time": "2015-06-08T16:12:34+00:00"
+            "time": "2015-06-08 16:12:34"
         },
         {
             "name": "cultuurnet/culturefeed-php",
@@ -983,7 +983,7 @@
                 }
             ],
             "description": "Culturefeed PHP library",
-            "time": "2018-11-08T09:30:52+00:00"
+            "time": "2018-11-08 09:30:52"
         },
         {
             "name": "cultuurnet/deserializer",
@@ -1030,7 +1030,7 @@
                 }
             ],
             "description": "Internet media type deserialization library",
-            "time": "2018-06-29T14:27:41+00:00"
+            "time": "2018-06-29 14:27:41"
         },
         {
             "name": "cultuurnet/entry",
@@ -1080,7 +1080,7 @@
                 }
             ],
             "description": "PHP library to access CultuurNet's Entry API",
-            "time": "2018-11-08T13:17:43+00:00"
+            "time": "2018-11-08 13:17:43"
         },
         {
             "name": "cultuurnet/geocoding",
@@ -1129,7 +1129,7 @@
                     "email": "bert@2dotstwice.be"
                 }
             ],
-            "time": "2018-06-29T14:21:16+00:00"
+            "time": "2018-06-29 14:21:16"
         },
         {
             "name": "cultuurnet/hydra",
@@ -1177,7 +1177,7 @@
                 }
             ],
             "description": "PHP library implementing concepts of http://www.hydra-cg.com/",
-            "time": "2018-06-29T14:26:23+00:00"
+            "time": "2018-06-29 14:26:23"
         },
         {
             "name": "cultuurnet/monolog-socketio",
@@ -1221,7 +1221,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:28:08+00:00"
+            "time": "2018-06-29 14:28:08"
         },
         {
             "name": "cultuurnet/search",
@@ -1320,7 +1320,7 @@
                 }
             ],
             "description": "Cultuurnet search service for version 3",
-            "time": "2019-02-14T11:49:27+00:00"
+            "time": "2019-02-14 11:49:27"
         },
         {
             "name": "cultuurnet/silex-amqp",
@@ -1363,7 +1363,7 @@
                 "Apache-2.0"
             ],
             "description": "AMQP integration for Silex projects",
-            "time": "2018-06-29T14:15:23+00:00"
+            "time": "2018-06-29 14:15:23"
         },
         {
             "name": "cultuurnet/silex-service-provider-jwt",
@@ -1405,7 +1405,7 @@
                 "Apache-2.0"
             ],
             "description": "JWT authentication for Silex",
-            "time": "2018-06-29T14:29:16+00:00"
+            "time": "2018-06-29 14:29:16"
         },
         {
             "name": "cultuurnet/symfony-security-jwt",
@@ -1447,7 +1447,7 @@
                 "Apache-2.0"
             ],
             "description": "JWT implementation for the Symfony Security component",
-            "time": "2018-06-29T14:29:57+00:00"
+            "time": "2018-06-29 14:29:57"
         },
         {
             "name": "cultuurnet/udb2-domain-events",
@@ -1496,7 +1496,7 @@
                 }
             ],
             "description": "PHP models for domain events in UiTdatabank version 2",
-            "time": "2018-06-29T14:27:15+00:00"
+            "time": "2018-06-29 14:27:15"
         },
         {
             "name": "cultuurnet/udb3",
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-09-06T14:06:45+00:00"
+            "time": "2019-09-06 14:06:45"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -1627,7 +1627,7 @@
                     "email": "bert@2dotstwice.be"
                 }
             ],
-            "time": "2018-10-03T08:52:10+00:00"
+            "time": "2018-10-03 08:52:10"
         },
         {
             "name": "cultuurnet/udb3-doctrine",
@@ -1672,7 +1672,7 @@
                 }
             ],
             "description": "UDB3 integration with Doctrine Cache",
-            "time": "2016-04-13T11:52:34+00:00"
+            "time": "2016-04-13 11:52:34"
         },
         {
             "name": "cultuurnet/udb3-http-foundation",
@@ -1713,7 +1713,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:28:42+00:00"
+            "time": "2018-06-29 14:28:42"
         },
         {
             "name": "cultuurnet/udb3-jwt",
@@ -1762,7 +1762,7 @@
                 }
             ],
             "description": "Provides JWT service classes",
-            "time": "2018-06-29T14:15:52+00:00"
+            "time": "2018-06-29 14:15:52"
         },
         {
             "name": "cultuurnet/udb3-models",
@@ -1807,7 +1807,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:08:37+00:00"
+            "time": "2018-06-29 14:08:37"
         },
         {
             "name": "cultuurnet/uitid-credentials",
@@ -1863,7 +1863,7 @@
                 }
             ],
             "description": "Brief description of this PHP library",
-            "time": "2018-11-08T09:40:00+00:00"
+            "time": "2018-11-08 09:40:00"
         },
         {
             "name": "cultuurnet/valueobjects",
@@ -5986,7 +5986,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -9020,12 +9020,6 @@
             "package": "chrisboulton/php-resque"
         },
         {
-            "alias": "0.1",
-            "alias_normalized": "0.1.0.0",
-            "version": "9999999-dev",
-            "package": "cultuurnet/udb3-api-guard"
-        },
-        {
             "alias": "1.3.1",
             "alias_normalized": "1.3.1.0",
             "version": "4.0.3.0-alpha",
@@ -9037,7 +9031,6 @@
         "chrisboulton/php-resque": 20,
         "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/search-v3": 20,
-        "cultuurnet/udb3-api-guard": 20,
         "doctrine/migrations": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
### Fixed
- No longer depend on a specific commit of the `udb3-api-guard` dependency
