### PR TITLE
III-3148 Geocode organizer address updates from cdbxml

### DIFF
--- a/src/Organizer/ProcessManager/GeoCoordinatesProcessManager.php
+++ b/src/Organizer/ProcessManager/GeoCoordinatesProcessManager.php
@@ -5,8 +5,17 @@ namespace CultuurNet\UDB3\Organizer\ProcessManager;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListenerInterface;
 use Broadway\CommandHandling\CommandBusInterface;
+use CultureFeed_Cdb_Data_Address;
+use CultuurNet\UDB3\Actor\ActorImportedFromUDB2;
+use CultuurNet\UDB3\Address\CultureFeedAddressFactoryInterface;
+use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Organizer\Commands\UpdateGeoCoordinatesFromAddress;
+use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
+use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 
 class GeoCoordinatesProcessManager implements EventListenerInterface
 {
@@ -15,21 +24,45 @@ class GeoCoordinatesProcessManager implements EventListenerInterface
      */
     private $commandBus;
 
-    public function __construct(CommandBusInterface $commandBus)
-    {
+    /**
+     * @var CultureFeedAddressFactoryInterface
+     */
+    private $addressFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param CommandBusInterface $commandBus
+     * @param CultureFeedAddressFactoryInterface $addressFactory
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        CommandBusInterface $commandBus,
+        CultureFeedAddressFactoryInterface $addressFactory,
+        LoggerInterface $logger
+    ) {
         $this->commandBus = $commandBus;
+        $this->addressFactory = $addressFactory;
+        $this->logger = $logger;
     }
 
-    public function handle(DomainMessage $domainMessage)
+    public function handle(DomainMessage $domainMessage): void
     {
         $event = $domainMessage->getPayload();
 
-        if ($event instanceof AddressUpdated) {
-            $this->dispatchUpdateGeoCoordinatesCommand($event);
+        if ($event instanceof AddressUpdated && !$event instanceof AddressTranslated) {
+            $this->handleAddressUpdated($event);
+        }
+
+        if ($event instanceof OrganizerImportedFromUDB2 || $event instanceof OrganizerUpdatedFromUDB2) {
+            $this->handleOrganizerFromUDB2($event);
         }
     }
 
-    public function dispatchUpdateGeoCoordinatesCommand(AddressUpdated $event): void
+    public function handleAddressUpdated(AddressUpdated $event): void
     {
         $this->commandBus->dispatch(
             new UpdateGeoCoordinatesFromAddress(
@@ -37,5 +70,65 @@ class GeoCoordinatesProcessManager implements EventListenerInterface
                 $event->getAddress()
             )
         );
+    }
+
+    public function handleOrganizerFromUDB2(ActorImportedFromUDB2 $actorImportedFromUDB2): void
+    {
+        $actor = ActorItemFactory::createActorFromCdbXml(
+            $actorImportedFromUDB2->getCdbXmlNamespaceUri(),
+            $actorImportedFromUDB2->getCdbXml()
+        );
+
+        $contactInfo = $actor->getContactInfo();
+
+        // Do nothing if no contact info is found.
+        if (!$contactInfo) {
+            return;
+        }
+
+        // Get all physical locations from the list of addresses.
+        $addresses = array_map(
+            function (CultureFeed_Cdb_Data_Address $address) {
+                return $address->getPhysicalAddress();
+            },
+            $contactInfo->getAddresses()
+        );
+
+        // Filter out addresses without physical location.
+        $addresses = array_filter($addresses);
+
+        // Do nothing if no address is found.
+        if (empty($addresses)) {
+            return;
+        }
+
+        /* @var \CultureFeed_Cdb_Data_Address_PhysicalAddress $cdbAddress */
+        $cdbAddress = $addresses[0];
+
+        try {
+            // Convert the cdbxml address to a udb3 address.
+            $address = $this->addressFactory->fromCdbAddress($cdbAddress);
+        } catch (InvalidArgumentException $e) {
+            // If conversion failed, log an error and do nothing.
+            $this->logger->error(
+                'Could not convert a cdbxml address to a udb3 address for geocoding.',
+                [
+                    'organizerId' => $actorImportedFromUDB2->getActorId(),
+                    'error' => $e->getMessage(),
+                ]
+            );
+            return;
+        }
+
+        // We don't know if the address has actually been updated because
+        // ActorImportedFromUDB2 is too coarse, but if we use the cached
+        // geocoding service we won't be wasting much resources when using
+        // a naive approach like this.
+        $command = new UpdateGeoCoordinatesFromAddress(
+            $actorImportedFromUDB2->getActorId(),
+            $address
+        );
+
+        $this->commandBus->dispatch($command);
     }
 }

--- a/tests/Organizer/ProcessManager/GeoCoordinatesProcessManagerTest.php
+++ b/tests/Organizer/ProcessManager/GeoCoordinatesProcessManagerTest.php
@@ -6,14 +6,21 @@ use Broadway\CommandHandling\CommandBusInterface;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Address\Address;
+use CultuurNet\UDB3\Address\CultureFeedAddressFactory;
+use CultuurNet\UDB3\Address\CultureFeedAddressFactoryInterface;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
-use CultuurNet\UDB3\Event\GeoCoordinatesProcessManager as GeoCoordinatesProcessManagerAlias;
+use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Organizer\Commands\UpdateGeoCoordinatesFromAddress;
+use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
+use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ValueObjects\Geography\Country;
 
 class GeoCoordinatesProcessManagerTest extends TestCase
@@ -24,60 +31,304 @@ class GeoCoordinatesProcessManagerTest extends TestCase
     private $commandBus;
 
     /**
-     * @var GeoCoordinatesProcessManagerAlias
+     * @var CultureFeedAddressFactoryInterface
+     */
+    private $addressFactory;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * @var GeoCoordinatesProcessManager
      */
     private $processManager;
 
     public function setUp()
     {
         $this->commandBus = $this->createMock(CommandBusInterface::class);
-        $this->processManager = new GeoCoordinatesProcessManager($this->commandBus);
+        $this->addressFactory = new CultureFeedAddressFactory();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->processManager = new GeoCoordinatesProcessManager(
+            $this->commandBus,
+            $this->addressFactory,
+            $this->logger
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider addressEventDataProvider
+     *
+     * @param DomainMessage $event
+     * @param UpdateGeoCoordinatesFromAddress $expectedCommand
+     */
+    public function it_dispatches_a_geocoding_command_when_an_address_change_is_suspected(
+        DomainMessage $event,
+        UpdateGeoCoordinatesFromAddress $expectedCommand
+    ): void {
+        $this->commandBus->expects($this->once())
+            ->method('dispatch')
+            ->with($expectedCommand);
+
+        $this->processManager->handle($event);
+    }
+
+    /**
+     * @test
+     * @dataProvider missingAddressEventDataProvider
+     *
+     * @param DomainMessage $event
+     */
+    public function it_does_not_dispatch_a_geocoding_command_when_a_cdbxml_import_or_update_is_missing_an_address(
+        DomainMessage $event
+    ): void {
+        $this->commandBus->expects($this->never())
+            ->method('dispatch');
+
+        $this->processManager->handle($event);
     }
 
     /**
      * @test
      */
-    public function it_dispatches_update_command_for_address_updated_event(): void
+    public function it_should_not_dispatch_a_geocoding_command_when_an_address_is_translated(): void
     {
-        $address = $this->anAddress();
-        $organizerId = $this->anUuid();
-
-        $addressUpdatedEvent = new AddressUpdated(
-            $organizerId,
-            $address
+        $event = DomainMessage::recordNow(
+            '4b735422-2bf3-4241-aabb-d70609d2d1d3',
+            1,
+            new Metadata([]),
+            new AddressTranslated(
+                '4b735422-2bf3-4241-aabb-d70609d2d1d3',
+                new Address(
+                    new Street('Teststraat 1'),
+                    new PostalCode('1000'),
+                    new Locality('Bxl'),
+                    Country::fromNative('BE')
+                ),
+                new Language('fr')
+            )
         );
 
+        $this->commandBus->expects($this->never())
+            ->method('dispatch');
+
+        $this->processManager->handle($event);
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_an_error_and_dispatches_no_command_when_a_cdbxml_import_or_update_has_an_invalid_address()
+    {
         $domainMessage = DomainMessage::recordNow(
-            $this->anUuid(),
+            '318F2ACB-F612-6F75-0037C9C29F44087A',
             0,
-            new Metadata(),
-            $addressUpdatedEvent
+            new Metadata([]),
+            new OrganizerImportedFromUDB2(
+                '318F2ACB-F612-6F75-0037C9C29F44087A',
+                file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+            )
         );
 
-        $expectedCommand = new UpdateGeoCoordinatesFromAddress(
-            $organizerId,
-            $address
+        /** @var CultureFeedAddressFactory|MockObject $addressFactory */
+        $addressFactory = $this->createMock(CultureFeedAddressFactoryInterface::class);
+
+        $processManager = new GeoCoordinatesProcessManager(
+            $this->commandBus,
+            $addressFactory,
+            $this->logger
         );
 
-        $this->commandBus->expects($this->once())
-            ->method('dispatch')
-            ->with($expectedCommand);
+        $addressFactory->expects($this->once())
+            ->method('fromCdbAddress')
+            ->willThrowException(new InvalidArgumentException('The given cdbxml address is missing a city'));
 
-        $this->processManager->handle($domainMessage);
+        $this->commandBus->expects($this->never())
+            ->method('dispatch');
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'Could not convert a cdbxml address to a udb3 address for geocoding.',
+                [
+                    'organizerId' => '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    'error' => 'The given cdbxml address is missing a city',
+                ]
+            );
+
+        $processManager->handle($domainMessage);
     }
 
-    public function anUuid(): string
+    /**
+     * @return array
+     */
+    public function addressEventDataProvider()
     {
-        return 'e3604613-af01-4d2b-8cee-13ab61b89651';
+        return [
+            'organizer_address_updated' => [
+                DomainMessage::recordNow(
+                    '4b735422-2bf3-4241-aabb-d70609d2d1d3',
+                    1,
+                    new Metadata([]),
+                    new AddressUpdated(
+                        '4b735422-2bf3-4241-aabb-d70609d2d1d3',
+                        new Address(
+                            new Street('Teststraat 1'),
+                            new PostalCode('1000'),
+                            new Locality('Bxl'),
+                            Country::fromNative('BE')
+                        )
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '4b735422-2bf3-4241-aabb-d70609d2d1d3',
+                    new Address(
+                        new Street('Teststraat 1'),
+                        new PostalCode('1000'),
+                        new Locality('Bxl'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+            'organizer_imported_from_udb2_with_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    0,
+                    new Metadata([]),
+                    new OrganizerImportedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+            'organizer_updated_from_udb2_with_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    1,
+                    new Metadata([]),
+                    new OrganizerUpdatedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+        ];
     }
 
-    public function anAddress(): Address
+    /**
+     * @return array
+     */
+    public function missingAddressEventDataProvider()
     {
-        return new Address(
-            new Street('Martelarenplein 1'),
-            new PostalCode('3000'),
-            new Locality('Leuven'),
-            Country::fromNative('BE')
-        );
+        return [
+            'organizer_imported_from_udb2_without_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    0,
+                    new Metadata([]),
+                    new OrganizerImportedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+            'organizer_updated_from_udb2_without_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    1,
+                    new Metadata([]),
+                    new OrganizerUpdatedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor_without_contactinfo.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+            'organizer_imported_from_udb2_with_virtual_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    0,
+                    new Metadata([]),
+                    new OrganizerImportedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+            'organizer_updated_from_udb2_with_virtual_address' => [
+                DomainMessage::recordNow(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    1,
+                    new Metadata([]),
+                    new OrganizerUpdatedFromUDB2(
+                        '318F2ACB-F612-6F75-0037C9C29F44087A',
+                        file_get_contents(__DIR__ . '/../Samples/actor_without_physical_address.xml'),
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    )
+                ),
+                new UpdateGeoCoordinatesFromAddress(
+                    '318F2ACB-F612-6F75-0037C9C29F44087A',
+                    new Address(
+                        new Street('Jeugdlaan 2'),
+                        new PostalCode('3900'),
+                        new Locality('Overpelt'),
+                        Country::fromNative('BE')
+                    )
+                ),
+            ],
+        ];
     }
 }

--- a/tests/Organizer/Samples/actor.xml
+++ b/tests/Organizer/Samples/actor.xml
@@ -1,0 +1,63 @@
+<cdb:actor xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           asset="true" availablefrom="2013-07-18T09:04:07"
+           availableto="2100-01-01T00:00:00" createdby="cultuurnet001"
+           creationdate="2010-01-06T13:33:06"
+           cdbid="318F2ACB-F612-6F75-0037C9C29F44087A"
+           externalid="Cultuurnet:organisation_1565"
+           lastupdated="2013-07-18T09:04:37" lastupdatedby="lotte@cultuurnet.be"
+           owner="Invoerders Algemeen ">
+    <cdb:actordetails>
+        <cdb:actordetail lang="nl">
+            <cdb:calendarsummary>
+                Bij voorstellingen is de balie van CC Palethe één uur voor
+                aanvang geopend.
+            </cdb:calendarsummary>
+            <cdb:media>
+                <cdb:file creationdate="5/11/2014 13:26:54" main="true">
+                    <cdb:copyright>'Bekend met Gent' - quiz</cdb:copyright>
+                    <cdb:filename>ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>//media.uitdatabank.be/20141105/ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:shortdescription>Cultuurcentrum van de gemeente Overpelt.</cdb:shortdescription>
+            <cdb:title>CC Palethe</cdb:title>
+        </cdb:actordetail>
+    </cdb:actordetails>
+    <cdb:categories>
+        <cdb:category catid="8.15.0.0.0" type="actortype">Locatie</cdb:category>
+        <cdb:category catid="8.11.0.0.0" type="actortype">Organisator(en)
+        </cdb:category>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal
+        </cdb:category>
+        <cdb:category catid="8.6.0.0.0" type="actortype">Cultuur, gemeenschaps
+            of ontmoetingscentrum
+        </cdb:category>
+    </cdb:categories>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Overpelt</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>5.427752</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.211603</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>2</cdb:housenr>
+                <cdb:street>Jeugdlaan</cdb:street>
+                <cdb:zipcode>3900</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:mail reservation="true">reservaties@palethe.be</cdb:mail>
+        <cdb:phone reservation="true" type="phone">+32 11 645952</cdb:phone>
+        <cdb:phone type="fax">+32 11 644504</cdb:phone>
+        <cdb:url>
+            http://toevla.vlaanderen.be/publiek/nl/register/detail/19
+        </cdb:url>
+        <cdb:url main="true">http://www.palethe.be/</cdb:url>
+    </cdb:contactinfo>
+    <cdb:keywords>
+        Aanvaarden van SABAM-cultuurchèques;Toevlalocatie;toevlalocatie
+    </cdb:keywords>
+</cdb:actor>

--- a/tests/Organizer/Samples/actor_without_contactinfo.xml
+++ b/tests/Organizer/Samples/actor_without_contactinfo.xml
@@ -1,0 +1,41 @@
+<cdb:actor xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           asset="true" availablefrom="2013-07-18T09:04:07"
+           availableto="2100-01-01T00:00:00" createdby="cultuurnet001"
+           creationdate="2010-01-06T13:33:06"
+           cdbid="318F2ACB-F612-6F75-0037C9C29F44087A"
+           externalid="Cultuurnet:organisation_1565"
+           lastupdated="2013-07-18T09:04:37" lastupdatedby="lotte@cultuurnet.be"
+           owner="Invoerders Algemeen ">
+    <cdb:actordetails>
+        <cdb:actordetail lang="nl">
+            <cdb:calendarsummary>
+                Bij voorstellingen is de balie van CC Palethe één uur voor
+                aanvang geopend.
+            </cdb:calendarsummary>
+            <cdb:media>
+                <cdb:file creationdate="5/11/2014 13:26:54" main="true">
+                    <cdb:copyright>'Bekend met Gent' - quiz</cdb:copyright>
+                    <cdb:filename>ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>//media.uitdatabank.be/20141105/ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:shortdescription>Cultuurcentrum van de gemeente Overpelt.</cdb:shortdescription>
+            <cdb:title>CC Palethe</cdb:title>
+        </cdb:actordetail>
+    </cdb:actordetails>
+    <cdb:categories>
+        <cdb:category catid="8.15.0.0.0" type="actortype">Locatie</cdb:category>
+        <cdb:category catid="8.11.0.0.0" type="actortype">Organisator(en)
+        </cdb:category>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal
+        </cdb:category>
+        <cdb:category catid="8.6.0.0.0" type="actortype">Cultuur, gemeenschaps
+            of ontmoetingscentrum
+        </cdb:category>
+    </cdb:categories>
+    <cdb:keywords>
+        Aanvaarden van SABAM-cultuurchèques;Toevlalocatie;toevlalocatie
+    </cdb:keywords>
+</cdb:actor>

--- a/tests/Organizer/Samples/actor_without_physical_address.xml
+++ b/tests/Organizer/Samples/actor_without_physical_address.xml
@@ -1,0 +1,55 @@
+<cdb:actor xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           asset="true" availablefrom="2013-07-18T09:04:07"
+           availableto="2100-01-01T00:00:00" createdby="cultuurnet001"
+           creationdate="2010-01-06T13:33:06"
+           cdbid="318F2ACB-F612-6F75-0037C9C29F44087A"
+           externalid="Cultuurnet:organisation_1565"
+           lastupdated="2013-07-18T09:04:37" lastupdatedby="lotte@cultuurnet.be"
+           owner="Invoerders Algemeen ">
+    <cdb:actordetails>
+        <cdb:actordetail lang="nl">
+            <cdb:calendarsummary>
+                Bij voorstellingen is de balie van CC Palethe één uur voor
+                aanvang geopend.
+            </cdb:calendarsummary>
+            <cdb:media>
+                <cdb:file creationdate="5/11/2014 13:26:54" main="true">
+                    <cdb:copyright>'Bekend met Gent' - quiz</cdb:copyright>
+                    <cdb:filename>ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>//media.uitdatabank.be/20141105/ed466c72-451f-4079-94d3-4ab2e0be7b15.jpg</cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:shortdescription>Cultuurcentrum van de gemeente Overpelt.</cdb:shortdescription>
+            <cdb:title>CC Palethe</cdb:title>
+        </cdb:actordetail>
+    </cdb:actordetails>
+    <cdb:categories>
+        <cdb:category catid="8.15.0.0.0" type="actortype">Locatie</cdb:category>
+        <cdb:category catid="8.11.0.0.0" type="actortype">Organisator(en)
+        </cdb:category>
+        <cdb:category catid="6.2.0.0.0" type="publicscope">Regionaal
+        </cdb:category>
+        <cdb:category catid="8.6.0.0.0" type="actortype">Cultuur, gemeenschaps
+            of ontmoetingscentrum
+        </cdb:category>
+    </cdb:categories>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:virtual>
+                <cdb:title>In a galaxy far far away...</cdb:title>
+            </cdb:virtual>
+        </cdb:address>
+        <cdb:mail reservation="true">reservaties@palethe.be</cdb:mail>
+        <cdb:phone reservation="true" type="phone">+32 11 645952</cdb:phone>
+        <cdb:phone type="fax">+32 11 644504</cdb:phone>
+        <cdb:url>
+            http://toevla.vlaanderen.be/publiek/nl/register/detail/19
+        </cdb:url>
+        <cdb:url main="true">http://www.palethe.be/</cdb:url>
+    </cdb:contactinfo>
+    <cdb:keywords>
+        Aanvaarden van SABAM-cultuurchèques;Toevlalocatie;toevlalocatie
+    </cdb:keywords>
+</cdb:actor>


### PR DESCRIPTION
### Added

- Added geocoding for organizer updates from cdbxml. This implementation and the tests were copied and adjusted from the [Place GeoCoordinatesProcessManager in the cultuurnet/udb3 
package](https://github.com/cultuurnet/udb3-php/blob/master/src/Place/GeoCoordinatesProcessManager.php#L75-L137)

---
Ticket: https://jira.uitdatabank.be/browse/III-3148

Note that this is pointing to another feature branch which should be merged first ideally.
