### PR TITLE
Bug: III-3243

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7272,8 +7272,8 @@
             "authors": [
                 {
                     "name": "Frank Kleine",
-                    "role": "Developer",
-                    "homepage": "http://frankkleine.de/"
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
                 }
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
@@ -7992,16 +7992,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.14",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2834789aeb9ac182ad69bfdf9ae91856a59945ff",
-                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
@@ -8061,8 +8061,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -8072,7 +8072,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-15T06:24:08+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "satooshi/php-coveralls",

--- a/src/User/Auth0UserIdentityResolver.php
+++ b/src/User/Auth0UserIdentityResolver.php
@@ -32,12 +32,12 @@ final class Auth0UserIdentityResolver implements UserIdentityResolverInterface
 
     public function getUserByEmail(EmailAddress $email): ?UserIdentityDetails
     {
-        return $this->fetchUser('email:"' . $email . '"');
+        return $this->fetchUser('email:"' . urlencode($email->toNative()) . '"');
     }
 
     public function getUserByNick(StringLiteral $nick): ?UserIdentityDetails
     {
-        return $this->fetchUser('email:"' . $nick . '" OR nickname:"' . $nick . '"');
+        return $this->fetchUser('email:"' . urlencode($nick->toNative()) . '" OR nickname:"' . urlencode($nick->toNative()) . '"');
     }
 
     /**

--- a/tests/User/Auth0UserIdentityResolverTest.php
+++ b/tests/User/Auth0UserIdentityResolverTest.php
@@ -87,7 +87,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"'.urlencode("ivo@hdz.com").'"'])
+            ->with(['q' => 'email:"ivo%40hdz.com"'])
             ->willReturn([$user]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
@@ -115,7 +115,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"'.urlencode("ivo@hdz.com").'"'])
+            ->with(['q' => 'email:"ivo%40hdz.com"'])
             ->willReturn([]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
@@ -144,7 +144,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"'.urlencode($name).'" OR nickname:"'.urlencode($name).'"'])
+                ->with(['q' => 'email:"Caca" OR nickname:"Caca"'])
             ->willReturn([$user]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);

--- a/tests/User/Auth0UserIdentityResolverTest.php
+++ b/tests/User/Auth0UserIdentityResolverTest.php
@@ -87,7 +87,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"ivo@hdz.com"'])
+            ->with(['q' => 'email:"'.urlencode("ivo@hdz.com").'"'])
             ->willReturn([$user]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
@@ -115,7 +115,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"ivo@hdz.com"'])
+            ->with(['q' => 'email:"'.urlencode("ivo@hdz.com").'"'])
             ->willReturn([]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);
@@ -144,7 +144,7 @@ class Auth0UserIdentityResolverTest extends TestCase
 
         $users->expects($this->atLeast(1))
             ->method('getAll')
-            ->with(['q' => 'email:"Caca" OR nickname:"Caca"'])
+            ->with(['q' => 'email:"'.urlencode($name).'" OR nickname:"'.urlencode($name).'"'])
             ->willReturn([$user]);
 
         $auth0UserIdentityResolver = new Auth0UserIdentityResolver($client);


### PR DESCRIPTION
### Fixed
- emails with `+` sing would not return correct result

### Added
- urlencode emails before sending them as queries to Auth0 SDK

---
Ticket:
[Jira](https://jira.uitdatabank.be/browse/III-3243)