### PR TITLE
Fix issue with publication date in the past breaking ETL tools

### DIFF
--- a/src/Offer/Commands/Moderation/AbstractPublish.php
+++ b/src/Offer/Commands/Moderation/AbstractPublish.php
@@ -2,6 +2,8 @@
 
 namespace CultuurNet\UDB3\Offer\Commands\Moderation;
 
+use Cake\Chronos\Chronos;
+
 abstract class AbstractPublish extends AbstractModerationCommand
 {
     /** @var  \DateTimeInterface */
@@ -16,8 +18,10 @@ abstract class AbstractPublish extends AbstractModerationCommand
     {
         parent::__construct($itemId);
 
-        if (is_null($publicationDate)) {
-            $publicationDate = new \DateTime();
+        $now = Chronos::now();
+
+        if (is_null($publicationDate) || $publicationDate < $now) {
+            $publicationDate = $now;
         }
         $this->publicationDate = $publicationDate;
     }

--- a/tests/Http/Offer/PatchOfferRestControllerTest.php
+++ b/tests/Http/Offer/PatchOfferRestControllerTest.php
@@ -115,13 +115,13 @@ class PatchOfferRestControllerTest extends TestCase
                 'offerType' => OfferType::EVENT(),
                 'request' => $this->generatePatchRequest(
                     'application/ld+json;domain-model=Publish',
-                    json_encode(['publicationDate' => '2017-02-01T12:00:00+00:00'])
+                    json_encode(['publicationDate' => '2030-02-01T12:00:00+00:00'])
                 ),
                 'expectedCommand' => new Publish(
                     $this->itemId,
                     \DateTime::createFromFormat(
                         \DateTime::ISO8601,
-                        '2017-02-01T12:00:00+00:00'
+                        '2030-02-01T12:00:00+00:00'
                     )
                 )
             ],

--- a/tests/Offer/Commands/Moderation/AbstractPublishTest.php
+++ b/tests/Offer/Commands/Moderation/AbstractPublishTest.php
@@ -13,7 +13,10 @@ class AbstractPublishTest extends TestCase
      */
     public function it_can_store_a_future_publication_date(): void
     {
-        $futurePublicationDate = Chronos::now()->addWeek();
+        $futurePublicationDate = \DateTimeImmutable::createFromFormat(
+            DATE_ATOM,
+            Chronos::now()->addWeek()->format(DATE_ATOM)
+        );
 
         $publishCommand = $this->getMockForAbstractClass(
             AbstractPublish::class,

--- a/tests/Offer/Commands/Moderation/AbstractPublishTest.php
+++ b/tests/Offer/Commands/Moderation/AbstractPublishTest.php
@@ -3,9 +3,6 @@
 namespace CultuurNet\UDB3\Offer\Commands\Moderation;
 
 use Cake\Chronos\Chronos;
-use DateTime;
-use DateTimeInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 


### PR DESCRIPTION
### Fixed
- Publishing only allows a future publication date or it will default to now.

---
Ticket: https://jira.uitdatabank.be/browse/III-3362
