### PR TITLE
III-3403 Productions backend tweaks/fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Validate composer.json and composer.lock
+              run: composer validate
+
+            - name: Cache Composer packages
+              id: composer-cache
+              uses: actions/cache@v2
+              with:
+                  path: vendor
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-php-
+
+            - name: Install dependencies
+              if: steps.composer-cache.outputs.cache-hit != 'true'
+              run: composer install --no-progress --no-suggest
+
+        - name: Run Phing
+          run: composer run-script phing

--- a/app/Migrations/Version20200804090405.php
+++ b/app/Migrations/Version20200804090405.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20200804090405 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table =  $schema->getTable('productions');
+
+        // Increase the max-length of the name column from 32 to 255.
+        // "Lord of the Rings: The Fellowship of the Ring" is already 45 characters for example.
+        $table->changeColumn('name', [
+            'length' => 255,
+            'notnull' => true,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table =  $schema->getTable('productions');
+
+        $table->changeColumn('name', [
+            'length' => 32,
+            'notnull' => true,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "cultuurnet/culturefeed-php": "~1.9.2",
     "cultuurnet/deserializer": "~0.1",
     "cultuurnet/entry": "~0.1",
-    "cultuurnet/hydra": "~0.1",
     "cultuurnet/monolog-socketio": "~0.1",
     "cultuurnet/search-v3": "dev-master",
     "cultuurnet/silex-amqp": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -112,5 +112,8 @@
       "type": "vcs",
       "url": "https://github.com/cultuurnet/php-resque.git"
     }
-  ]
+  ],
+  "scripts": {
+    "phing": "./vendor/bin/phing test"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7ab93cfc0561237cdef6b8af678c520",
+    "content-hash": "af8812f35e6b32794a8f937eb888aae7",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1157,54 +1157,6 @@
                 }
             ],
             "time": "2018-06-29T14:21:16+00:00"
-        },
-        {
-            "name": "cultuurnet/hydra",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cultuurnet/Hydra.git",
-                "reference": "1309afe7583632ac12d3bd2ab567fcf1c7d21b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/Hydra/zipball/1309afe7583632ac12d3bd2ab567fcf1c7d21b62",
-                "reference": "1309afe7583632ac12d3bd2ab567fcf1c7d21b62",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phing/phing": "~2.11",
-                "phpunit/phpunit": "~5.7",
-                "satooshi/php-coveralls": "~0.7",
-                "squizlabs/php_codesniffer": "~2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "CultuurNet\\Hydra\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Kristof Coomans",
-                    "email": "kristof@2dotstwice.be"
-                },
-                {
-                    "name": "Bram Cordie",
-                    "email": "bram@2dotstwice.be"
-                }
-            ],
-            "description": "PHP library implementing concepts of http://www.hydra-cg.com/",
-            "time": "2018-06-29T14:26:23+00:00"
         },
         {
             "name": "cultuurnet/monolog-socketio",

--- a/src/Event/Productions/GroupEventsAsProduction.php
+++ b/src/Event/Productions/GroupEventsAsProduction.php
@@ -45,7 +45,7 @@ class GroupEventsAsProduction implements AuthorizableCommandInterface
 
     public function getPermission()
     {
-        Permission::PRODUCTIES_AANMAKEN();
+        return Permission::PRODUCTIES_AANMAKEN();
     }
 
     /**

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -6,6 +6,7 @@ use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use ValueObjects\StringLiteral\StringLiteral;
 
 class ProductionRepository extends AbstractDBALRepository
@@ -109,6 +110,11 @@ class ProductionRepository extends AbstractDBALRepository
                 'keyword' => $keyword,
                 'start' => $start,
                 'limit' => $limit,
+            ],
+            [
+                'keyword' => ParameterType::STRING,
+                'start' => ParameterType::INTEGER,
+                'limit' => ParameterType::INTEGER,
             ]
         )->fetchAll();
 
@@ -139,6 +145,9 @@ class ProductionRepository extends AbstractDBALRepository
             $sql,
             [
                 'keyword' => $keyword,
+            ],
+            [
+                'keyword' => ParameterType::STRING,
             ]
         )->fetchColumn(0);
     }

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -136,7 +136,7 @@ class ProductionRepository extends AbstractDBALRepository
 
     public function count(string $keyword): int
     {
-        $sql = 'SELECT COUNT(*)
+        $sql = 'SELECT production_id
                 FROM ' . $this->getTableName()->toNative() . ' 
                 WHERE MATCH (name) AGAINST (:keyword)
                 GROUP BY production_id';
@@ -149,7 +149,7 @@ class ProductionRepository extends AbstractDBALRepository
             [
                 'keyword' => ParameterType::STRING,
             ]
-        )->fetchColumn(0);
+        )->rowCount();
     }
 
     public function findProductionForEventId(string $eventId): Production

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -128,7 +128,8 @@ class ProductionRepository extends AbstractDBALRepository
         );
     }
 
-    public function count(string $keyword): int {
+    public function count(string $keyword): int
+    {
         $sql = 'SELECT COUNT(*)
                 FROM ' . $this->getTableName()->toNative() . ' 
                 WHERE MATCH (name) AGAINST (:keyword)

--- a/src/Http/Label/ReadRestController.php
+++ b/src/Http/Label/ReadRestController.php
@@ -3,7 +3,7 @@
 namespace CultuurNet\UDB3\Http\Label;
 
 use Crell\ApiProblem\ApiProblem;
-use CultuurNet\Hydra\PagedCollection;
+use CultuurNet\UDB3\Http\Response\PagedCollectionResponse;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Label\Services\ReadServiceInterface;
@@ -78,12 +78,11 @@ class ReadRestController
         if ($totalEntities) {
             $entities = $this->readService->search($query);
 
-            $pagedCollection = $this->createPagedCollection(
+            return $this->createPagedCollectionResponse(
                 $query,
                 $entities !== null ? $entities : [],
                 $totalEntities
             );
-            return new JsonResponse($pagedCollection);
         } else {
             $apiProblem = new ApiProblem('No label found for search query.');
             $apiProblem->setStatus(Response::HTTP_NOT_FOUND);
@@ -96,30 +95,23 @@ class ReadRestController
      * @param Query $query
      * @param Entity[] $entities
      * @param Natural $totalEntities
-     * @return PagedCollection
+     * @return PagedCollectionResponse
      */
-    private function createPagedCollection(
+    private function createPagedCollectionResponse(
         Query $query,
         array $entities,
         Natural $totalEntities
-    ) {
-        $pageNumber = 0;
+    ): PagedCollectionResponse {
         $limit = 0;
-
-        if ($query->getOffset() && $query->getLimit()) {
-            $pageNumber = (int) ($query->getOffset()->toNative() /
-                $query->getLimit()->toNative());
-        }
 
         if ($query->getLimit()) {
             $limit = $query->getLimit()->toNative();
         }
 
-        return new PagedCollection(
-            $pageNumber,
+        return new PagedCollectionResponse(
             $limit,
-            $entities,
-            $totalEntities->toNative()
+            $totalEntities->toNative(),
+            $entities
         );
     }
 }

--- a/src/Http/Productions/ProductionsSearchController.php
+++ b/src/Http/Productions/ProductionsSearchController.php
@@ -27,8 +27,8 @@ class ProductionsSearchController
     public function search(Request $request): Response
     {
         $keyword = $request->get('name', '');
-        $start = $request->get('start', self::DEFAULT_START);
-        $limit = $request->get('limit', self::DEFAULT_LIMIT);
+        $start = (int) $request->get('start', self::DEFAULT_START);
+        $limit = (int) $request->get('limit', self::DEFAULT_LIMIT);
         $pageNumber = (int) ($start / $limit);
 
         $count = $this->repository->count($keyword);

--- a/src/Http/Productions/ProductionsSearchController.php
+++ b/src/Http/Productions/ProductionsSearchController.php
@@ -26,7 +26,7 @@ class ProductionsSearchController
 
     public function search(Request $request): Response
     {
-        $keyword = $request->get('name');
+        $keyword = $request->get('name', '');
         $start = $request->get('start', self::DEFAULT_START);
         $limit = $request->get('limit', self::DEFAULT_LIMIT);
         $pageNumber = (int) ($start / $limit);

--- a/src/Http/Productions/ProductionsSearchController.php
+++ b/src/Http/Productions/ProductionsSearchController.php
@@ -29,7 +29,7 @@ class ProductionsSearchController
         $keyword = $request->get('name');
         $start = $request->get('start', self::DEFAULT_START);
         $limit = $request->get('limit', self::DEFAULT_LIMIT);
-        $pageNumber = (int) $start / $limit;
+        $pageNumber = (int) ($start / $limit);
 
         $count = $this->repository->count($keyword);
 

--- a/src/Http/Productions/ProductionsSearchController.php
+++ b/src/Http/Productions/ProductionsSearchController.php
@@ -2,10 +2,9 @@
 
 namespace CultuurNet\UDB3\Http\Productions;
 
-use CultuurNet\Hydra\PagedCollection;
 use CultuurNet\UDB3\Event\Productions\Production;
 use CultuurNet\UDB3\Event\Productions\ProductionRepository;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use CultuurNet\UDB3\Http\Response\PagedCollectionResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,18 +28,14 @@ class ProductionsSearchController
         $keyword = $request->get('name', '');
         $start = (int) $request->get('start', self::DEFAULT_START);
         $limit = (int) $request->get('limit', self::DEFAULT_LIMIT);
-        $pageNumber = (int) ($start / $limit);
 
         $count = $this->repository->count($keyword);
 
         if ($count === 0 || $start > $count) {
-            return new JsonResponse(
-                new PagedCollection(
-                    $pageNumber,
-                    $limit,
-                    [],
-                    $count
-                )
+            return new PagedCollectionResponse(
+                $limit,
+                $count,
+                []
             );
         }
 
@@ -51,13 +46,10 @@ class ProductionsSearchController
             $this->repository->search($keyword, $start, $limit)
         );
 
-        return new JsonResponse(
-            new PagedCollection(
-                $pageNumber,
-                $limit,
-                $serializedProductions,
-                $count
-            )
+        return new PagedCollectionResponse(
+            $limit,
+            $count,
+            $serializedProductions
         );
     }
 

--- a/src/Http/Response/PagedCollectionResponse.php
+++ b/src/Http/Response/PagedCollectionResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Response;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class PagedCollectionResponse extends JsonResponse
+{
+    public function __construct(
+        int $itemsPerPage,
+        int $totalItems,
+        array $members = [],
+        $status = 200,
+        $headers = []
+    ) {
+        $data = [
+            '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+            '@type' => 'PagedCollection',
+            'itemsPerPage' => $itemsPerPage,
+            'totalItems' => $totalItems,
+            'member' => $members,
+        ];
+        parent::__construct($data, $status, $headers);
+    }
+}

--- a/tests/Http/Label/ReadRestControllerTest.php
+++ b/tests/Http/Label/ReadRestControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\UDB3\Http\Label;
 
-use CultuurNet\Hydra\PagedCollection;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Label\Services\ReadServiceInterface;
@@ -140,17 +139,18 @@ class ReadRestControllerTest extends TestCase
     {
         $jsonResponse = $this->readRestController->search($this->request);
 
-        $expectedJsonResponse = new JsonResponse(new PagedCollection(
-            (int)(5/2),
-            2,
-            [
+        $expectedJson = [
+            '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+            '@type' => 'PagedCollection',
+            'itemsPerPage' => 2,
+            'totalItems' => 2,
+            'member' => [
                 $this->entityToArray($this->entity),
                 $this->entityToArray($this->entity)
             ],
-            2
-        ));
+        ];
 
-        $this->assertEquals($expectedJsonResponse, $jsonResponse);
+        $this->assertEquals($expectedJson, json_decode($jsonResponse->getContent(), true));
     }
 
     private function mockGetByUuid()

--- a/tests/Http/Productions/ProductionsSearchControllerTest.php
+++ b/tests/Http/Productions/ProductionsSearchControllerTest.php
@@ -31,7 +31,7 @@ class ProductionsSearchControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_an_empty_result_(): void
+    public function it_returns_an_empty_result_if_the_total_count_is_zero(): void
     {
         $this->repository->expects($this->once())->method('count')->with('foo')->willReturn(0);
         $this->repository->expects($this->never())->method('search');
@@ -43,6 +43,27 @@ class ProductionsSearchControllerTest extends TestCase
                 '@type' => 'PagedCollection',
                 'itemsPerPage' => 30,
                 'totalItems' => 0,
+                'member' => [],
+            ],
+            json_decode($response->getContent(), true)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_result_if_the_total_count_is_less_than_the_start(): void
+    {
+        $this->repository->expects($this->once())->method('count')->with('foo')->willReturn(100);
+        $this->repository->expects($this->never())->method('search');
+        $response = $this->controller->search(new Request(['name' => 'foo', 'start' => 101]));
+
+        $this->assertEquals(
+            [
+                '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+                '@type' => 'PagedCollection',
+                'itemsPerPage' => 30,
+                'totalItems' => 100,
                 'member' => [],
             ],
             json_decode($response->getContent(), true)

--- a/tests/Http/Productions/ProductionsSearchControllerTest.php
+++ b/tests/Http/Productions/ProductionsSearchControllerTest.php
@@ -33,10 +33,20 @@ class ProductionsSearchControllerTest extends TestCase
      */
     public function it_returns_an_empty_result_(): void
     {
-        $this->repository->expects($this->once())->method('search')->with('foo')->willReturn([]);
+        $this->repository->expects($this->once())->method('count')->with('foo')->willReturn(0);
+        $this->repository->expects($this->never())->method('search');
         $response = $this->controller->search(new Request(['name' => 'foo']));
 
-        $this->assertEquals([], json_decode($response->getContent(), true));
+        $this->assertEquals(
+            [
+                '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+                '@type' => 'PagedCollection',
+                'itemsPerPage' => 30,
+                'totalItems' => 0,
+                'member' => [],
+            ],
+            json_decode($response->getContent(), true)
+        );
     }
 
     /**
@@ -52,16 +62,23 @@ class ProductionsSearchControllerTest extends TestCase
         ];
 
         $productions = [new Production($productionId, $name, $events),];
-        $this->repository->expects($this->once())->method('search')->with('foo', 15)->willReturn($productions);
+        $this->repository->expects($this->once())->method('count')->with('foo')->willReturn(43);
+        $this->repository->expects($this->once())->method('search')->with('foo', 30, 15)->willReturn($productions);
 
-        $response = $this->controller->search(new Request(['name' => 'foo', 'limit' => 15]));
+        $response = $this->controller->search(new Request(['name' => 'foo', 'start' => 30, 'limit' => 15]));
 
         $this->assertEquals(
             [
-                [
-                    'production_id' => $productionId->toNative(),
-                    'name' => $name,
-                    'events' => $events,
+                '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+                '@type' => 'PagedCollection',
+                'itemsPerPage' => 15,
+                'totalItems' => 43,
+                'member' => [
+                    [
+                        'production_id' => $productionId->toNative(),
+                        'name' => $name,
+                        'events' => $events,
+                    ],
                 ],
             ],
             json_decode($response->getContent(), true)


### PR DESCRIPTION
### Added

- Added `start` parameter to productions search endpoint
- Added `limit` parameter to productions search endpoint

### Changed

- The response from the productions search endoint is now a paged collection object
- The `name` parameter is now optional, and when omitted the search endpoint will return all productions (paginated)
- Increased the length of `name` column from 32 to 255

### Fixed

- Added missing return type in `GroupEventsAsProduction`

---
Ticket: https://jira.uitdatabank.be/browse/III-3403
