### PR TITLE
III-3451 Use LIKE instead of MATCH for productions search

### DIFF
--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -133,7 +133,7 @@ class ProductionRepository extends AbstractDBALRepository
             ->from($this->getTableName()->toNative());
 
         if (!empty($keyword)) {
-            $query = $query->where('name LIKE CONCAT(\'%\', :keyword, \'%\')')
+            $query = $query->where('MATCH(name) AGAINST(CONCAT(:keyword, \'*\') IN BOOLEAN MODE)')
                 ->setParameter(':keyword', $keyword);
         }
 

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -133,7 +133,7 @@ class ProductionRepository extends AbstractDBALRepository
             ->from($this->getTableName()->toNative());
 
         if (!empty($keyword)) {
-            $query = $query->where('MATCH (name) AGAINST (:keyword)')
+            $query = $query->where('name LIKE CONCAT(\'%\', :keyword, \'%\')')
                 ->setParameter(':keyword', $keyword);
         }
 

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -133,7 +133,8 @@ class ProductionRepository extends AbstractDBALRepository
             ->from($this->getTableName()->toNative());
 
         if (!empty($keyword)) {
-            $query = $query->where('MATCH(name) AGAINST(CONCAT(:keyword, \'*\') IN BOOLEAN MODE)')
+            $keyword .= '*';
+            $query = $query->where('MATCH(name) AGAINST(:keyword IN BOOLEAN MODE)')
                 ->setParameter(':keyword', $keyword);
         }
 


### PR DESCRIPTION
### Changed

- Productions search by name now uses `LIKE` (with wildcards) instead of `MATCH` to make autocomplete/typeahead possible.

---
Ticket: https://jira.uitdatabank.be/browse/III-3451
