### PR TITLE
Validate if event exists

### DIFF
--- a/app/Event/ProductionServiceProvider.php
+++ b/app/Event/ProductionServiceProvider.php
@@ -30,7 +30,11 @@ class ProductionServiceProvider implements ServiceProviderInterface
 
         $app[ProductionCommandHandler::class] = $app->share(
             function ($app) {
-                return new ProductionCommandHandler($app[ProductionRepository::class], $app[SimilaritiesClient::class]);
+                return new ProductionCommandHandler(
+                    $app[ProductionRepository::class],
+                    $app[SimilaritiesClient::class],
+                    $app{'event_jsonld_repository'}
+                );
             }
         );
     }

--- a/app/Event/ProductionServiceProvider.php
+++ b/app/Event/ProductionServiceProvider.php
@@ -33,7 +33,7 @@ class ProductionServiceProvider implements ServiceProviderInterface
                 return new ProductionCommandHandler(
                     $app[ProductionRepository::class],
                     $app[SimilaritiesClient::class],
-                    $app{'event_jsonld_repository'}
+                    $app['event_jsonld_repository']
                 );
             }
         );

--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -6,17 +6,24 @@ use Exception;
 
 final class EventCannotBeAddedToProduction extends Exception
 {
-    public static function becauseItAlreadyBelongsToAnotherProduction(string $eventId, ProductionId $productionId)
+    public static function becauseItAlreadyBelongsToAnotherProduction(string $eventId, ProductionId $productionId): self
     {
         return new self(
             'Event with id ' . $eventId . ' cannot be added to production with id ' . $productionId->toNative() . ' because it already belongs to another production.'
         );
     }
 
-    public static function becauseSomeEventsBelongToAnotherProduction(array $eventIds, ProductionId $productionId)
+    public static function becauseSomeEventsBelongToAnotherProduction(array $eventIds, ProductionId $productionId): self
     {
         return new self(
             'Events with ids ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because some events already belong to another production.'
+        );
+    }
+
+    public static function becauseItDoesNotExist(string $eventId): self
+    {
+        return new self(
+            'Event with id ' . $eventId . ' cannot be added to a production because the event does not exist.'
         );
     }
 }

--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -16,7 +16,7 @@ final class EventCannotBeAddedToProduction extends Exception
     public static function becauseSomeEventsBelongToAnotherProduction(array $eventIds, ProductionId $productionId): self
     {
         return new self(
-            'Events with ids ' . join(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because some events already belong to another production.'
+            'Events with ids ' . implode(',', $eventIds) . ' cannot be added to production with id ' . $productionId->toNative() . ' because some events already belong to another production.'
         );
     }
 

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -42,6 +42,11 @@ class ProductionCommandHandler extends Udb3CommandHandler
             $command->getName(),
             $command->getEventIds()
         );
+
+        foreach ($command->getEventIds() as $eventId) {
+            $this->assertEventExists($eventId);
+        }
+
         try {
             $this->productionRepository->add($production);
             $this->eventsWereAddedToProduction($command->getEventIds()[0], $command->getProductionId());
@@ -114,5 +119,13 @@ class ProductionCommandHandler extends Udb3CommandHandler
             }
         }
         $this->similaritiesClient->excludeTemporarily($eventPairs);
+    }
+
+    private function assertEventExists(string $eventId)
+    {
+        $event = $this->eventRepository->get($eventId);
+        if (!$event) {
+            throw EventCannotBeAddedToProduction::becauseItDoesNotExist($eventId);
+        }
     }
 }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -60,6 +60,8 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
     public function handleAddEventToProduction(AddEventToProduction $command): void
     {
+        $this->assertEventExists($command->getEventId());
+
         $production = $this->productionRepository->find($command->getProductionId());
         if ($production->containsEvent($command->getEventId())) {
             return;

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -28,8 +28,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
         ProductionRepository $productionRepository,
         SimilaritiesClient $similaritiesClient,
         DocumentRepositoryInterface $eventRepository
-    )
-    {
+    ) {
         $this->productionRepository = $productionRepository;
         $this->similaritiesClient = $similaritiesClient;
         $this->eventRepository = $eventRepository;

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use Doctrine\DBAL\DBALException;
 
@@ -124,7 +125,12 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
     private function assertEventExists(string $eventId)
     {
-        $event = $this->eventRepository->get($eventId);
+        try {
+            $event = $this->eventRepository->get($eventId);
+        } catch (DocumentGoneException $e) {
+            $event = null;
+        }
+
         if (!$event) {
             throw EventCannotBeAddedToProduction::becauseItDoesNotExist($eventId);
         }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
 use Doctrine\DBAL\DBALException;
 
 class ProductionCommandHandler extends Udb3CommandHandler
@@ -18,10 +19,20 @@ class ProductionCommandHandler extends Udb3CommandHandler
      */
     private $similaritiesClient;
 
-    public function __construct(ProductionRepository $productionRepository, SimilaritiesClient $similaritiesClient)
+    /**
+     * @var DocumentRepositoryInterface
+     */
+    private $eventRepository;
+
+    public function __construct(
+        ProductionRepository $productionRepository,
+        SimilaritiesClient $similaritiesClient,
+        DocumentRepositoryInterface $eventRepository
+    )
     {
         $this->productionRepository = $productionRepository;
         $this->similaritiesClient = $similaritiesClient;
+        $this->eventRepository = $eventRepository;
     }
 
     public function handleGroupEventsAsProduction(GroupEventsAsProduction $command): void

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -98,7 +98,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
     public function handleRejectSuggestedEventPair(RejectSuggestedEventPair $command): void
     {
-        $this->similaritiesClient->excludePermanently(SimilarEventPair::fromArray($command->getEventIds()));
+        $this->similaritiesClient->excludePermanently([SimilarEventPair::fromArray($command->getEventIds())]);
     }
 
     private function eventsWereAddedToProduction(string $eventId, ProductionId $productionId): void

--- a/src/Event/Productions/SimilaritiesClient.php
+++ b/src/Event/Productions/SimilaritiesClient.php
@@ -52,12 +52,18 @@ class SimilaritiesClient
         );
     }
 
-    public function excludePermanently(SimilarEventPair $pair)
+    /**
+     * @param SimilarEventPair[] $eventPairs
+     */
+    public function excludePermanently(array $eventPairs): void
     {
-        $data['pairs'] = [
-            'event1' => $pair->getEventOne(),
-            'event2' => $pair->getEventTwo(),
-        ];
+        $data['pairs'] = [];
+        foreach ($eventPairs as $pair) {
+            $data['pairs'][] = [
+                'event1' => $pair->getEventOne(),
+                'event2' => $pair->getEventTwo(),
+            ];
+        }
 
         $this->client->request(
             'PATCH',

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -318,7 +318,7 @@ class ProductionCommandHandlerTest extends TestCase
 
         $this->similaritiesClient->expects(self::atLeastOnce())
             ->method('excludePermanently')
-            ->with($eventPair);
+            ->with([$eventPair]);
 
         $command = new RejectSuggestedEventPair($eventPair);
         $this->commandHandler->handle($command);

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -109,6 +109,26 @@ class ProductionCommandHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_will_not_group_events_as_production_when_event_does_not_exist(): void
+    {
+        $event = Uuid::uuid4()->toString();
+
+        $this->eventRepository->method('get')->willReturn(null);
+        $this->expectException(EventCannotBeAddedToProduction::class);
+        $this->commandHandler->handle(
+            GroupEventsAsProduction::withProductionName(
+                [
+                    $event,
+                    Uuid::uuid4()->toString(),
+                ],
+                'Some production'
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_add_event_to_production(): void
     {
         $name = "A Midsummer Night's Scream 2";

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -185,6 +185,20 @@ class ProductionCommandHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_cannot_add_a_non_existing_event_to_a_production(): void
+    {
+        $eventId = Uuid::uuid4()->toString();
+        $this->eventRepository->method('get')->with(...[$eventId])->willReturn(null);
+
+        $this->expectException(EventCannotBeAddedToProduction::class);
+        $this->commandHandler->handle(
+            new AddEventToProduction($eventId, ProductionId::generate())
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_remove_an_event_from_a_production(): void
     {
         $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -188,7 +188,7 @@ class ProductionCommandHandlerTest extends TestCase
     public function it_cannot_add_a_non_existing_event_to_a_production(): void
     {
         $eventId = Uuid::uuid4()->toString();
-        $this->eventRepository->method('get')->with(...[$eventId])->willReturn(null);
+        $this->eventRepository->method('get')->with($eventId)->willReturn(null);
 
         $this->expectException(EventCannotBeAddedToProduction::class);
         $this->commandHandler->handle(

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -5,6 +5,8 @@ namespace CultuurNet\UDB3\Event\Productions;
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Productions\Doctrine\SchemaConfigurator;
+use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Rhumsaa\Uuid\Uuid;
 
@@ -23,9 +25,14 @@ class ProductionCommandHandlerTest extends TestCase
     private $commandHandler;
 
     /**
-     * @var SimilaritiesClient|\PHPUnit\Framework\MockObject\MockObject
+     * @var SimilaritiesClient|MockObject
      */
     private $similaritiesClient;
+
+    /**
+     * @var DocumentRepositoryInterface|MockObject
+     */
+    private $eventRepository;
 
     protected function setUp(): void
     {
@@ -33,7 +40,12 @@ class ProductionCommandHandlerTest extends TestCase
         $schema->configure($this->getConnection()->getSchemaManager());
         $this->productionRepository = new ProductionRepository($this->getConnection());
         $this->similaritiesClient = $this->createMock(SimilaritiesClient::class);
-        $this->commandHandler = new ProductionCommandHandler($this->productionRepository, $this->similaritiesClient);
+        $this->eventRepository = $this->createMock(DocumentRepositoryInterface::class);
+        $this->commandHandler = new ProductionCommandHandler(
+            $this->productionRepository,
+            $this->similaritiesClient,
+            $this->eventRepository
+        );
     }
 
     /**

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Productions\Doctrine\SchemaConfigurator;
 use CultuurNet\UDB3\Event\ReadModel\DocumentRepositoryInterface;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Rhumsaa\Uuid\Uuid;
@@ -60,6 +61,8 @@ class ProductionCommandHandlerTest extends TestCase
             Uuid::uuid4()->toString(),
         ];
 
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $this->similaritiesClient->expects(self::any())
             ->method('excludeTemporarily');
 
@@ -85,7 +88,7 @@ class ProductionCommandHandlerTest extends TestCase
             Uuid::uuid4()->toString(),
         ];
 
-        $this->similaritiesClient->expects($this->once())->method('excludeTemporarily');
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
 
         $command = GroupEventsAsProduction::withProductionName($events, $name);
         $this->commandHandler->handle($command);
@@ -116,6 +119,8 @@ class ProductionCommandHandlerTest extends TestCase
             Uuid::uuid4()->toString(),
         ];
 
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $this->similaritiesClient->expects(self::any())
             ->method('excludeTemporarily');
 
@@ -139,6 +144,8 @@ class ProductionCommandHandlerTest extends TestCase
      */
     public function it_cannot_add_an_event_that_already_belongs_to_another_production(): void
     {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $eventBelongingToFirstProduction = Uuid::uuid4()->toString();
         $name = "A Midsummer Night's Scream 2";
         $firstProductionCommand = GroupEventsAsProduction::withProductionName([$eventBelongingToFirstProduction],
@@ -158,8 +165,10 @@ class ProductionCommandHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_can_remove_an_event_from_aproduction(): void
+    public function it_can_remove_an_event_from_a_production(): void
     {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $name = "A Midsummer Night's Scream 2";
         $eventToRemove = Uuid::uuid4()->toString();
         $events = [
@@ -186,6 +195,8 @@ class ProductionCommandHandlerTest extends TestCase
      */
     public function it_will_not_remove_events_from_another_production()
     {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $eventBelongingToFirstProduction = Uuid::uuid4()->toString();
         $name = "A Midsummer Night's Scream 2";
         $firstProductionCommand = GroupEventsAsProduction::withProductionName([$eventBelongingToFirstProduction],
@@ -214,6 +225,8 @@ class ProductionCommandHandlerTest extends TestCase
      */
     public function it_can_merge_productions()
     {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $event1 = Uuid::uuid4()->toString();
         $name = "I know what you did last Midsummer Night";
         $fromProductionCommand = GroupEventsAsProduction::withProductionName([$event1], $name);
@@ -244,6 +257,8 @@ class ProductionCommandHandlerTest extends TestCase
      */
     public function it_will_not_merge_to_unknown_production()
     {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
         $event1 = Uuid::uuid4()->toString();
         $name = "I know what you did last Midsummer Night";
         $fromProductionCommand = GroupEventsAsProduction::withProductionName([$event1], $name);


### PR DESCRIPTION
### Fixed
- Events that are being grouped as production or added to an existing production are now validated for their existence.
- Call to Google Cloud Api to permanently exclude an event pair now works correctly

---
Ticket: https://jira.uitdatabank.be/browse/III-3324
