### PR TITLE
Enrich events with production

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -6,6 +6,8 @@ use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
+use CultuurNet\UDB3\Event\Productions\ProductionEnrichedEventRepository;
+use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ReadModel\JSONLD\CdbXMLImporter;
 use CultuurNet\UDB3\Event\ReadModel\JSONLD\EventFactory;
 use CultuurNet\UDB3\Event\ReadModel\JSONLD\EventJsonDocumentLanguageAnalyzer;
@@ -30,7 +32,11 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     $app['event_jsonld_cache']
                 );
 
-                $productionEnrichedEventRepository = new ProductionEnrichedEventRepository($cachedRepository);
+                $productionEnrichedEventRepository = new ProductionEnrichedEventRepository(
+                    $cachedRepository,
+                    $app[ProductionRepository::class],
+                    $app['event_iri_generator']
+                );
 
                 $broadcastingRepository = new BroadcastingDocumentRepositoryDecorator(
                     $productionEnrichedEventRepository,

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -30,8 +30,10 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     $app['event_jsonld_cache']
                 );
 
+                $productionEnrichedEventRepository = new ProductionEnrichedEventRepository($cachedRepository);
+
                 $broadcastingRepository = new BroadcastingDocumentRepositoryDecorator(
-                    $cachedRepository,
+                    $productionEnrichedEventRepository,
                     $app['event_bus'],
                     new EventFactory(
                         $app['event_iri_generator']

--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\Productions;
+
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryDecorator;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+
+class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
+{
+    /**
+     * @var ProductionRepository
+     */
+    private $productionRepository;
+
+    public function __construct(
+        DocumentRepositoryInterface $repository,
+        ProductionRepository $productionRepository
+    ) {
+        parent::__construct($repository);
+        $this->productionRepository = $productionRepository;
+    }
+
+    public function get($id)
+    {
+        $document = parent::get($id);
+
+        $jsonObject = $document->getBody();
+        $jsonObject->production = null;
+
+        try {
+            $production = $this->productionRepository->findProductionForEventId($id);
+        } catch (EntityNotFoundException $e) {
+            return $document->withBody($jsonObject);
+        }
+
+        return $document->withBody($jsonObject);
+    }
+
+}

--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -31,7 +31,7 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
 
             $jsonObject->production = (object) [
                 'id' => $production->getProductionId()->toNative(),
-                'title' => $production->getName()
+                'title' => $production->getName(),
             ];
 
             $jsonObject->production->otherEvents = array_values(array_filter(
@@ -40,12 +40,10 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
                     return $eventId != $id;
                 }
             ));
-
         } catch (EntityNotFoundException $e) {
             $jsonObject->production = null;
         }
 
         return $document->withBody($jsonObject);
     }
-
 }

--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -43,7 +43,7 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
             ];
 
             $otherEvents = [];
-            foreach($production->getEventIds() as $eventId) {
+            foreach ($production->getEventIds() as $eventId) {
                 if ($eventId !== $id) {
                     $otherEvents[] = $this->iriGenerator->iri($eventId);
                 }

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -122,4 +122,30 @@ class ProductionRepository extends AbstractDBALRepository
             $results
         );
     }
+
+    public function findProductionForEventId(string $eventId): Production
+    {
+        $results = $this->getConnection()->fetchAll(
+            'SELECT * FROM productions WHERE production_id = (SELECT production_id FROM productions WHERE event_id = :eventId)',
+            [
+                'eventId' => $eventId,
+            ]
+        );
+
+        if (!$results) {
+            throw new EntityNotFoundException('No production found for event with id ' . $eventId);
+        }
+
+        $production = new Production(
+            ProductionId::FromNative($results[0]['production_id']),
+            $results[0]['name'],
+            []
+        );
+
+        foreach ($results as $result) {
+            $production = $production->addEvent($result['event_id']);
+        }
+
+        return $production;
+    }
 }

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\Productions;
+
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rhumsaa\Uuid\Uuid;
+
+class ProductionEnrichedEventRepositoryTest extends TestCase
+{
+    /**
+     * @var ProductionEnrichedEventRepository
+     */
+    private $productionEnrichedEventRepository;
+
+    /**
+     * @var ProductionRepository | MockObject
+     */
+    private $productionRepository;
+
+    /**
+     * @var DocumentRepositoryInterface | MockObject
+     */
+    private $eventRepository;
+
+    protected function setUp(): void
+    {
+        $this->eventRepository = $this->createMock(DocumentRepositoryInterface::class);
+        $this->productionRepository = $this->createMock(ProductionRepository::class);
+
+        $this->productionEnrichedEventRepository = new ProductionEnrichedEventRepository(
+            $this->eventRepository,
+            $this->productionRepository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_null_production_when_the_event_does_not_belong_to_a_production(): void
+    {
+        $eventId = Uuid::uuid4()->toString();
+        $originalJsonDocument = new JsonDocument(
+            $eventId,
+            json_encode((object) ['@id' => $eventId])
+        );
+
+
+        $this->eventRepository->method('get')->willReturn($originalJsonDocument);
+        $this->productionRepository->method('findProductionForEventId')->willThrowException(
+            new EntityNotFoundException()
+        );
+
+        $actual = $this->productionEnrichedEventRepository->get($eventId);
+
+        $this->assertEquals($eventId, $actual->getBody()->{'@id'});
+        $this->assertNull($actual->getBody()->production);
+    }
+}

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +23,11 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
     private $productionRepository;
 
     /**
+     * @var IriGeneratorInterface | MockObject
+     */
+    private $iriGenerator;
+
+    /**
      * @var DocumentRepositoryInterface | MockObject
      */
     private $eventRepository;
@@ -30,10 +36,12 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
     {
         $this->eventRepository = $this->createMock(DocumentRepositoryInterface::class);
         $this->productionRepository = $this->createMock(ProductionRepository::class);
+        $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
 
         $this->productionEnrichedEventRepository = new ProductionEnrichedEventRepository(
             $this->eventRepository,
-            $this->productionRepository
+            $this->productionRepository,
+            $this->iriGenerator
         );
     }
 
@@ -85,12 +93,13 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
 
         $this->eventRepository->method('get')->willReturn($originalJsonDocument);
         $this->productionRepository->method('findProductionForEventId')->willReturn($production);
+        $this->iriGenerator->method('iri')->with($otherEventId)->willReturn('foo/' . $otherEventId);
 
         $actual = $this->productionEnrichedEventRepository->get($eventId);
 
         $this->assertEquals($eventId, $actual->getBody()->{'@id'});
         $this->assertEquals($productionId->toNative(), $actual->getBody()->production->id);
         $this->assertEquals($productionName, $actual->getBody()->production->title);
-        $this->assertEquals([$otherEventId], $actual->getBody()->production->otherEvents);
+        $this->assertEquals(['foo/' . $otherEventId], $actual->getBody()->production->otherEvents);
     }
 }

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -59,4 +59,38 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
         $this->assertEquals($eventId, $actual->getBody()->{'@id'});
         $this->assertNull($actual->getBody()->production);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_production_data_when_event_belongs_to_a_production(): void
+    {
+        $eventId = Uuid::uuid4()->toString();
+        $originalJsonDocument = new JsonDocument(
+            $eventId,
+            json_encode((object) ['@id' => $eventId])
+        );
+
+        $otherEventId = Uuid::uuid4()->toString();
+        $productionId = ProductionId::generate();
+        $productionName = 'The Teenage Mutant Ninja String Quartet in Concert - Heroes in a half Cello';
+        $production = new Production(
+            $productionId,
+            $productionName,
+            [
+                $eventId,
+                $otherEventId,
+            ]
+        );
+
+        $this->eventRepository->method('get')->willReturn($originalJsonDocument);
+        $this->productionRepository->method('findProductionForEventId')->willReturn($production);
+
+        $actual = $this->productionEnrichedEventRepository->get($eventId);
+
+        $this->assertEquals($eventId, $actual->getBody()->{'@id'});
+        $this->assertEquals($productionId->toNative(), $actual->getBody()->production->id);
+        $this->assertEquals($productionName, $actual->getBody()->production->title);
+        $this->assertEquals([$otherEventId], $actual->getBody()->production->otherEvents);
+    }
 }


### PR DESCRIPTION
### Changed
- Events now have an additional `production` property in JSONLD.

---
https://confluence.uitdatabank.be/pages/viewpage.action?pageId=26192041#Backend(UDB)-5/Propertyforstoringlinkedevents