### PR TITLE
Do not relocate events to canonical place on replays

### DIFF
--- a/app/Event/EventEditingServiceProvider.php
+++ b/app/Event/EventEditingServiceProvider.php
@@ -59,9 +59,11 @@ class EventEditingServiceProvider implements ServiceProviderInterface
 
         $app[RelocateEventToCanonicalPlace::class] = $app->share(
             function ($app) {
-                return new RelocateEventToCanonicalPlace(
-                    $app['event_command_bus'],
-                    new CanonicalPlaceRepository($app['place_repository'])
+                return new ReplayFilteringEventListener(
+                    new RelocateEventToCanonicalPlace(
+                        $app['event_command_bus'],
+                        new CanonicalPlaceRepository($app['place_repository'])
+                    )
                 );
             }
         );


### PR DESCRIPTION
### Fixed

- Don't relocate events to canonical places when replaying
