### PR TITLE
III-3113 Fix type error caused by uitid_token_credentials being an array

### DIFF
--- a/app/Impersonator.php
+++ b/app/Impersonator.php
@@ -60,6 +60,6 @@ class Impersonator
         $this->user->mbox = $metadata['user_email'] ?? null;
         $this->jwt = $metadata['auth_jwt'] ?? null;
         $this->apiKey = $metadata['auth_api_key'] ?? null;
-        $this->tokenCredentials = $metadata['uitid_token_credentials'];
+        $this->tokenCredentials = $metadata['uitid_token_credentials'] ?? null;
     }
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Broadway\Domain\Metadata;
 use CultuurNet\SilexAMQP\Console\ConsumeCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeByCdbidCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeCommand;
@@ -48,7 +49,14 @@ $consoleApp = $app['console'];
 // To avoid fixing this locally in the amqp-silex lib, all CLI commands are executed as udb3 system user.
 /** @var Impersonator $impersonator */
 $impersonator = $app['impersonator'];
-$impersonator->impersonate($app['udb3_system_user_metadata']);
+$impersonator->impersonate(
+    new Metadata(
+        [
+            'user_id' => SYSTEM_USER_UUID,
+            'user_nick' => 'udb3',
+        ]
+    )
+);
 
 $consoleApp->add(
     (new ConsumeCommand('amqp-listen', 'amqp.udb2_event_bus_forwarding_consumer'))

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1273,17 +1273,6 @@ $app->register(new \CultuurNet\UDB3\Silex\Place\PlaceGeoCoordinatesServiceProvid
 $app->register(new \CultuurNet\UDB3\Silex\Event\EventGeoCoordinatesServiceProvider());
 $app->register(new \CultuurNet\UDB3\Silex\Organizer\OrganizerGeoCoordinatesServiceProvider());
 
-$app['udb3_system_user_metadata'] = $app->share(
-    function () {
-        return new Metadata(
-            [
-                'user_id' => SYSTEM_USER_UUID,
-                'user_nick' => 'udb3',
-            ]
-        );
-    }
-);
-
 $app->register(new \CultuurNet\UDB3\Silex\Event\EventImportServiceProvider());
 $app->register(new \CultuurNet\UDB3\Silex\Place\PlaceImportServiceProvider());
 $app->register(new \CultuurNet\UDB3\Silex\Organizer\OrganizerImportServiceProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1279,7 +1279,6 @@ $app['udb3_system_user_metadata'] = $app->share(
             [
                 'user_id' => SYSTEM_USER_UUID,
                 'user_nick' => 'udb3',
-                'uitid_token_credentials' => [],
             ]
         );
     }


### PR DESCRIPTION
### Fixed

- Fixed console commands crashing because of a type error in the `Impersonator` class caused by invalid `uitid_token_credentials` data

---
Ticket: https://jira.uitdatabank.be/browse/III-3113
