### PR TITLE
III-3425 - Check if event can be removed from production

### DIFF
--- a/src/Event/Productions/EventCannotBeRemovedFromProduction.php
+++ b/src/Event/Productions/EventCannotBeRemovedFromProduction.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CultuurNet\UDB3\Event\Productions;
+
+use Exception;
+
+final class EventCannotBeRemovedFromProduction extends Exception
+{
+    public static function becauseItDoesNotBelongToIt(string $eventId, ProductionId $productionId): self
+    {
+        return new self(
+            'Event with id ' . $eventId . ' cannot be removed from production with id ' . $productionId->toNative() . ' because it does not belong to it.'
+        );
+    }
+
+    public static function becauseItDoesNotExist(string $eventId): self
+    {
+        return new self(
+            'Event with id ' . $eventId . ' cannot be removed from a production because the event does not exist.'
+        );
+    }
+}

--- a/src/Event/Productions/EventCannotBeRemovedFromProduction.php
+++ b/src/Event/Productions/EventCannotBeRemovedFromProduction.php
@@ -6,10 +6,10 @@ use Exception;
 
 final class EventCannotBeRemovedFromProduction extends Exception
 {
-    public static function becauseItDoesNotBelongToIt(string $eventId, ProductionId $productionId): self
+    public static function becauseProductionDoesNotExist(string $eventId, ProductionId $productionId): self
     {
         return new self(
-            'Event with id ' . $eventId . ' cannot be removed from production with id ' . $productionId->toNative() . ' because it does not belong to it.'
+            'Event with id ' . $eventId . ' cannot be removed from production with id ' . $productionId->toNative() . ' because that production does not exist.'
         );
     }
 

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -145,7 +145,6 @@ class ProductionCommandHandler extends Udb3CommandHandler
             if (!$production->containsEvent($eventId)) {
                 throw EventCannotBeRemovedFromProduction::becauseItDoesNotBelongToIt($eventId, $productionId);
             }
-
         } catch (DocumentGoneException $e) {
             throw EventCannotBeRemovedFromProduction::becauseItDoesNotExist($eventId);
         }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -44,7 +44,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
         );
 
         foreach ($command->getEventIds() as $eventId) {
-            $this->assertEventExists($eventId);
+            $this->assertEventCanBeAddedToProduction($eventId);
         }
 
         try {
@@ -60,7 +60,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
     public function handleAddEventToProduction(AddEventToProduction $command): void
     {
-        $this->assertEventExists($command->getEventId());
+        $this->assertEventCanBeAddedToProduction($command->getEventId());
 
         $production = $this->productionRepository->find($command->getProductionId());
         if ($production->containsEvent($command->getEventId())) {
@@ -124,7 +124,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
         $this->similaritiesClient->excludeTemporarily($eventPairs);
     }
 
-    private function assertEventExists(string $eventId)
+    private function assertEventCanBeAddedToProduction(string $eventId)
     {
         try {
             $event = $this->eventRepository->get($eventId);

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -80,6 +80,7 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
     public function handleRemoveEventFromProduction(RemoveEventFromProduction $command): void
     {
+        $this->assertEventCanBeRemovedFromProduction($command->getEventId(), $command->getProductionId());
         $this->productionRepository->removeEvent($command->getEventId(), $command->getProductionId());
     }
 
@@ -133,6 +134,20 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
         if (!$event) {
             throw EventCannotBeAddedToProduction::becauseItDoesNotExist($eventId);
+        }
+    }
+
+    private function assertEventCanBeRemovedFromProduction(string $eventId, ProductionId $productionId)
+    {
+        try {
+            $this->eventRepository->get($eventId);
+            $production = $this->productionRepository->find($productionId);
+            if (!$production->containsEvent($eventId)) {
+                throw EventCannotBeRemovedFromProduction::becauseItDoesNotBelongToIt($eventId, $productionId);
+            }
+
+        } catch (DocumentGoneException $e) {
+            throw EventCannotBeRemovedFromProduction::becauseItDoesNotExist($eventId);
         }
     }
 }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -141,12 +141,11 @@ class ProductionCommandHandler extends Udb3CommandHandler
     {
         try {
             $this->eventRepository->get($eventId);
-            $production = $this->productionRepository->find($productionId);
-            if (!$production->containsEvent($eventId)) {
-                throw EventCannotBeRemovedFromProduction::becauseItDoesNotBelongToIt($eventId, $productionId);
-            }
+            $this->productionRepository->find($productionId);
         } catch (DocumentGoneException $e) {
             throw EventCannotBeRemovedFromProduction::becauseItDoesNotExist($eventId);
+        } catch (EntityNotFoundException $e) {
+            throw EventCannotBeRemovedFromProduction::becauseProductionDoesNotExist($eventId, $productionId);
         }
     }
 }

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -243,15 +243,10 @@ class ProductionCommandHandlerTest extends TestCase
             $name);
         $this->commandHandler->handle($secondProductionCommand);
 
+        $this->expectException(EventCannotBeRemovedFromProduction::class);
         $this->commandHandler->handle(
             new RemoveEventFromProduction($eventBelongingToFirstProduction, $secondProductionCommand->getProductionId())
         );
-
-        $firstProduction = $this->productionRepository->find($firstProductionCommand->getProductionId());
-        $this->assertTrue($firstProduction->containsEvent($eventBelongingToFirstProduction));
-
-        $secondProduction = $this->productionRepository->find($secondProductionCommand->getProductionId());
-        $this->assertTrue($secondProduction->containsEvent($eventBelongingToSecondProduction));
     }
 
     /**

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -243,10 +243,15 @@ class ProductionCommandHandlerTest extends TestCase
             $name);
         $this->commandHandler->handle($secondProductionCommand);
 
-        $this->expectException(EventCannotBeRemovedFromProduction::class);
         $this->commandHandler->handle(
             new RemoveEventFromProduction($eventBelongingToFirstProduction, $secondProductionCommand->getProductionId())
         );
+
+        $firstProduction = $this->productionRepository->find($firstProductionCommand->getProductionId());
+        $this->assertTrue($firstProduction->containsEvent($eventBelongingToFirstProduction));
+
+        $secondProduction = $this->productionRepository->find($secondProductionCommand->getProductionId());
+        $this->assertTrue($secondProduction->containsEvent($eventBelongingToSecondProduction));
     }
 
     /**


### PR DESCRIPTION
### Changed
- To align with adding an event to a production, we now check if an event and production exist before we try to remove it. That way, endpoint responses will be consistent across the productions api.

---
Ticket: https://jira.uitdatabank.be/browse/III-3425