### PR TITLE
Add api key to event metadata and history projection

### DIFF
--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -103,7 +103,7 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                         throw new RequestAuthenticationException('Given API key is not authorized to use EntryAPI.');
                     }
                 },
-                Application::LATE_EVENT
+                Application::EARLY_EVENT
             );
         }
     }

--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -18,7 +18,6 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\ClassNameCommandFilter;
 use CultuurNet\UDB3\Security\CultureFeedUserIdentification;
 use CultuurNet\UDB3\Security\SecurityWithUserPermission;
-use CultuurNet\UDB3\Silex\ContextDecoratedCommandBus;
 use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use Qandidate\Toggle\ToggleManager;
 use Silex\Application;

--- a/app/CommandHandling/ContextDecoratedCommandBus.php
+++ b/app/CommandHandling/ContextDecoratedCommandBus.php
@@ -3,7 +3,7 @@
  * @file
  */
 
-namespace CultuurNet\UDB3\Silex;
+namespace CultuurNet\UDB3\Silex\CommandHandling;
 
 use Broadway\CommandHandling\CommandBusInterface;
 use CultuurNet\Auth\TokenCredentials;

--- a/app/CommandHandling/ContextDecoratedCommandBus.php
+++ b/app/CommandHandling/ContextDecoratedCommandBus.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @file
- */
 
 namespace CultuurNet\UDB3\Silex\CommandHandling;
 
@@ -37,34 +34,13 @@ class ContextDecoratedCommandBus extends CommandBusDecoratorBase
     public function dispatch($command)
     {
         if ($this->decoratee instanceof ContextAwareInterface) {
-            /** @var \CultureFeed_User $user */
-            $user = $this->application['current_user'];
-
-            $contextValues = array();
-            if ($user) {
-                $contextValues['user_id'] = $user->id;
-                $contextValues['user_nick'] = $user->nick;
-                $contextValues['user_email'] = $user->mbox;
-                $contextValues['auth_jwt'] = $this->application['jwt'];
-                $contextValues['auth_api_key'] = $this->application['api_key'];
-
-                /** @var TokenCredentials $tokenCredentials */
-                $tokenCredentials = $this->application['culturefeed_token_credentials'];
-                $contextValues['uitid_token_credentials'] = $tokenCredentials;
-            }
-
-            /** @var RequestStack $requestStack */
-            $requestStack = $this->application['request_stack'];
-            $request = $requestStack->getMasterRequest();
-            if ($request) {
-                // @todo Add to Impersonator? Sometimes an additional command
-                // is dispatched by the worker itself.
-                $contextValues['client_ip'] = $request->getClientIp();
-            }
-
-            $contextValues['request_time'] = $_SERVER['REQUEST_TIME'];
-
-            $context = new \Broadway\Domain\Metadata($contextValues);
+            $context = ContextFactory::createContext(
+                $this->application['current_user'],
+                $this->application['jwt'],
+                $this->application['api_key'],
+                $this->application['culturefeed_token_credentials'],
+                $this->application['request_stack']->getMasterRequest()
+            );
 
             $this->decoratee->setContext($context);
         }

--- a/app/CommandHandling/ContextFactory.php
+++ b/app/CommandHandling/ContextFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\CommandHandling;
+
+use Broadway\Domain\Metadata;
+use CultureFeed_User;
+use CultuurNet\Auth\TokenCredentials;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use Lcobucci\JWT\Token;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ContextFactory
+{
+    public static function createContext(
+        ?CultureFeed_User $user = null,
+        ?Token $jwt = null,
+        ?ApiKey $apiKey = null,
+        ?TokenCredentials $cultureFeedTokenCredentials = null,
+        ?Request $request = null
+    ): Metadata {
+        $contextValues = array();
+
+        if ($user) {
+            $contextValues['user_id'] = $user->id;
+            $contextValues['user_nick'] = $user->nick;
+            $contextValues['user_email'] = $user->mbox;
+        }
+
+        if ($jwt) {
+            $contextValues['auth_jwt'] = $jwt;
+        }
+
+        if ($apiKey) {
+            $contextValues['auth_api_key'] = $apiKey;
+        }
+
+        if ($cultureFeedTokenCredentials) {
+            $contextValues['uitid_token_credentials'] = $cultureFeedTokenCredentials;
+        }
+
+        if ($request) {
+            $contextValues['client_ip'] = $request->getClientIp();
+        }
+
+        $contextValues['request_time'] = $_SERVER['REQUEST_TIME'];
+
+        return new Metadata($contextValues);
+    }
+
+    public static function prepareForLogging(Metadata $metadata): Metadata
+    {
+        $metadata = $metadata->serialize();
+
+        // Don't store the JWT or UiTID access token when logging the metadata in the event store.
+        unset($metadata['auth_jwt'], $metadata['uitid_token_credentials']);
+
+        // Convert the ApiKey object to a string so it can get JSON-encoded.
+        if (isset($metadata['auth_api_key'])) {
+            $metadata['auth_api_key'] = (string) $metadata['auth_api_key'];
+        }
+
+        return new Metadata($metadata);
+    }
+}

--- a/app/Impersonator.php
+++ b/app/Impersonator.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3\Silex;
 
 use Broadway\Domain\Metadata;
+use CultureFeed_User;
 use CultuurNet\Auth\TokenCredentials;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use Lcobucci\JWT\Token as Jwt;
@@ -10,7 +11,7 @@ use Lcobucci\JWT\Token as Jwt;
 class Impersonator
 {
     /**
-     * @var \CultureFeed_User
+     * @var CultureFeed_User
      */
     private $user;
 
@@ -25,67 +26,40 @@ class Impersonator
     private $jwt;
 
     /**
-     * @var ApiKey
+     * @var ApiKey|null
      */
     private $apiKey;
 
-    public function __construct()
-    {
-        $this->user = null;
-        $this->tokenCredentials = null;
-    }
-
-    /**
-     * @return \CultureFeed_User|null
-     */
-    public function getUser()
+    public function getUser(): ?CultureFeed_User
     {
         return $this->user;
     }
 
-    /**
-     * @return TokenCredentials|null
-     */
-    public function getTokenCredentials()
+    public function getTokenCredentials(): ?TokenCredentials
     {
         return $this->tokenCredentials;
     }
 
-    /**
-     * @return Jwt|null
-     */
-    public function getJwt()
+    public function getJwt(): ?Jwt
     {
         return $this->jwt;
     }
 
-    /**
-     * @return ApiKey|null
-     */
-    public function getApiKey()
+    public function getApiKey(): ?ApiKey
     {
         return $this->apiKey;
     }
 
-    /**
-     * @param Metadata $metadata
-     */
-    public function impersonate(Metadata $metadata)
+    public function impersonate(Metadata $metadata): void
     {
         $metadata = $metadata->serialize();
 
-        $this->user = new \CultureFeed_User();
+        $this->user = new CultureFeed_User();
         $this->user->id = $metadata['user_id'];
         $this->user->nick = $metadata['user_nick'];
-
-        // There might still be queued commands without this metadata because
-        // it was added later.
-        $this->user->mbox = isset($metadata['user_email']) ? $metadata['user_email'] : null;
-        $this->jwt = isset($metadata['auth_jwt']) ? $metadata['auth_jwt'] : null;
-
-        // It is also possible to work without ApiKey enabled. So this can be null.
-        $this->apiKey = isset($metadata['auth_api_key']) ? $metadata['auth_api_key'] : null;
-
+        $this->user->mbox = $metadata['user_email'] ?? null;
+        $this->jwt = $metadata['auth_jwt'] ?? null;
+        $this->apiKey = $metadata['auth_api_key'] ?? null;
         $this->tokenCredentials = $metadata['uitid_token_credentials'];
     }
 }

--- a/app/Metadata/MetadataServiceProvider.php
+++ b/app/Metadata/MetadataServiceProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Metadata;
+
+use Broadway\Domain\Metadata;
+use Broadway\EventDispatcher\EventDispatcher;
+use Broadway\EventSourcing\MetadataEnrichment\MetadataEnrichingEventStreamDecorator;
+use CultuurNet\UDB3\CommandHandling\ResqueCommandBus;
+use CultuurNet\UDB3\EventSourcing\ExecutionContextMetadataEnricher;
+use CultuurNet\UDB3\Silex\CommandHandling\ContextFactory;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class MetadataServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['execution_context_metadata_enricher'] = $app::share(
+            static function () {
+                return new ExecutionContextMetadataEnricher();
+            }
+        );
+
+        $app['event_stream_metadata_enricher'] = $app::share(
+            static function ($app) {
+                $eventStreamDecorator = new MetadataEnrichingEventStreamDecorator();
+                $eventStreamDecorator->registerEnricher(
+                    $app['execution_context_metadata_enricher']
+                );
+                return $eventStreamDecorator;
+            }
+        );
+
+        $app['command_bus_event_dispatcher'] = $app::share(
+            function ($app) {
+                $dispatcher = new EventDispatcher();
+                $dispatcher->addListener(
+                    ResqueCommandBus::EVENT_COMMAND_CONTEXT_SET,
+                    function ($context) use ($app) {
+                        $this->setEventStreamMetadata($app['execution_context_metadata_enricher'], $context);
+                    }
+                );
+
+                return $dispatcher;
+            }
+        );
+
+        $app->before(
+            function (Request $request, Application $app) {
+                $context = ContextFactory::createContext(
+                    $app['current_user'],
+                    $app['jwt'],
+                    $app['api_key'],
+                    $app['culturefeed_token_credentials'],
+                    $request
+                );
+
+                $this->setEventStreamMetadata($app['execution_context_metadata_enricher'], $context);
+            },
+            Application::LATE_EVENT
+        );
+    }
+
+    public function boot(Application $app)
+    {
+    }
+
+    private function setEventStreamMetadata(
+        ExecutionContextMetadataEnricher $executionContextMetadataEnricher,
+        ?Metadata $metadata
+    ): void {
+        $executionContextMetadataEnricher->setContext(
+            $metadata ? ContextFactory::prepareForLogging($metadata) : null
+        );
+    }
+}

--- a/app/Metadata/MetadataServiceProvider.php
+++ b/app/Metadata/MetadataServiceProvider.php
@@ -19,13 +19,13 @@ final class MetadataServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['execution_context_metadata_enricher'] = $app::share(
-            static function () {
+            function () {
                 return new ExecutionContextMetadataEnricher();
             }
         );
 
         $app['event_stream_metadata_enricher'] = $app::share(
-            static function ($app) {
+            function ($app) {
                 $eventStreamDecorator = new MetadataEnrichingEventStreamDecorator();
                 $eventStreamDecorator->registerEnricher(
                     $app['execution_context_metadata_enricher']

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/silex-service-provider-jwt": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "dev-master#c2352099eeb9d8e40feceabd55a10670f532a02b",
+    "cultuurnet/udb3": "dev-feature/III-3113 as 0.1",
     "cultuurnet/udb3-api-guard": "~0.1",
     "cultuurnet/udb3-doctrine": "~0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/silex-service-provider-jwt": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "dev-feature/III-3113 as 0.1",
+    "cultuurnet/udb3": "~0.1",
     "cultuurnet/udb3-api-guard": "~0.1",
     "cultuurnet/udb3-doctrine": "~0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f17c2e57fd89cf8aff0d5b814d4da346",
+    "content-hash": "4ab22907b764f2ac481ea7285b9a5ba1",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1500,16 +1500,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-feature/III-3113",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "0fb7088818f2bf070ab99cf39e3bc59124cbb5e9"
+                "reference": "211db0667a7e0e353b124503c6303d9a113c1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/0fb7088818f2bf070ab99cf39e3bc59124cbb5e9",
-                "reference": "0fb7088818f2bf070ab99cf39e3bc59124cbb5e9",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/211db0667a7e0e353b124503c6303d9a113c1296",
+                "reference": "211db0667a7e0e353b124503c6303d9a113c1296",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-11-13T13:39:45+00:00"
+            "time": "2019-11-14T08:35:05+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -9020,12 +9020,6 @@
             "package": "chrisboulton/php-resque"
         },
         {
-            "alias": "0.1",
-            "alias_normalized": "0.1.0.0",
-            "version": "dev-feature/III-3113",
-            "package": "cultuurnet/udb3"
-        },
-        {
             "alias": "1.3.1",
             "alias_normalized": "1.3.1.0",
             "version": "4.0.3.0-alpha",
@@ -9037,7 +9031,6 @@
         "chrisboulton/php-resque": 20,
         "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/search-v3": 20,
-        "cultuurnet/udb3": 20,
         "doctrine/migrations": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2c675fc8903b580f57c5ccce89a61d6",
+    "content-hash": "f17c2e57fd89cf8aff0d5b814d4da346",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1500,16 +1500,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-master",
+            "version": "dev-feature/III-3113",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "c2352099eeb9d8e40feceabd55a10670f532a02b"
+                "reference": "0fb7088818f2bf070ab99cf39e3bc59124cbb5e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/c2352099eeb9d8e40feceabd55a10670f532a02b",
-                "reference": "c2352099eeb9d8e40feceabd55a10670f532a02b",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/0fb7088818f2bf070ab99cf39e3bc59124cbb5e9",
+                "reference": "0fb7088818f2bf070ab99cf39e3bc59124cbb5e9",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-11-05T11:15:04+00:00"
+            "time": "2019-11-13T13:39:45+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -7298,8 +7298,8 @@
             "authors": [
                 {
                     "name": "Frank Kleine",
-                    "homepage": "http://frankkleine.de/",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "homepage": "http://frankkleine.de/"
                 }
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
@@ -8087,8 +8087,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -9018,6 +9018,12 @@
             "alias_normalized": "1.2.0.0",
             "version": "dev-compat-1-2",
             "package": "chrisboulton/php-resque"
+        },
+        {
+            "alias": "0.1",
+            "alias_normalized": "0.1.0.0",
+            "version": "dev-feature/III-3113",
+            "package": "cultuurnet/udb3"
         },
         {
             "alias": "1.3.1",

--- a/web/index.php
+++ b/web/index.php
@@ -2,11 +2,13 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use CultuurNet\SymfonySecurityJwt\Authentication\JwtUserToken;
+use CultuurNet\UDB3\EventSourcing\ExecutionContextMetadataEnricher;
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\AnyOfRequestMatcher;
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\PreflightRequestMatcher;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Silex\CommandHandling\ContextFactory;
 use CultuurNet\UDB3\Silex\FeatureControllerProvider;
+use CultuurNet\UDB3\Silex\Metadata\MetadataServiceProvider;
 use CultuurNet\UDB3\Silex\Role\UserPermissionsServiceProvider;
 use CultuurNet\UDB3\Http\Management\PermissionsVoter;
 use CultuurNet\UDB3\Http\Management\UserPermissionsVoter;
@@ -183,36 +185,6 @@ if (isset($app['config']['search_proxy']) &&
         Application::EARLY_EVENT
     );
 }
-
-/**
- * Bootstrap metadata based on user context.
- */
-$app->before(
-    function (Request $request, Application $app) {
-        $contextValues = [];
-
-        $contextValues['client_ip'] = $request->getClientIp();
-        $contextValues['request_time'] = $_SERVER['REQUEST_TIME'];
-
-        /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage $tokenStorage */
-        $tokenStorage = $app['security.token_storage'];
-        $authToken = $tokenStorage->getToken();
-
-        if ($authToken instanceof JwtUserToken && $authToken->isAuthenticated()) {
-            $jwt = $authToken->getCredentials();
-            $contextValues['user_id'] = $jwt->getClaim('uid');
-            $contextValues['user_nick'] = $jwt->getClaim('nick');
-            $contextValues['user_email'] = $jwt->getClaim('email');
-        }
-
-        $contextValues['client_ip'] = $request->getClientIp();
-        $contextValues['request_time'] = $_SERVER['REQUEST_TIME'];
-
-        /** @var \CultuurNet\UDB3\EventSourcing\ExecutionContextMetadataEnricher $metadataEnricher */
-        $metadataEnricher = $app['execution_context_metadata_enricher'];
-        $metadataEnricher->setContext(new \Broadway\Domain\Metadata($contextValues));
-    }
-);
 
 $app->before(function (Request $request, Application $app) {
     $app['request_logger']->logRequest($request);


### PR DESCRIPTION
### Changed

- Refactored the way context / metadata is determined and set.

### Fixed

- The api key is now added to all events' metadata instead of only in some edge cases.

### Removed

- Removed `auth_jwt` and `uitid_token_credentials` from the metadata that gets stored as they were cast to `{}` anyway and are too sensitive to store.

---
Ticket: https://jira.uitdatabank.be/browse/III-3113
