### PR TITLE
Loosen up return type because the process manager is decorated with a…

### DIFF
--- a/app/Console/MarkPlaceAsDuplicateCommand.php
+++ b/app/Console/MarkPlaceAsDuplicateCommand.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UDB3\Silex\Console;
 
+use Broadway\EventHandling\EventListenerInterface;
 use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use CultuurNet\UDB3\Place\CannotMarkPlaceAsCanonical;
 use CultuurNet\UDB3\Place\CannotMarkPlaceAsDuplicate;
@@ -43,7 +44,7 @@ class MarkPlaceAsDuplicateCommand extends AbstractCommand
         }
     }
 
-    protected function getProcessManager(): LocationMarkedAsDuplicateProcessManager
+    protected function getProcessManager(): EventListenerInterface
     {
         $app = $this->getSilexApplication();
         return $app[LocationMarkedAsDuplicateProcessManager::class];


### PR DESCRIPTION
### Fixed
- After decorating a process manager with a replay filtering event listener in https://github.com/cultuurnet/udb3-silex/pull/427, we forgot to loosen the enforced return type in an internal method of the console command to mark places as duplicate. We now loosened to return type of that method to `EventListenerInterface`.

---
Ticket: https://jira.uitdatabank.be/browse/III-3252
