### PR TITLE
Feature/iii 3096

### DIFF
--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -182,13 +182,6 @@ class EventDocumentImporter implements DocumentImporterInterface
             $commands[] = new UpdateDescription($id, $mainLanguage, $description);
         }
 
-        $organizerId = $adapter->getOrganizerId();
-        if ($organizerId) {
-            $commands[] = new UpdateOrganizer($id, $organizerId);
-        } else {
-            $commands[] = new DeleteCurrentOrganizer($id);
-        }
-
         $ageRange = $adapter->getAgeRange();
         if ($ageRange) {
             $commands[] = new UpdateTypicalAgeRange($id, $ageRange);
@@ -219,6 +212,15 @@ class EventDocumentImporter implements DocumentImporterInterface
         $commands[] = (new ImportLabels($id, $import->getLabels()))
             ->withLabelsToKeepIfAlreadyOnOffer($lockedLabels)
             ->withLabelsToRemoveWhenOnOffer($unlockedLabels);
+
+        // Update the organizer only at the end, because it can trigger UiTPAS to send messages to another worker
+        // which might cause race conditions if we're still dispatching other commands here as well.
+        $organizerId = $adapter->getOrganizerId();
+        if ($organizerId) {
+            $commands[] = new UpdateOrganizer($id, $organizerId);
+        } else {
+            $commands[] = new DeleteCurrentOrganizer($id);
+        }
 
         $this->dispatchCommands($commands, $id);
     }

--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -214,12 +214,6 @@ class EventDocumentImporter implements DocumentImporterInterface
         $images = $this->imageCollectionFactory->fromMediaObjectReferences($import->getMediaObjectReferences());
         $commands[] = new ImportImages($id, $images);
 
-        $this->dispatchCommands($commands, $id);
-
-        /** Dispatch label updates separately to avoid issues with labels added after import.
-         *  The ImportLabels command only retains labels that are already on the event.
-         */
-        $commands = [];
         $lockedLabels = $this->lockedLabelRepository->getLockedLabelsForItem($id);
         $unlockedLabels = $this->lockedLabelRepository->getUnlockedLabelsForItem($id);
         $commands[] = (new ImportLabels($id, $import->getLabels()))

--- a/tests/Model/Import/Event/EventDocumentImporterTest.php
+++ b/tests/Model/Import/Event/EventDocumentImporterTest.php
@@ -204,12 +204,12 @@ class EventDocumentImporterTest extends TestCase
             new UpdateAudience($id, new Audience(AudienceType::EVERYONE())),
             new UpdateBookingInfo($id, new BookingInfo()),
             new UpdateContactPoint($id, new ContactPoint()),
-            new DeleteCurrentOrganizer($id),
             new DeleteTypicalAgeRange($id),
             new UpdateTitle($id, new Language('fr'), new Title('Nom example')),
             new UpdateTitle($id, new Language('en'), new Title('Example name')),
             new ImportImages($id, new ImageCollection()),
             new ImportLabels($id, new Labels()),
+            new DeleteCurrentOrganizer($id),
         ];
 
         $recordedCommands = $this->commandBus->getRecordedCommands();
@@ -267,12 +267,12 @@ class EventDocumentImporterTest extends TestCase
             new UpdateAudience($id, new Audience(AudienceType::EVERYONE())),
             new UpdateBookingInfo($id, new BookingInfo()),
             new UpdateContactPoint($id, new ContactPoint()),
-            new DeleteCurrentOrganizer($id),
             new DeleteTypicalAgeRange($id),
             new UpdateTitle($id, new Language('fr'), new Title('Nom example')),
             new UpdateTitle($id, new Language('en'), new Title('Example name')),
             new ImportImages($id, new ImageCollection()),
             new ImportLabels($id, new Labels()),
+            new DeleteCurrentOrganizer($id),
         ];
 
         $recordedCommands = $this->commandBus->getRecordedCommands();
@@ -320,12 +320,12 @@ class EventDocumentImporterTest extends TestCase
             new UpdateAudience($id, new Audience(AudienceType::EVERYONE())),
             new UpdateBookingInfo($id, new BookingInfo()),
             new UpdateContactPoint($id, new ContactPoint()),
-            new DeleteCurrentOrganizer($id),
             new DeleteTypicalAgeRange($id),
             new UpdateTitle($id, new Language('fr'), new Title('Nom example')),
             new UpdateTitle($id, new Language('en'), new Title('Example name')),
             new ImportImages($id, new ImageCollection()),
             new ImportLabels($id, new Labels()),
+            new DeleteCurrentOrganizer($id),
         ];
 
         $recordedCommands = $this->commandBus->getRecordedCommands();


### PR DESCRIPTION
### Fixed

- Fixed UiTPAS labels not being applied by waiting to update / delete the organizer until the end of the import of a given event. That way the UiTPAS worker only kicks in when the import is already done.

---
Ticket: https://jira.uitdatabank.be/browse/III-3096
