### PR TITLE
III-3070 Add command to re-dispatch MarkedAsDuplicate event

### DIFF
--- a/app/Console/DispatchMarkedAsDuplicateEventCommand.php
+++ b/app/Console/DispatchMarkedAsDuplicateEventCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventHandling\EventBusInterface;
+use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use ValueObjects\Identity\UUID;
+
+class DispatchMarkedAsDuplicateEventCommand extends AbstractCommand
+{
+    private const DUPLICATE_PLACE_ID_ARGUMENT = 'duplicate_place_id';
+    private const CANONICAL_PLACE_ID_ARGUMENT = 'canonical_place_id';
+
+    public function configure()
+    {
+        $this->setName('place:mark-as-duplicate:redispatch-event');
+        $this->setDescription('Re-dispatch the MarkedAsDuplicate event to trigger related process managers');
+        $this->addArgument(self::DUPLICATE_PLACE_ID_ARGUMENT, InputArgument::REQUIRED, 'uuid of the duplicate place');
+        $this->addArgument(self::CANONICAL_PLACE_ID_ARGUMENT, InputArgument::REQUIRED, 'uuid of the canonical place');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+            $this->getEventBus()->publish(
+                new DomainEventStream([
+                    DomainMessage::recordNow(
+                        UUID::generateAsString(),
+                        0,
+                        Metadata::deserialize([]),
+                        new MarkedAsDuplicate(
+                            $input->getArgument(self::DUPLICATE_PLACE_ID_ARGUMENT),
+                            $input->getArgument(self::CANONICAL_PLACE_ID_ARGUMENT)
+                        )
+                    )
+                ])
+            );
+            $output->writeln('Successfully re-dispatched MarkedAsDuplicate event');
+    }
+
+    /**
+     * @return EventBusInterface
+     */
+    protected function getEventBus()
+    {
+        $app = $this->getSilexApplication();
+        return $app['event_bus'];
+    }
+}

--- a/app/Console/DispatchMarkedAsDuplicateEventCommand.php
+++ b/app/Console/DispatchMarkedAsDuplicateEventCommand.php
@@ -28,17 +28,19 @@ class DispatchMarkedAsDuplicateEventCommand extends AbstractCommand
     public function execute(InputInterface $input, OutputInterface $output)
     {
             $this->getEventBus()->publish(
-                new DomainEventStream([
-                    DomainMessage::recordNow(
-                        UUID::generateAsString(),
-                        0,
-                        Metadata::deserialize([]),
-                        new MarkedAsDuplicate(
-                            $input->getArgument(self::DUPLICATE_PLACE_ID_ARGUMENT),
-                            $input->getArgument(self::CANONICAL_PLACE_ID_ARGUMENT)
-                        )
-                    )
-                ])
+                new DomainEventStream(
+                    [
+                        DomainMessage::recordNow(
+                            UUID::generateAsString(),
+                            0,
+                            Metadata::deserialize([]),
+                            new MarkedAsDuplicate(
+                                $input->getArgument(self::DUPLICATE_PLACE_ID_ARGUMENT),
+                                $input->getArgument(self::CANONICAL_PLACE_ID_ARGUMENT)
+                            )
+                        ),
+                    ]
+                )
             );
             $output->writeln('Successfully re-dispatched MarkedAsDuplicate event');
     }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -4,6 +4,7 @@
 use CultuurNet\SilexAMQP\Console\ConsumeCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeByCdbidCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeCommand;
+use CultuurNet\UDB3\Silex\Console\DispatchMarkedAsDuplicateEventCommand;
 use CultuurNet\UDB3\Silex\Console\EventAncestorsCommand;
 use CultuurNet\UDB3\Silex\Console\EventCdbXmlCommand;
 use CultuurNet\UDB3\Silex\Console\FireProjectedToJSONLDCommand;
@@ -89,5 +90,6 @@ $consoleApp->add(new ImportEventCdbXmlCommand());
 $consoleApp->add(new ImportPlaceCdbXmlCommand());
 $consoleApp->add(new ValidatePlaceJsonLdCommand());
 $consoleApp->add(new MarkPlaceAsDuplicateCommand());
+$consoleApp->add(new DispatchMarkedAsDuplicateEventCommand());
 
 $consoleApp->run();


### PR DESCRIPTION
### Added

- Added CLI command to re-dispatch MarkedAsDuplicateEvent to re-trigger LocationMarkedAsDuplicate process manager for testing purposes

---
Ticket: https://jira.uitdatabank.be/browse/III-3070
