### PR TITLE
Move the history projectors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/silex-service-provider-jwt": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "dev-feature/III-3141 as 0.1",
+    "cultuurnet/udb3": "dev-master#7700f878ff42cf89ba6d6470ad752b1b1c4b6b4c as 0.1",
     "cultuurnet/udb3-api-guard": "~0.1",
     "cultuurnet/udb3-doctrine": "~0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/silex-service-provider-jwt": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "dev-master#4df7a02622da8854b6e08f90fce699f24898e4bc as 0.1",
+    "cultuurnet/udb3": "dev-feature/III-3141 as 0.1",
     "cultuurnet/udb3-api-guard": "~0.1",
     "cultuurnet/udb3-doctrine": "~0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8e3e90dc2cc64e7e218ee5dfc00345b",
+    "content-hash": "0ea69c4937eb5d00676d3bc28b7b2128",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1500,16 +1500,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-feature/III-3141",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "980af61f60ac797931c3015b6a5c374a6397c98e"
+                "reference": "7700f878ff42cf89ba6d6470ad752b1b1c4b6b4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/980af61f60ac797931c3015b6a5c374a6397c98e",
-                "reference": "980af61f60ac797931c3015b6a5c374a6397c98e",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/7700f878ff42cf89ba6d6470ad752b1b1c4b6b4c",
+                "reference": "7700f878ff42cf89ba6d6470ad752b1b1c4b6b4c",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-11-14T13:35:27+00:00"
+            "time": "2019-11-14T14:08:57+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -9022,7 +9022,7 @@
         {
             "alias": "0.1",
             "alias_normalized": "0.1.0.0",
-            "version": "dev-feature/III-3141",
+            "version": "9999999-dev",
             "package": "cultuurnet/udb3"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62d7a66d063f69551da21745caeffa79",
+    "content-hash": "d8e3e90dc2cc64e7e218ee5dfc00345b",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1500,16 +1500,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-master",
+            "version": "dev-feature/III-3141",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "4df7a02622da8854b6e08f90fce699f24898e4bc"
+                "reference": "980af61f60ac797931c3015b6a5c374a6397c98e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/4df7a02622da8854b6e08f90fce699f24898e4bc",
-                "reference": "4df7a02622da8854b6e08f90fce699f24898e4bc",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/980af61f60ac797931c3015b6a5c374a6397c98e",
+                "reference": "980af61f60ac797931c3015b6a5c374a6397c98e",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2019-11-14T13:02:57+00:00"
+            "time": "2019-11-14T13:35:27+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -9022,7 +9022,7 @@
         {
             "alias": "0.1",
             "alias_normalized": "0.1.0.0",
-            "version": "9999999-dev",
+            "version": "dev-feature/III-3141",
             "package": "cultuurnet/udb3"
         },
         {

--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\ReadModel\History;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListenerInterface;
+use CultuurNet\UDB3\Cdb\EventItemFactory;
+use CultuurNet\UDB3\Event\Events\DescriptionTranslated;
+use CultuurNet\UDB3\Event\Events\EventCopied;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
+use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
+use CultuurNet\UDB3\Event\Events\LabelAdded;
+use CultuurNet\UDB3\Event\Events\LabelRemoved;
+use CultuurNet\UDB3\Event\Events\TitleTranslated;
+use CultuurNet\UDB3\Offer\ReadModel\History\OfferHistoryProjector;
+use ValueObjects\StringLiteral\StringLiteral;
+
+class HistoryProjector extends OfferHistoryProjector implements EventListenerInterface
+{
+
+    protected function applyEventImportedFromUDB2(
+        EventImportedFromUDB2 $eventImportedFromUDB2,
+        DomainMessage $domainMessage
+    ) {
+        $udb2Event = EventItemFactory::createEventFromCdbXml(
+            $eventImportedFromUDB2->getCdbXmlNamespaceUri(),
+            $eventImportedFromUDB2->getCdbXml()
+        );
+
+        $this->writeHistory(
+            $eventImportedFromUDB2->getEventId(),
+            new Log(
+                $this->dateFromUdb2DateString(
+                    $udb2Event->getCreationDate()
+                ),
+                new StringLiteral('Aangemaakt in UDB2'),
+                new StringLiteral($udb2Event->getCreatedBy())
+            )
+        );
+
+        $this->writeHistory(
+            $eventImportedFromUDB2->getEventId(),
+            new Log(
+                $this->domainMessageDateToNativeDate(
+                    $domainMessage->getRecordedOn()
+                ),
+                new StringLiteral('Geïmporteerd vanuit UDB2'),
+                null,
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    protected function applyEventUpdatedFromUDB2(
+        EventUpdatedFromUDB2 $eventUpdatedFromUDB2,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $eventUpdatedFromUDB2->getEventId(),
+            new Log(
+                $this->domainMessageDateToNativeDate($domainMessage->getRecordedOn()),
+                new StringLiteral('Geüpdatet vanuit UDB2'),
+                null,
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    /**
+     * @param EventCreated $eventCreated
+     * @param DomainMessage $domainMessage
+     */
+    protected function applyEventCreated(
+        EventCreated $eventCreated,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $eventCreated->getEventId(),
+            new Log(
+                $this->domainMessageDateToNativeDate(
+                    $domainMessage->getRecordedOn()
+                ),
+                new StringLiteral('Aangemaakt in UiTdatabank'),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    /**
+     * @param EventCopied $eventCopied
+     * @param DomainMessage $domainMessage
+     */
+    protected function applyEventCopied(
+        EventCopied $eventCopied,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $eventCopied->getItemId(),
+            new Log(
+                $this->domainMessageDateToNativeDate(
+                    $domainMessage->getRecordedOn()
+                ),
+                new StringLiteral('Event gekopieerd van ' . $eventCopied->getOriginalEventId()),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLabelAddedClassName()
+    {
+        return LabelAdded::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLabelRemovedClassName()
+    {
+        return LabelRemoved::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTitleTranslatedClassName()
+    {
+        return TitleTranslated::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDescriptionTranslatedClassName()
+    {
+        return DescriptionTranslated::class;
+    }
+}

--- a/src/Event/ReadModel/History/Log.php
+++ b/src/Event/ReadModel/History/Log.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\ReadModel\History;
+
+use DateTime;
+use JsonSerializable;
+use ValueObjects\StringLiteral\StringLiteral;
+
+class Log implements JsonSerializable
+{
+    /**
+     * @var DateTime
+     */
+    private $date;
+
+    /**
+     * @var String
+     */
+    private $author;
+
+    /**
+     * @var String
+     */
+    private $description;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @var string
+     */
+    private $api;
+
+    public function __construct(
+        DateTime $date,
+        StringLiteral $description,
+        StringLiteral $author = null,
+        string $apiKey = null,
+        string $api = null
+    ) {
+        $this->date = clone $date;
+        $this->description = $description;
+        $this->author = $author;
+        $this->apiKey = $apiKey;
+        $this->api = $api;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize()
+    {
+        $log = [
+            'date' => $this->date->format('c'),
+            'description' => $this->description->toNative(),
+        ];
+
+        if ($this->author) {
+            $log['author'] = $this->author->toNative();
+        }
+
+        if ($this->apiKey) {
+            $log['apiKey'] = $this->apiKey;
+        }
+
+        if ($this->api) {
+            $log['api'] = $this->api;
+        }
+
+        return $log;
+    }
+}

--- a/src/Offer/ReadModel/History/OfferHistoryProjector.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjector.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace CultuurNet\UDB3\Offer\ReadModel\History;
+
+use Broadway\Domain\DateTime;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use CultuurNet\UDB3\Event\ReadModel\History\Log;
+use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
+use CultuurNet\UDB3\Offer\Events\AbstractDescriptionTranslated;
+use CultuurNet\UDB3\Offer\Events\AbstractLabelAdded;
+use CultuurNet\UDB3\Offer\Events\AbstractLabelRemoved;
+use CultuurNet\UDB3\Offer\Events\AbstractTitleTranslated;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use ValueObjects\StringLiteral\StringLiteral;
+
+abstract class OfferHistoryProjector
+{
+    use DelegateEventHandlingToSpecificMethodTrait {
+        DelegateEventHandlingToSpecificMethodTrait::handle as handleUnknownEvents;
+    }
+
+    /**
+     * @var DocumentRepositoryInterface
+     */
+    private $documentRepository;
+
+    public function __construct(DocumentRepositoryInterface $documentRepository)
+    {
+        $this->documentRepository = $documentRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DomainMessage $domainMessage)
+    {
+        $event = $domainMessage->getPayload();
+
+        $eventName = get_class($event);
+        $eventHandlers = $this->getEventHandlers();
+
+        if (isset($eventHandlers[$eventName])) {
+            $handler = $eventHandlers[$eventName];
+            call_user_func(array($this, $handler), $event, $domainMessage);
+        } else {
+            $this->handleUnknownEvents($domainMessage);
+        }
+    }
+
+    /**
+     * @return string[]
+     *   An associative array of commands and their handler methods.
+     */
+    protected function getEventHandlers()
+    {
+        $events = [];
+
+        foreach (get_class_methods($this) as $method) {
+            $matches = [];
+
+            if (preg_match('/^apply(.+)$/', $method, $matches)) {
+                $event = $matches[1];
+                $classNameMethod = 'get' . $event . 'ClassName';
+
+                if (method_exists($this, $classNameMethod)) {
+                    $eventFullClassName = call_user_func(array($this, $classNameMethod));
+                    $events[$eventFullClassName] = $method;
+                }
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getLabelAddedClassName();
+
+    /**
+     * @return string
+     */
+    abstract protected function getLabelRemovedClassName();
+
+    /**
+     * @return string
+     */
+    abstract protected function getTitleTranslatedClassName();
+
+    /**
+     * @return string
+     */
+    abstract protected function getDescriptionTranslatedClassName();
+
+    /**
+     * @param AbstractLabelAdded $labelAdded
+     * @param DomainMessage $domainMessage
+     */
+    protected function applyLabelAdded(
+        AbstractLabelAdded $labelAdded,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $labelAdded->getItemId(),
+            new Log(
+                $this->domainMessageDateToNativeDate($domainMessage->getRecordedOn()),
+                new StringLiteral("Label '{$labelAdded->getLabel()}' toegepast"),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    /**
+     * @param AbstractLabelRemoved $labelRemoved
+     * @param DomainMessage $domainMessage
+     */
+    protected function applyLabelRemoved(
+        AbstractLabelRemoved $labelRemoved,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $labelRemoved->getItemId(),
+            new Log(
+                $this->domainMessageDateToNativeDate($domainMessage->getRecordedOn()),
+                new StringLiteral("Label '{$labelRemoved->getLabel()}' verwijderd"),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    protected function applyTitleTranslated(
+        AbstractTitleTranslated $titleTranslated,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $titleTranslated->getItemId(),
+            new Log(
+                $this->domainMessageDateToNativeDate($domainMessage->getRecordedOn()),
+                new StringLiteral("Titel vertaald ({$titleTranslated->getLanguage()})"),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    protected function applyDescriptionTranslated(
+        AbstractDescriptionTranslated $descriptionTranslated,
+        DomainMessage $domainMessage
+    ) {
+        $this->writeHistory(
+            $descriptionTranslated->getItemId(),
+            new Log(
+                $this->domainMessageDateToNativeDate($domainMessage->getRecordedOn()),
+                new StringLiteral("Beschrijving vertaald ({$descriptionTranslated->getLanguage()})"),
+                $this->getAuthorFromMetadata($domainMessage->getMetadata()),
+                $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
+                $this->getApiFromMetadata($domainMessage->getMetadata())
+            )
+        );
+    }
+
+    /**
+     * @param DateTime $date
+     * @return \DateTime
+     */
+    protected function domainMessageDateToNativeDate(DateTime $date)
+    {
+        $dateString = $date->toString();
+        return \DateTime::createFromFormat(
+            DateTime::FORMAT_STRING,
+            $dateString
+        );
+    }
+
+    /**
+     * @param $dateString
+     * @return \DateTime
+     */
+    protected function dateFromUdb2DateString($dateString)
+    {
+        return \DateTime::createFromFormat(
+            'Y-m-d?H:i:s',
+            $dateString,
+            new \DateTimeZone('Europe/Brussels')
+        );
+    }
+
+    /**
+     * @param Metadata $metadata
+     * @return String|null
+     */
+    protected function getAuthorFromMetadata(Metadata $metadata)
+    {
+        $properties = $metadata->serialize();
+
+        if (isset($properties['user_nick'])) {
+            return new StringLiteral($properties['user_nick']);
+        }
+    }
+
+    /**
+     * @param Metadata $metadata
+     * @return String|null
+     */
+    protected function getConsumerFromMetadata(Metadata $metadata)
+    {
+        $properties = $metadata->serialize();
+
+        if (isset($properties['consumer']['name'])) {
+            return new StringLiteral($properties['consumer']['name']);
+        }
+    }
+
+    /**
+     * @param string $eventId
+     * @return JsonDocument
+     */
+    protected function loadDocumentFromRepositoryByEventId($eventId)
+    {
+        $historyDocument = $this->documentRepository->get($eventId);
+
+        if (!$historyDocument) {
+            $historyDocument = new JsonDocument($eventId, '[]');
+        }
+
+        return $historyDocument;
+    }
+
+    /**
+     * @param string $eventId
+     * @param Log[]|Log $logs
+     */
+    protected function writeHistory($eventId, $logs)
+    {
+        $historyDocument = $this->loadDocumentFromRepositoryByEventId($eventId);
+
+        $history = $historyDocument->getBody();
+
+        if (!is_array($logs)) {
+            $logs = [$logs];
+        }
+
+        // Append most recent one to the top.
+        foreach ($logs as $log) {
+            array_unshift($history, $log);
+        }
+
+        $this->documentRepository->save(
+            $historyDocument->withBody($history)
+        );
+    }
+
+    protected function getApiKeyFromMetadata(Metadata $metadata): ?string
+    {
+        $properties = $metadata->serialize();
+
+        if (isset($properties['auth_api_key'])) {
+            return $properties['auth_api_key'];
+        }
+
+        return null;
+    }
+
+    protected function getApiFromMetadata(Metadata $metadata): ?string
+    {
+        $properties = $metadata->serialize();
+
+        if (isset($properties['api'])) {
+            return $properties['api'];
+        }
+
+        return null;
+    }
+}

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\ReadModel\History;
+
+use Broadway\Domain\DateTime;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Description;
+use CultuurNet\UDB3\Event\Events\DescriptionTranslated;
+use CultuurNet\UDB3\Event\Events\EventCopied;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
+use CultuurNet\UDB3\Event\Events\EventUpdatedFromUDB2;
+use CultuurNet\UDB3\Event\Events\LabelAdded;
+use CultuurNet\UDB3\Event\Events\LabelRemoved;
+use CultuurNet\UDB3\Event\Events\TitleTranslated;
+use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use CultuurNet\UDB3\Event\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Theme;
+use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\TestCase;
+
+class HistoryProjectorTest extends TestCase
+{
+    const EVENT_ID_1 = 'a0ee7b1c-a9c1-4da1-af7e-d15496014656';
+    const EVENT_ID_2 = 'a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3';
+
+    const CDBXML_NAMESPACE = 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL';
+
+    /**
+     * @var HistoryProjector
+     */
+    protected $historyProjector;
+
+    /**
+     * @var DocumentRepositoryInterface
+     */
+    protected $documentRepository;
+
+    public function setUp()
+    {
+        $this->documentRepository = new InMemoryDocumentRepository();
+
+        $this->historyProjector = new HistoryProjector(
+            $this->documentRepository
+        );
+
+        $eventImported = new EventImportedFromUDB2(
+            self::EVENT_ID_1,
+            $this->getEventCdbXml(self::EVENT_ID_1),
+            self::CDBXML_NAMESPACE
+        );
+
+        $importedDate = '2015-03-04T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $eventImported->getEventId(),
+            1,
+            new Metadata(),
+            $eventImported,
+            DateTime::fromString($importedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+    }
+
+    /**
+     * @param string $eventId
+     * @return string
+     */
+    protected function getEventCdbXml($eventId)
+    {
+        return file_get_contents(__DIR__ . '/event-' . $eventId . '.xml');
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_EventImportedFromUDB2()
+    {
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+
+        $eventImported = new EventImportedFromUDB2(
+            self::EVENT_ID_2,
+            $this->getEventCdbXml(self::EVENT_ID_2),
+            self::CDBXML_NAMESPACE
+        );
+
+        $importedDate = '2015-03-01T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $eventImported->getEventId(),
+            1,
+            new Metadata(),
+            $eventImported,
+            DateTime::fromString($importedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_2,
+            [
+                (object) [
+                    'date' => '2015-03-01T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-09-08T09:10:16+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'info@traeghe.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_EventUpdatedFromUDB2()
+    {
+        $eventUpdated = new EventUpdatedFromUDB2(
+            self::EVENT_ID_1,
+            $this->getEventCdbXml(self::EVENT_ID_1),
+            self::CDBXML_NAMESPACE
+        );
+
+        $updatedDate = '2015-03-25T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $eventUpdated->getEventId(),
+            2,
+            new Metadata(),
+            $eventUpdated,
+            DateTime::fromString($updatedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'description' => 'Geüpdatet vanuit UDB2',
+                    'date' => '2015-03-25T10:17:19+02:00',
+                ],
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_creating_an_event()
+    {
+        $eventId = 'f2b227c5-4756-49f6-a25d-8286b6a2351f';
+
+        $eventCreated = new EventCreated(
+            $eventId,
+            new Language('en'),
+            new Title('Faith no More'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            new LocationId('7a59de16-6111-4658-aa6e-958ff855d14e'),
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.1.0.0', 'Rock')
+        );
+
+        $now = new \DateTime();
+
+        $domainMessage = new DomainMessage(
+            $eventId,
+            4,
+            new Metadata(
+                [
+                    'user_nick' => 'Jan Janssen',
+                    'auth_api_key' => 'my-super-duper-key',
+                    'api' => 'json-api',
+                ]
+            ),
+            $eventCreated,
+            DateTime::fromString($now->format(\DateTime::ATOM))
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            $eventId,
+            [
+                (object) [
+                    'date' => $now->format('c'),
+                    'author' => 'Jan Janssen',
+                    'description' => 'Aangemaakt in UiTdatabank',
+                    'apiKey' => 'my-super-duper-key',
+                    'api' => 'json-api',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_copying_an_event()
+    {
+        $eventId = 'f2b227c5-4756-49f6-a25d-8286b6a2351f';
+        $originalEventId = '1fd05542-ce0b-4ed1-ad17-cf5a0f316da4';
+
+        $eventCopied = new EventCopied(
+            $eventId,
+            $originalEventId,
+            new Calendar(CalendarType::PERMANENT())
+        );
+
+        $now = new \DateTime();
+
+        $domainMessage = new DomainMessage(
+            $eventId,
+            4,
+            new Metadata(['user_nick' => 'Jan Janssen']),
+            $eventCopied,
+            DateTime::fromString($now->format(\DateTime::ATOM))
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            $eventId,
+            [
+                (object) [
+                    'date' => $now->format('c'),
+                    'author' => 'Jan Janssen',
+                    'description' => 'Event gekopieerd van ' . $originalEventId,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_titleTranslated()
+    {
+        $titleTranslated = new TitleTranslated(
+            self::EVENT_ID_1,
+            new Language('fr'),
+            new Title('Titre en français')
+        );
+
+        $translatedDate = '2015-03-26T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $titleTranslated->getItemId(),
+            3,
+            new Metadata(['user_nick' => 'JohnDoe']),
+            $titleTranslated,
+            DateTime::fromString($translatedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-26T10:17:19+02:00',
+                    'author' => 'JohnDoe',
+                    'description' => 'Titel vertaald (fr)',
+                ],
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_descriptionTranslated()
+    {
+        $descriptionTranslated = new DescriptionTranslated(
+            self::EVENT_ID_1,
+            new Language('fr'),
+            new Description('Signalement en français')
+        );
+
+        $translatedDate = '2015-03-27T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $descriptionTranslated->getItemId(),
+            3,
+            new Metadata(['user_nick' => 'JaneDoe']),
+            $descriptionTranslated,
+            DateTime::fromString($translatedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'JaneDoe',
+                    'description' => 'Beschrijving vertaald (fr)',
+                ],
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_eventWasTagged()
+    {
+        $eventWasTagged = new LabelAdded(
+            self::EVENT_ID_1,
+            new Label('foo')
+        );
+
+        $taggedDate = '2015-03-27T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $eventWasTagged->getItemId(),
+            2,
+            new Metadata(['user_nick' => 'Jan Janssen']),
+            $eventWasTagged,
+            DateTime::fromString($taggedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'Jan Janssen',
+                    'description' => "Label 'foo' toegepast",
+                ],
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_tagErased()
+    {
+        $tagErased = new LabelRemoved(
+            self::EVENT_ID_1,
+            new Label('foo')
+        );
+
+        $tagErasedDate = '2015-03-27T10:17:19.176169+02:00';
+
+        $domainMessage = new DomainMessage(
+            $tagErased->getItemId(),
+            2,
+            new Metadata(['user_nick' => 'Jan Janssen']),
+            $tagErased,
+            DateTime::fromString($tagErasedDate)
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryOfEvent(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'Jan Janssen',
+                    'description' => "Label 'foo' verwijderd",
+                ],
+                (object) [
+                    'date' => '2015-03-04T10:17:19+02:00',
+                    'description' => 'Geïmporteerd vanuit UDB2',
+                ],
+                (object) [
+                    'date' => '2014-04-28T11:30:28+02:00',
+                    'description' => 'Aangemaakt in UDB2',
+                    'author' => 'kris.classen@overpelt.be',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @param string $eventId
+     * @param array $history
+     */
+    protected function assertHistoryOfEvent($eventId, $history)
+    {
+        /** @var JsonDocument $document */
+        $document = $this->documentRepository->get($eventId);
+
+        $this->assertEquals(
+            $history,
+            $document->getBody()
+        );
+    }
+
+    /**
+     * @param string $userNick
+     * @param string $consumerName
+     * @return Metadata
+     */
+    protected function entryApiMetadata($userNick, $consumerName)
+    {
+        $values = [
+            'user_nick' => $userNick,
+            'consumer' => [
+                'name' => $consumerName,
+            ],
+        ];
+
+        return new Metadata($values);
+    }
+}

--- a/tests/Event/ReadModel/History/event-a0ee7b1c-a9c1-4da1-af7e-d15496014656.xml
+++ b/tests/Event/ReadModel/History/event-a0ee7b1c-a9c1-4da1-af7e-d15496014656.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-04-28T00:00:00" availableto="2015-03-05T00:00:00" cdbid="a0ee7b1c-a9c1-4da1-af7e-d15496014656" createdby="kris.classen@overpelt.be" creationdate="2014-04-28T11:30:28" externalid="CDB:3ac166a8-dba8-4290-80b1-36768fd173f1" isparent="false" lastupdated="2014-04-28T11:31:56" lastupdatedby="kris.classen@overpelt.be" pctcomplete="80" published="true" owner="Invoerders Algemeen " private="false" validator="Overpelt Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:agefrom>10</cdb:agefrom>
+    <cdb:calendar>
+        <cdb:timestamps>
+            <cdb:timestamp>
+                <cdb:date>2015-03-04</cdb:date>
+                <cdb:timestart>16:00:00</cdb:timestart>
+            </cdb:timestamp>
+        </cdb:timestamps>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal</cdb:category>
+        <cdb:category catid="1.7.14.0.0" type="theme">Meerdere filmgenres</cdb:category>
+        <cdb:category catid="2.2.7.0.0" type="targetaudience">Kinderen vanaf 9 jaar (9+)</cdb:category>
+        <cdb:category catid="reg.362" type="flanderstouristregion">Limburgse Kempen</cdb:category>
+        <cdb:category catid="0.50.6.0.0" type="eventtype">Film</cdb:category>
+        <cdb:category catid="reg.971" type="flandersregion">3900 Overpelt</cdb:category>
+        <cdb:category catid="umv.7" type="umv">Film</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Overpelt</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>5.427836</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.211713</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>2</cdb:housenr>
+                <cdb:street>Jeugdlaan</cdb:street>
+                <cdb:zipcode>3900</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:url>http://www.palethe.be</cdb:url>
+    </cdb:contactinfo>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>woe 04/03/15 om 16:00</cdb:calendarsummary>
+            <cdb:longdescription>
+                In de Cine Pelt-filmvoorstellingen voorzien we ook enkele films voor jonge tieners vanaf 10 jaar.<br /><br />We leggen binnenkort nog vast welke leuke film we gaan tonen. Hou hiervoor zeker www.palethe.be in de gaten!<p class="uiv-source">Bron: <a href="http://www.uitinvlaanderen.be/agenda/e/cine-pelt-4-teens/a0ee7b1c-a9c1-4da1-af7e-d15496014656">UiTinVlaanderen.be</a></p>
+            </cdb:longdescription>
+            <cdb:media>
+                <cdb:file>
+                    <cdb:hlink>http://www.palethe.be</cdb:hlink>
+                    <cdb:mediatype>webresource</cdb:mediatype>
+                </cdb:file>
+                <cdb:file creationdate="28/04/2014 11:31:09" main="true">
+                    <cdb:copyright>Cine Pelt 4 Teens</cdb:copyright>
+                    <cdb:filename>59165647-4617-43d1-ad4f-592101fe1cd0.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>
+                        //media.uitdatabank.be/20140428/59165647-4617-43d1-ad4f-592101fe1cd0.jpg
+                    </cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:price>
+                <cdb:pricevalue>3.0</cdb:pricevalue>
+                <cdb:pricedescription>
+                    Vergeet ook je filmpas niet te vragen: elk zesde ticket is gratis. Bij filmvoorstellingen in CC Palethe kan je ook betalen met Knipoogbonnen.
+                </cdb:pricedescription>
+            </cdb:price>
+            <cdb:shortdescription>
+                In de Cine Pelt-filmvoorstellingen voorzien we ook enkele films voor jonge tieners vanaf 10 jaar. We leggen binnenkort nog vast welke leuke film we gaan tonen. Hou hiervoor zeker www.palethe.be in de gaten!
+            </cdb:shortdescription>
+            <cdb:title>Cine Pelt 4 Teens</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Overpelt</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>5.427836</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.211713</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>2</cdb:housenr>
+                <cdb:street>Jeugdlaan</cdb:street>
+                <cdb:zipcode>3900</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label cdbid="318F2ACB-F612-6F75-0037C9C29F44087A">CC Palethe</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label cdbid="318F2ACB-F612-6F75-0037C9C29F44087A">CC Palethe</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/ReadModel/History/event-a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3.xml
+++ b/tests/Event/ReadModel/History/event-a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL" availablefrom="2014-09-08T00:00:00" availableto="2014-11-10T00:00:00" cdbid="a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3" createdby="info@traeghe.be" creationdate="2014-09-08T09:10:16" externalid="CDB:90147070-0af7-4b27-add0-e7d3c0f3bbc7" isparent="false" lastupdated="2014-09-08T09:11:59" lastupdatedby="info@traeghe.be" pctcomplete="95" published="true" owner="Invoerders Algemeen " private="false" validator="Brugge Validatoren" wfstatus="readyforvalidation">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:calendar>
+        <cdb:periods>
+            <cdb:period>
+                <cdb:datefrom>2014-11-01</cdb:datefrom>
+                <cdb:dateto>2014-11-09</cdb:dateto>
+                <cdb:weekscheme>
+                    <cdb:monday opentype="closed"/>
+                    <cdb:tuesday opentype="closed"/>
+                    <cdb:wednesday opentype="closed"/>
+                    <cdb:thursday opentype="open">
+                        <cdb:openingtime from="13:30:00" to="18:00:00"/>
+                    </cdb:thursday>
+                    <cdb:friday opentype="open">
+                        <cdb:openingtime from="13:30:00" to="18:00:00"/>
+                    </cdb:friday>
+                    <cdb:saturday opentype="open">
+                        <cdb:openingtime from="13:30:00" to="18:00:00"/>
+                    </cdb:saturday>
+                    <cdb:sunday opentype="open">
+                        <cdb:openingtime from="13:30:00" to="18:00:00"/>
+                    </cdb:sunday>
+                </cdb:weekscheme>
+            </cdb:period>
+        </cdb:periods>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="1.0.4.0.0" type="theme">Grafiek</cdb:category>
+        <cdb:category catid="reg.363" type="flanderstouristregion">Kunststad Brugge</cdb:category>
+        <cdb:category catid="0.0.0.0.0" type="eventtype">Tentoonstelling</cdb:category>
+        <cdb:category catid="reg.999" type="flandersregion">8000 Brugge</cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Brugge</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.223553</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.204641</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>38</cdb:housenr>
+                <cdb:street>Mariastraat</cdb:street>
+                <cdb:zipcode>8000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:url>http://www.traeghe.be</cdb:url>
+    </cdb:contactinfo>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>
+                van 01/11/14 tot 09/11/14 zo, do, vrij, za van 13:30 tot 18:00 (ma, di, woe gesloten)
+            </cdb:calendarsummary>
+            <cdb:performers>
+                <cdb:performer>
+                    <cdb:role>kunstenares</cdb:role>
+                    <cdb:label>Janine de Coninck</cdb:label>
+                </cdb:performer>
+            </cdb:performers>
+            <cdb:longdescription>
+                Dirk Vanderveken en Galerij TRAEGHE GENUINE ARTS brengen de tentoonstelling door de Brugse kunstenares <br />JANINE DE CONINCK ‘licht en schaduw’<br />zaterdag 1 November tot en met 9 November 2014.<br /><p class="uiv-source">Bron: <a href="http://www.uitinvlaanderen.be/agenda/e/gallery-traeghe-exhibition-janine-de-coninck-black/a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3">UiTinVlaanderen.be</a></p>
+            </cdb:longdescription>
+            <cdb:media>
+                <cdb:file>
+                    <cdb:hlink>http://www.traeghe.be</cdb:hlink>
+                    <cdb:mediatype>webresource</cdb:mediatype>
+                </cdb:file>
+                <cdb:file creationdate="8/09/2014 9:13:37" main="true">
+                    <cdb:copyright>
+                        GALLERY TRAEGHE exhibition Janine de Conink 'BLACK AND WHITE' 1 - 9 November 2014
+                    </cdb:copyright>
+                    <cdb:filename>de94b1ec-e77c-495e-980d-2ccd183d1daa.png</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>
+                        //media.uitdatabank.be/20140908/de94b1ec-e77c-495e-980d-2ccd183d1daa.png
+                    </cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:price>
+                <cdb:pricevalue>0.0</cdb:pricevalue>
+            </cdb:price>
+            <cdb:shortdescription>
+                Dirk Vanderveken en Galerij TRAEGHE GENUINE ARTS brengen de tentoonstelling door de Brugse kunstenares JANINE DE CONINCK '‘licht en schaduw’van Zaterdag1 November tot en met 9 November 2014.
+            </cdb:shortdescription>
+            <cdb:title>
+                GALLERY TRAEGHE exhibition Janine de Coninck 'BLACK AND WHITE' 1 - 9 November 2014
+            </cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:keywords>
+        kunst;tentoonstelling;brugge;grafiek;oud sint jan;TRAEGHE GENUINE ARTS;janine de conink;brugge oktober
+    </cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Brugge</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>3.223553</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.204641</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>38</cdb:housenr>
+                <cdb:street>Mariastraat</cdb:street>
+                <cdb:zipcode>8000</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>TRAEGHE GENUINE ARTS - oud sint Jan Brugge</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>TRAEGHE GEN</cdb:label>
+    </cdb:organiser>
+</cdb:event>


### PR DESCRIPTION
### Added

- Added the history projectors from udb3-php

---
Ticket: https://jira.uitdatabank.be/browse/III-3141

---

Note: I had to remove the tests for `OfferHistoryProjector` because they relied on classes that are only found in the `tests` directory of `udb3-php`. However, the exact same functionality was also being tested in `HistoryProjector`, so we still have the same coverage.
