### PR TITLE
III-3153 Add logger to search results generator

### DIFF
--- a/src/EventExport/EventExportService.php
+++ b/src/EventExport/EventExportService.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
 use Generator;
 use Guzzle\Http\Exception\ClientErrorResponseException;
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use ValueObjects\Web\EmailAddress;
@@ -89,6 +90,10 @@ class EventExportService implements EventExportServiceInterface
     ) {
         if (!$logger instanceof LoggerInterface) {
             $logger = new NullLogger();
+        }
+
+        if ($this->resultsGenerator instanceof LoggerAwareInterface) {
+            $this->resultsGenerator->setLogger($logger);
         }
 
         if (is_array($selection) && !empty($selection)) {


### PR DESCRIPTION
### Added

- Add a logger to the search results generator in the export service. This generator already has logging support but was not configured in this context (only in the mark as duplicate context)

---
Ticket: https://jira.uitdatabank.be/browse/III-3153
