### PR TITLE
Add consumer name to history projection

### DIFF
--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -48,7 +48,8 @@ class HistoryProjector extends OfferHistoryProjector implements EventListenerInt
                 new StringLiteral('Geïmporteerd vanuit UDB2'),
                 null,
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -64,7 +65,8 @@ class HistoryProjector extends OfferHistoryProjector implements EventListenerInt
                 new StringLiteral('Geüpdatet vanuit UDB2'),
                 null,
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -86,7 +88,8 @@ class HistoryProjector extends OfferHistoryProjector implements EventListenerInt
                 new StringLiteral('Aangemaakt in UiTdatabank'),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -108,7 +111,8 @@ class HistoryProjector extends OfferHistoryProjector implements EventListenerInt
                 new StringLiteral('Event gekopieerd van ' . $eventCopied->getOriginalEventId()),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }

--- a/src/Event/ReadModel/History/Log.php
+++ b/src/Event/ReadModel/History/Log.php
@@ -33,18 +33,25 @@ class Log implements JsonSerializable
      */
     private $api;
 
+    /**
+     * @var string
+     */
+    private $consumerName;
+
     public function __construct(
         DateTime $date,
         StringLiteral $description,
         StringLiteral $author = null,
         string $apiKey = null,
-        string $api = null
+        string $api = null,
+        string $consumerName = null
     ) {
         $this->date = clone $date;
         $this->description = $description;
         $this->author = $author;
         $this->apiKey = $apiKey;
         $this->api = $api;
+        $this->consumerName = $consumerName;
     }
 
     /**
@@ -67,6 +74,10 @@ class Log implements JsonSerializable
 
         if ($this->api) {
             $log['api'] = $this->api;
+        }
+
+        if ($this->consumerName) {
+            $log['consumerName'] = $this->consumerName;
         }
 
         return $log;

--- a/src/Offer/ReadModel/History/OfferHistoryProjector.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjector.php
@@ -109,7 +109,8 @@ abstract class OfferHistoryProjector
                 new StringLiteral("Label '{$labelAdded->getLabel()}' toegepast"),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -129,7 +130,8 @@ abstract class OfferHistoryProjector
                 new StringLiteral("Label '{$labelRemoved->getLabel()}' verwijderd"),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -145,7 +147,8 @@ abstract class OfferHistoryProjector
                 new StringLiteral("Titel vertaald ({$titleTranslated->getLanguage()})"),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }
@@ -161,7 +164,8 @@ abstract class OfferHistoryProjector
                 new StringLiteral("Beschrijving vertaald ({$descriptionTranslated->getLanguage()})"),
                 $this->getAuthorFromMetadata($domainMessage->getMetadata()),
                 $this->getApiKeyFromMetadata($domainMessage->getMetadata()),
-                $this->getApiFromMetadata($domainMessage->getMetadata())
+                $this->getApiFromMetadata($domainMessage->getMetadata()),
+                $this->getConsumerFromMetadata($domainMessage->getMetadata())
             )
         );
     }

--- a/src/Offer/ReadModel/History/OfferHistoryProjector.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjector.php
@@ -192,30 +192,26 @@ abstract class OfferHistoryProjector
         );
     }
 
-    /**
-     * @param Metadata $metadata
-     * @return String|null
-     */
-    protected function getAuthorFromMetadata(Metadata $metadata)
+    protected function getAuthorFromMetadata(Metadata $metadata): ?StringLiteral
     {
         $properties = $metadata->serialize();
 
         if (isset($properties['user_nick'])) {
             return new StringLiteral($properties['user_nick']);
         }
+
+        return null;
     }
 
-    /**
-     * @param Metadata $metadata
-     * @return String|null
-     */
-    protected function getConsumerFromMetadata(Metadata $metadata)
+    protected function getConsumerFromMetadata(Metadata $metadata): ?StringLiteral
     {
         $properties = $metadata->serialize();
 
         if (isset($properties['consumer']['name'])) {
             return new StringLiteral($properties['consumer']['name']);
         }
+
+        return null;
     }
 
     /**

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -204,6 +204,9 @@ class HistoryProjectorTest extends TestCase
                     'user_nick' => 'Jan Janssen',
                     'auth_api_key' => 'my-super-duper-key',
                     'api' => 'json-api',
+                    'consumer' => [
+                        'name' => 'My super duper name',
+                    ]
                 ]
             ),
             $eventCreated,
@@ -221,6 +224,7 @@ class HistoryProjectorTest extends TestCase
                     'description' => 'Aangemaakt in UiTdatabank',
                     'apiKey' => 'my-super-duper-key',
                     'api' => 'json-api',
+                    'consumerName' => 'My super duper name',
                 ],
             ]
         );


### PR DESCRIPTION
### Added

- If the event metadata contains a consumer name, it is now projected in the history projection

---
Ticket: https://jira.uitdatabank.be/browse/III-3141
