### PR TITLE
Add route to remove an event from an existing production

### DIFF
--- a/app/Event/ProductionControllerProvider.php
+++ b/app/Event/ProductionControllerProvider.php
@@ -2,6 +2,7 @@
 
 namespace CultuurNet\UDB3\Silex\Event;
 
+use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use CultuurNet\UDB3\Http\Productions\CreateProductionValidator;
 use CultuurNet\UDB3\Http\Productions\ProductionsWriteController;
 use Silex\Application;
@@ -25,5 +26,6 @@ class ProductionControllerProvider implements ControllerProviderInterface
         $controllers = $app['controllers_factory'];
         $controllers->post('/', ProductionsWriteController::class . ':create');
         $controllers->put('/{productionId}/events/{eventId}', ProductionsWriteController::class . ':addEventToProduction');
+        $controllers->delete('/{productionId}/events/{eventId}', RemoveEventFromProduction::class . ':removeEventFromProduction');
     }
 }

--- a/app/Event/ProductionControllerProvider.php
+++ b/app/Event/ProductionControllerProvider.php
@@ -26,6 +26,6 @@ class ProductionControllerProvider implements ControllerProviderInterface
         $controllers = $app['controllers_factory'];
         $controllers->post('/', ProductionsWriteController::class . ':create');
         $controllers->put('/{productionId}/events/{eventId}', ProductionsWriteController::class . ':addEventToProduction');
-        $controllers->delete('/{productionId}/events/{eventId}', RemoveEventFromProduction::class . ':removeEventFromProduction');
+        $controllers->delete('/{productionId}/events/{eventId}', ProductionsWriteController::class . ':removeEventFromProduction');
     }
 }

--- a/src/Http/Productions/ProductionsWriteController.php
+++ b/src/Http/Productions/ProductionsWriteController.php
@@ -57,7 +57,7 @@ class ProductionsWriteController
 
         $this->commandBus->dispatch($command);
 
-        return new Response('', 201);
+        return new Response('', 200);
     }
 
     public function removeEventFromProduction(
@@ -71,6 +71,6 @@ class ProductionsWriteController
 
         $this->commandBus->dispatch($command);
 
-        return new Response('', 201);
+        return new Response('', 200);
     }
 }

--- a/src/Http/Productions/ProductionsWriteController.php
+++ b/src/Http/Productions/ProductionsWriteController.php
@@ -6,6 +6,7 @@ use Broadway\CommandHandling\CommandBusInterface;
 use CultuurNet\UDB3\Event\Productions\AddEventToProduction;
 use CultuurNet\UDB3\Event\Productions\GroupEventsAsProduction;
 use CultuurNet\UDB3\Event\Productions\ProductionId;
+use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -50,6 +51,20 @@ class ProductionsWriteController
         string $eventId
     ): Response {
         $command = new AddEventToProduction(
+            $eventId,
+            ProductionId::fromNative($productionId)
+        );
+
+        $this->commandBus->dispatch($command);
+
+        return new Response('', 201);
+    }
+
+    public function removeEventFromProduction(
+        string $productionId,
+        string $eventId
+    ): Response {
+        $command = new RemoveEventFromProduction(
             $eventId,
             ProductionId::fromNative($productionId)
         );

--- a/tests/Http/Productions/ProductionsWriteControllerTest.php
+++ b/tests/Http/Productions/ProductionsWriteControllerTest.php
@@ -7,6 +7,7 @@ use CultuurNet\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Event\Productions\AddEventToProduction;
 use CultuurNet\UDB3\Event\Productions\GroupEventsAsProduction;
 use CultuurNet\UDB3\Event\Productions\ProductionId;
+use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Rhumsaa\Uuid\Uuid;
@@ -99,6 +100,22 @@ class ProductionsWriteControllerTest extends TestCase
             }
         );
         $this->controller->addEventToProduction($productionId->toNative(), $eventId);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_remove_an_event_from_an_existing_production(): void
+    {
+        $productionId = ProductionId::generate();
+        $eventId = Uuid::uuid4();
+        $this->commandBus->expects($this->once())->method('dispatch')->willReturnCallback(
+            function (RemoveEventFromProduction $command) use ($productionId, $eventId) {
+                $this->assertEquals($productionId, $command->getProductionId());
+                $this->assertEquals($eventId, $command->getEventId());
+            }
+        );
+        $this->controller->removeEventFromProduction($productionId->toNative(), $eventId);
     }
 
     private function buildRequestWithBody(array $body): Request


### PR DESCRIPTION
### Added
- Route to remove an event from an existing production: `DELETE /{productionId}/events/{eventId}`
