### PR TITLE
Clean up and fix production command handling

### DIFF
--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -9,14 +9,14 @@ final class EventCannotBeAddedToProduction extends Exception
     public static function becauseItAlreadyBelongsToAnotherProduction(string $eventId, ProductionId $productionId)
     {
         return new self(
-            'Event with id ' . $eventId . ' cannot be added to production with id ' . $productionId->toNative()
+            'Event with id ' . $eventId . ' cannot be added to production with id ' . $productionId->toNative() . ' because it already belongs to another production.'
         );
     }
 
     public static function becauseTheyAlreadyBelongToAnotherProduction(array $eventIds, ProductionId $productionId)
     {
         return new self(
-            'Events with id ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative()
+            'Events with ids ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because they already belong to another production.'
         );
     }
 }

--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -9,7 +9,14 @@ final class EventCannotBeAddedToProduction extends Exception
     public static function becauseItAlreadyBelongsToAnotherProduction(string $eventId, ProductionId $productionId)
     {
         return new self(
-            'Event with id ' . $eventId . ' can not be added to production with id ' . $productionId->toNative()
+            'Event with id ' . $eventId . ' cannot be added to production with id ' . $productionId->toNative()
+        );
+    }
+
+    public static function becauseTheyAlreadyBelongToAnotherProduction(array $eventIds, ProductionId $productionId)
+    {
+        return new self(
+            'Events with id ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative()
         );
     }
 }

--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -13,10 +13,10 @@ final class EventCannotBeAddedToProduction extends Exception
         );
     }
 
-    public static function becauseTheyAlreadyBelongToAnotherProduction(array $eventIds, ProductionId $productionId)
+    public static function becauseSomeEventsBelongToAnotherProduction(array $eventIds, ProductionId $productionId)
     {
         return new self(
-            'Events with ids ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because they already belong to another production.'
+            'Events with ids ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because some events already belong to another production.'
         );
     }
 }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -31,8 +31,15 @@ class ProductionCommandHandler extends Udb3CommandHandler
             $command->getName(),
             $command->getEventIds()
         );
-        $this->productionRepository->add($production);
-        $this->eventsWereAddedToProduction($command->getEventIds()[0], $command->getProductionId());
+        try {
+            $this->productionRepository->add($production);
+            $this->eventsWereAddedToProduction($command->getEventIds()[0], $command->getProductionId());
+        } catch (DBALException $e) {
+            throw EventCannotBeAddedToProduction::becauseTheyAlreadyBelongToAnotherProduction(
+                $command->getEventIds(),
+                $command->getProductionId()
+            );
+        }
     }
 
     public function handleAddEventToProduction(AddEventToProduction $command): void

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -35,7 +35,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
             $this->productionRepository->add($production);
             $this->eventsWereAddedToProduction($command->getEventIds()[0], $command->getProductionId());
         } catch (DBALException $e) {
-            throw EventCannotBeAddedToProduction::becauseTheyAlreadyBelongToAnotherProduction(
+            throw EventCannotBeAddedToProduction::becauseSomeEventsBelongToAnotherProduction(
                 $command->getEventIds(),
                 $command->getProductionId()
             );

--- a/src/Event/Productions/RejectSuggestedEventPair.php
+++ b/src/Event/Productions/RejectSuggestedEventPair.php
@@ -5,18 +5,20 @@ namespace CultuurNet\UDB3\Event\Productions;
 final class RejectSuggestedEventPair
 {
     /**
-     * @var string
+     * @var SimilarEventPair
      */
-    private $eventIds;
+    private $eventPair;
 
-
-    public function __construct(array $eventIds)
+    public function __construct(SimilarEventPair $eventPair)
     {
-        $this->eventIds = $eventIds;
+        $this->eventPair = $eventPair;
     }
 
     public function getEventIds(): array
     {
-        return $this->eventIds;
+        return [
+            $this->eventPair->getEventOne(),
+            $this->eventPair->getEventTwo(),
+        ];
     }
 }

--- a/src/Event/Productions/SimilarEventPair.php
+++ b/src/Event/Productions/SimilarEventPair.php
@@ -29,14 +29,6 @@ class SimilarEventPair
         return new self($eventIds[0], $eventIds[1]);
     }
 
-    public function asArray(): array
-    {
-        return [
-            $this->eventOne,
-            $this->eventTwo,
-        ];
-    }
-
     public function getEventOne(): string
     {
         return $this->eventOne;

--- a/src/Http/Productions/ProductionsWriteController.php
+++ b/src/Http/Productions/ProductionsWriteController.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Event\Productions\MergeProductions;
 use CultuurNet\UDB3\Event\Productions\ProductionId;
 use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use CultuurNet\UDB3\Event\Productions\RejectSuggestedEventPair;
+use CultuurNet\UDB3\Event\Productions\SimilarEventPair;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -105,7 +106,7 @@ class ProductionsWriteController
 
         $this->commandBus->dispatch(
             new RejectSuggestedEventPair(
-                $data['eventIds']
+                SimilarEventPair::fromArray($data['eventIds'])
             )
         );
 

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -58,7 +58,37 @@ class ProductionCommandHandlerTest extends TestCase
         $this->assertEquals($command->getProductionId(), $createdProduction->getProductionId());
         $this->assertEquals($name, $createdProduction->getName());
         $this->assertEquals($events, $createdProduction->getEventIds());
+    }
 
+    /**
+     * @test
+     */
+    public function it_will_not_group_events_as_production_when_event_already_belongs_to_production(): void
+    {
+        $event = Uuid::uuid4()->toString();
+
+        $name = "A Midsummer Night's Scream";
+        $events = [
+            $event,
+            Uuid::uuid4()->toString(),
+        ];
+
+        $this->similaritiesClient->expects($this->once())->method('excludeTemporarily');
+
+        $command = GroupEventsAsProduction::withProductionName($events, $name);
+        $this->commandHandler->handle($command);
+
+
+        $this->expectException(EventCannotBeAddedToProduction::class);
+        $this->commandHandler->handle(
+            GroupEventsAsProduction::withProductionName(
+                [
+                    $event,
+                    Uuid::uuid4()->toString(),
+                ],
+                'Some other production'
+            )
+        );
     }
 
     /**

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -220,16 +220,16 @@ class ProductionCommandHandlerTest extends TestCase
      */
     public function it_can_mark_events_as_skipped()
     {
-        $events = [
+        $eventPair = SimilarEventPair::fromArray([
             Uuid::uuid4()->toString(),
             Uuid::uuid4()->toString(),
-        ];
+        ]);
 
         $this->similaritiesClient->expects(self::atLeastOnce())
             ->method('excludePermanently')
-            ->with(SimilarEventPair::fromArray($events));
+            ->with($eventPair);
 
-        $command = new RejectSuggestedEventPair($events);
+        $command = new RejectSuggestedEventPair($eventPair);
         $this->commandHandler->handle($command);
     }
 }


### PR DESCRIPTION
### Changed
- Renamed methods that deal with a side-effect to better clarify their reactive nature. We decided not to implement a full event+listener flow due to the lack of simple event bus in UDB3 that is not forcing the Broadway event structure.
- `RejectSuggestedEventPair` now uses the `SimilarEventPair` VO instead of relying on a potentially faulty array of strings.

### Removed
- Unused method

### Fixed
- Trying to create a new production with an event that already belongs to a production now throws the correct domain exception instead of a unique constraint error on database level.
