### PR TITLE
III-3245 Project organizer name as translatable property on udb2 imports/updates

### DIFF
--- a/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\LabelImporter;
+use stdClass;
 use ValueObjects\Geography\Country;
 
 /**
@@ -19,12 +20,12 @@ class CdbXMLImporter
     /**
      * Imports a UDB2 organizer actor into a UDB3 JSON-LD document.
      *
-     * @param \stdClass $base
+     * @param stdClass $base
      *   The JSON-LD document object to start from.
      * @param \CultureFeed_Cdb_Item_Actor $actor
      *   The actor data from UDB2 to import.
      *
-     * @return \stdClass
+     * @return stdClass
      *   A new JSON-LD document object with the UDB2 actor data merged in.
      */
     public function documentWithCdbXML(
@@ -38,6 +39,7 @@ class CdbXMLImporter
         /** @var \CultureFeed_Cdb_Data_Detail[] $details */
         $details = $actor->getDetails();
 
+        $jsonLD->name = new stdClass();
         foreach ($details as $languageDetail) {
             // The first language detail found will be used to retrieve
             // properties from which in UDB3 are not any longer considered
@@ -45,11 +47,11 @@ class CdbXMLImporter
             if (!$detail) {
                 $detail = $languageDetail;
             }
+
+            $jsonLD->name->{$detail->getLanguage()} = $detail->getTitle();
         }
 
-        $jsonLD->name = $detail->getTitle();
-
-        $jsonLD->address = new \stdClass();
+        $jsonLD->address = new stdClass();
         $cdbContact = $actor->getContactInfo();
         if ($cdbContact) {
             /** @var \CultureFeed_Cdb_Data_Address[] $addresses * */

--- a/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
@@ -39,7 +39,10 @@ class CdbXMLImporter
         /** @var \CultureFeed_Cdb_Data_Detail[] $details */
         $details = $actor->getDetails();
 
-        $jsonLD->name = new stdClass();
+        if (empty($jsonLD->name)) {
+            $jsonLD->name = new stdClass();
+        }
+
         foreach ($details as $languageDetail) {
             // The first language detail found will be used to retrieve
             // properties from which in UDB3 are not any longer considered

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -348,6 +348,54 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
+    public function it_should_set_name_when_importing_from_udb2()
+    {
+        $event = $this->organizerImportedFromUDB2('organizer_with_email.cdbxml.xml');
+        $domainMessage = $this->createDomainMessage($event);
+
+        $actualName = null;
+
+        $this->documentRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (JsonDocument $document) use (&$actualName) {
+                $actualName = $document->getBody()->name;
+                return true;
+            }));
+
+        $this->projector->handle($domainMessage);
+
+        $this->assertEquals((object) ['nl' => 'DE Studio'], $actualName);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_set_name_when_updating_from_udb2()
+    {
+        // First make sure there is an already created organizer.
+        $organizerId = 'someId';
+        $this->mockGet($organizerId, 'organizer_with_main_language.json');
+
+        $event = $this->organizerUpdatedFromUDB2('organizer_with_email.cdbxml.xml');
+        $domainMessage = $this->createDomainMessage($event);
+
+        $actualName = null;
+
+        $this->documentRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (JsonDocument $document) use (&$actualName) {
+                $actualName = $document->getBody()->name;
+                return true;
+            }));
+
+        $this->projector->handle($domainMessage);
+
+        $this->assertEquals((object) ['nl' => 'DE Studio'], $actualName);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_set_main_language_when_importing_from_udb2()
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_email.cdbxml.xml');


### PR DESCRIPTION
### Fixed

- Organizer names are now projected as translatable properties when imported or updated from UDB2. Previous translations that are not found in the CDBXML will be kept (same behaviour as events and places).

---
Ticket: https://jira.uitdatabank.be/browse/III-3245
