### PR TITLE
III-3087 BIS - Explicitly pass which labels can be removed from the offer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "1b428d4b75e1f3e1d90bab1658df7b49",
@@ -54,7 +54,7 @@
                 }
             ],
             "description": " Library for creating collection classes with strict typing.",
-            "time": "2015-12-16T09:28:40+00:00"
+            "time": "2015-12-16 09:28:40"
         },
         {
             "name": "2dotstwice/silex-feature-toggles-provider",
@@ -96,7 +96,7 @@
                 "MIT"
             ],
             "description": "Feature toggles for Silex",
-            "time": "2017-07-03T14:15:24+00:00"
+            "time": "2017-07-03 14:15:24"
         },
         {
             "name": "2dotstwice/value-objects",
@@ -644,7 +644,7 @@
                 "Apache-2.0"
             ],
             "description": "Authentication service for CultuurNet web services",
-            "time": "2015-08-24T20:22:37+00:00"
+            "time": "2015-08-24 20:22:37"
         },
         {
             "name": "cultuurnet/broadway-amqp",
@@ -691,7 +691,7 @@
                 "Apache-2.0"
             ],
             "description": "AMQP integration for Broadway library",
-            "time": "2018-06-29T14:20:00+00:00"
+            "time": "2018-06-29 14:20:00"
         },
         {
             "name": "cultuurnet/broadway-tools",
@@ -732,7 +732,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-09-28T12:46:42+00:00"
+            "time": "2018-09-28 12:46:42"
         },
         {
             "name": "cultuurnet/calendar-summary",
@@ -836,7 +836,7 @@
                 }
             ],
             "description": "Library to convert cultuurnet dates to a readable summary",
-            "time": "2019-03-13T16:49:38+00:00"
+            "time": "2019-03-13 16:49:38"
         },
         {
             "name": "cultuurnet/cdb",
@@ -874,7 +874,7 @@
                 "Apache-2.0"
             ],
             "description": "PHP library for hydrating/manipulating CultuurNet's Cdb XML documents",
-            "time": "2018-10-17T12:47:54+00:00"
+            "time": "2018-10-17 12:47:54"
         },
         {
             "name": "cultuurnet/clock",
@@ -915,7 +915,7 @@
                 }
             ],
             "description": "Clock abstraction library",
-            "time": "2015-06-08T16:12:34+00:00"
+            "time": "2015-06-08 16:12:34"
         },
         {
             "name": "cultuurnet/culturefeed-php",
@@ -983,7 +983,7 @@
                 }
             ],
             "description": "Culturefeed PHP library",
-            "time": "2018-11-08T09:30:52+00:00"
+            "time": "2018-11-08 09:30:52"
         },
         {
             "name": "cultuurnet/deserializer",
@@ -1030,7 +1030,7 @@
                 }
             ],
             "description": "Internet media type deserialization library",
-            "time": "2018-06-29T14:27:41+00:00"
+            "time": "2018-06-29 14:27:41"
         },
         {
             "name": "cultuurnet/entry",
@@ -1080,7 +1080,7 @@
                 }
             ],
             "description": "PHP library to access CultuurNet's Entry API",
-            "time": "2018-11-08T13:17:43+00:00"
+            "time": "2018-11-08 13:17:43"
         },
         {
             "name": "cultuurnet/geocoding",
@@ -1129,7 +1129,7 @@
                     "email": "bert@2dotstwice.be"
                 }
             ],
-            "time": "2018-06-29T14:21:16+00:00"
+            "time": "2018-06-29 14:21:16"
         },
         {
             "name": "cultuurnet/hydra",
@@ -1177,7 +1177,7 @@
                 }
             ],
             "description": "PHP library implementing concepts of http://www.hydra-cg.com/",
-            "time": "2018-06-29T14:26:23+00:00"
+            "time": "2018-06-29 14:26:23"
         },
         {
             "name": "cultuurnet/monolog-socketio",
@@ -1221,7 +1221,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:28:08+00:00"
+            "time": "2018-06-29 14:28:08"
         },
         {
             "name": "cultuurnet/search",
@@ -1320,7 +1320,7 @@
                 }
             ],
             "description": "Cultuurnet search service for version 3",
-            "time": "2019-02-14T11:49:27+00:00"
+            "time": "2019-02-14 11:49:27"
         },
         {
             "name": "cultuurnet/silex-amqp",
@@ -1363,7 +1363,7 @@
                 "Apache-2.0"
             ],
             "description": "AMQP integration for Silex projects",
-            "time": "2018-06-29T14:15:23+00:00"
+            "time": "2018-06-29 14:15:23"
         },
         {
             "name": "cultuurnet/silex-service-provider-jwt",
@@ -1405,7 +1405,7 @@
                 "Apache-2.0"
             ],
             "description": "JWT authentication for Silex",
-            "time": "2018-06-29T14:29:16+00:00"
+            "time": "2018-06-29 14:29:16"
         },
         {
             "name": "cultuurnet/symfony-security-jwt",
@@ -1447,7 +1447,7 @@
                 "Apache-2.0"
             ],
             "description": "JWT implementation for the Symfony Security component",
-            "time": "2018-06-29T14:29:57+00:00"
+            "time": "2018-06-29 14:29:57"
         },
         {
             "name": "cultuurnet/udb2-domain-events",
@@ -1496,7 +1496,7 @@
                 }
             ],
             "description": "PHP models for domain events in UiTdatabank version 2",
-            "time": "2018-06-29T14:27:15+00:00"
+            "time": "2018-06-29 14:27:15"
         },
         {
             "name": "cultuurnet/udb3",
@@ -1504,12 +1504,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "664c38a38a41d3d0179aeb73646529112a9a4d5f"
+                "reference": "4ed7d3c2d6999ad076dd7cba4b3fe713fb402699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/664c38a38a41d3d0179aeb73646529112a9a4d5f",
-                "reference": "664c38a38a41d3d0179aeb73646529112a9a4d5f",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/4ed7d3c2d6999ad076dd7cba4b3fe713fb402699",
+                "reference": "4ed7d3c2d6999ad076dd7cba4b3fe713fb402699",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-09-12T09:26:29+00:00"
+            "time": "2019-09-24 13:45:46"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -1627,7 +1627,7 @@
                     "email": "bert@2dotstwice.be"
                 }
             ],
-            "time": "2018-10-03T08:52:10+00:00"
+            "time": "2018-10-03 08:52:10"
         },
         {
             "name": "cultuurnet/udb3-doctrine",
@@ -1672,7 +1672,7 @@
                 }
             ],
             "description": "UDB3 integration with Doctrine Cache",
-            "time": "2016-04-13T11:52:34+00:00"
+            "time": "2016-04-13 11:52:34"
         },
         {
             "name": "cultuurnet/udb3-http-foundation",
@@ -1713,7 +1713,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:28:42+00:00"
+            "time": "2018-06-29 14:28:42"
         },
         {
             "name": "cultuurnet/udb3-jwt",
@@ -1762,7 +1762,7 @@
                 }
             ],
             "description": "Provides JWT service classes",
-            "time": "2018-06-29T14:15:52+00:00"
+            "time": "2018-06-29 14:15:52"
         },
         {
             "name": "cultuurnet/udb3-models",
@@ -1807,7 +1807,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "time": "2018-06-29T14:08:37+00:00"
+            "time": "2018-06-29 14:08:37"
         },
         {
             "name": "cultuurnet/uitid-credentials",
@@ -1863,7 +1863,7 @@
                 }
             ],
             "description": "Brief description of this PHP library",
-            "time": "2018-11-08T09:40:00+00:00"
+            "time": "2018-11-08 09:40:00"
         },
         {
             "name": "cultuurnet/valueobjects",
@@ -5986,7 +5986,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -221,8 +221,10 @@ class EventDocumentImporter implements DocumentImporterInterface
          */
         $commands = [];
         $lockedLabels = $this->lockedLabelRepository->getLockedLabelsForItem($id);
+        $unlockedLabels = $this->lockedLabelRepository->getUnlockedLabelsForItem($id);
         $commands[] = (new ImportLabels($id, $import->getLabels()))
-            ->withLabelsToKeepIfAlreadyOnOffer($lockedLabels);
+            ->withLabelsToKeepIfAlreadyOnOffer($lockedLabels)
+            ->withLabelsToRemoveWhenOnOffer($unlockedLabels);
 
         $this->dispatchCommands($commands, $id);
     }

--- a/src/Model/Import/Taxonomy/Label/LockedLabelRepository.php
+++ b/src/Model/Import/Taxonomy/Label/LockedLabelRepository.php
@@ -6,9 +6,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 
 interface LockedLabelRepository
 {
-    /**
-     * @param $itemId
-     * @return Labels
-     */
-    public function getLockedLabelsForItem($itemId);
+    public function getLockedLabelsForItem(string $itemId): Labels;
+
+    public function getUnlockedLabelsForItem(string $itemId): Labels;
 }

--- a/tests/Model/Import/Event/EventDocumentImporterTest.php
+++ b/tests/Model/Import/Event/EventDocumentImporterTest.php
@@ -193,6 +193,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventDoesNotExist($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
         $this->expectCreateEvent($event);
 
         $this->commandBus->record();
@@ -255,6 +256,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventDoesNotExist($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
         $this->expectCreateEvent($event);
 
         $this->commandBus->record();
@@ -289,6 +291,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $this->commandBus->record();
 
@@ -347,6 +350,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $this->commandBus->record();
 
@@ -381,6 +385,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $this->commandBus->record();
 
@@ -408,6 +413,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $this->commandBus->record();
 
@@ -442,6 +448,7 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $this->commandBus->record();
 
@@ -489,6 +496,7 @@ class EventDocumentImporterTest extends TestCase
 
         $this->expectEventIdExists($id);
         $this->expectNoLockedLabels();
+        $this->expectNoUnlockedLabels();
 
         $expectedImages = ImageCollection::fromArray(
             [
@@ -568,10 +576,21 @@ class EventDocumentImporterTest extends TestCase
             new Label(new LabelName('locked1')),
             new Label(new LabelName('locked2'))
         );
+        $unlockedLabels = new Labels(
+            new Label(new LabelName('foo'), true),
+            new Label(new LabelName('bar'), true),
+            new Label(new LabelName('lorem'), false),
+            new Label(new LabelName('ipsum'), false)
+        );
         $this->lockedLabelRepository->expects($this->once())
             ->method('getLockedLabelsForItem')
             ->with($id)
             ->willReturn($lockedLabels);
+
+        $this->lockedLabelRepository->expects($this->once())
+            ->method('getUnlockedLabelsForItem')
+            ->with($id)
+            ->willReturn($unlockedLabels);
 
         $this->commandBus->record();
 
@@ -590,7 +609,8 @@ class EventDocumentImporterTest extends TestCase
                         new Label(new LabelName('ipsum'), false)
                     )
                 )
-            )->withLabelsToKeepIfAlreadyOnOffer($lockedLabels),
+            )->withLabelsToKeepIfAlreadyOnOffer($lockedLabels)
+                ->withLabelsToRemoveWhenOnOffer($unlockedLabels),
             $recordedCommands
         );
     }
@@ -762,6 +782,13 @@ class EventDocumentImporterTest extends TestCase
             ->willReturn(new Labels());
     }
 
+    private function expectNoUnlockedLabels()
+    {
+        $this->lockedLabelRepository->expects($this->any())
+            ->method('getUnlockedLabelsForItem')
+            ->willReturn(new Labels());
+    }
+
     private function assertContainsObject($needle, array $haystack)
     {
         $this->assertContains(
@@ -772,4 +799,5 @@ class EventDocumentImporterTest extends TestCase
             false
         );
     }
+
 }

--- a/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
+++ b/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
@@ -81,4 +81,53 @@ final class RelationshipModelLockedLabelRepositoryTest extends TestCase
 
         $this->assertEquals($expectedLabels, $actualLabels);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_imported_labels_related_to_the_given_item()
+    {
+        $itemId = 'A09D5CAA-DFD7-43D1-BEE1-1307ECB3A1C1';
+
+        $relations = [
+            new LabelRelation(
+                new Udb3LabelName('applied_via_ui_1'),
+                RelationType::EVENT(),
+                new StringLiteral($itemId),
+                false
+            ),
+            new LabelRelation(
+                new Udb3LabelName('imported_1'),
+                RelationType::EVENT(),
+                new StringLiteral($itemId),
+                true
+            ),
+            new LabelRelation(
+                new Udb3LabelName('applied_via_ui_2'),
+                RelationType::EVENT(),
+                new StringLiteral($itemId),
+                false
+            ),
+            new LabelRelation(
+                new Udb3LabelName('imported_2'),
+                RelationType::EVENT(),
+                new StringLiteral($itemId),
+                true
+            ),
+        ];
+
+        $this->relationshipsRepository->expects($this->once())
+            ->method('getLabelRelationsForItem')
+            ->with($itemId)
+            ->willReturn($relations);
+
+        $expectedLabels = new Labels(
+            new Label(new LabelName('imported_1')),
+            new Label(new LabelName('imported_2'))
+        );
+
+        $actualLabels = $this->lockedLabelRepository->getUnlockedLabelsForItem($itemId);
+
+        $this->assertEquals($expectedLabels, $actualLabels);
+    }
 }


### PR DESCRIPTION
### Fixed
- Uitpas labels are no longer removed from events after import. This was originally tried in https://github.com/cultuurnet/udb3-silex/pull/381 but that didn't cover everything.

---
Ticket: https://jira.uitdatabank.be/browse/III-3087
