### PR TITLE
III-3433 Remove validation for start and end date for single and multiple calendars

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "cultuurnet/search-v3": "dev-master",
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "dev-feature/III-3433 as 0.1",
+    "cultuurnet/udb3": "~0.1",
     "cultuurnet/udb3-api-guard": "0.x-dev#179f67e56d04ccd402b1291dec894ac85b6e6a80 as 0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",
     "cultuurnet/udb3-jwt": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "cultuurnet/search-v3": "dev-master",
     "cultuurnet/silex-amqp": "~0.1",
     "cultuurnet/udb2-domain-events": "~0.1",
-    "cultuurnet/udb3": "~0.1",
+    "cultuurnet/udb3": "dev-feature/III-3433 as 0.1",
     "cultuurnet/udb3-api-guard": "0.x-dev#179f67e56d04ccd402b1291dec894ac85b6e6a80 as 0.1",
     "cultuurnet/udb3-http-foundation": "~0.1",
     "cultuurnet/udb3-jwt": "~0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af8812f35e6b32794a8f937eb888aae7",
+    "content-hash": "58094c4d738393c834bc5bee7110627f",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1348,16 +1348,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-master",
+            "version": "dev-feature/III-3433",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "e22388409b1227aaa9dd2a602d4fc8db6ac1262c"
+                "reference": "7ed4b785ee515f32d4bfb3f2d337550fd778aa8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/e22388409b1227aaa9dd2a602d4fc8db6ac1262c",
-                "reference": "e22388409b1227aaa9dd2a602d4fc8db6ac1262c",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/7ed4b785ee515f32d4bfb3f2d337550fd778aa8b",
+                "reference": "7ed4b785ee515f32d4bfb3f2d337550fd778aa8b",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1422,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2020-09-07T07:42:44+00:00"
+            "time": "2020-09-07T15:06:58+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -9120,6 +9120,12 @@
         {
             "alias": "0.1",
             "alias_normalized": "0.1.0.0",
+            "version": "dev-feature/III-3433",
+            "package": "cultuurnet/udb3"
+        },
+        {
+            "alias": "0.1",
+            "alias_normalized": "0.1.0.0",
             "version": "0.9999999.9999999.9999999-dev",
             "package": "cultuurnet/udb3-api-guard"
         },
@@ -9135,6 +9141,7 @@
         "chrisboulton/php-resque": 20,
         "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/search-v3": 20,
+        "cultuurnet/udb3": 20,
         "cultuurnet/udb3-api-guard": 20,
         "doctrine/migrations": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1352,12 +1352,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "886cf694fba563226db2e14fdb4a25ec427b79f4"
+                "reference": "c283db4f19f97293752e653ddce3458e8a1cca40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/886cf694fba563226db2e14fdb4a25ec427b79f4",
-                "reference": "886cf694fba563226db2e14fdb4a25ec427b79f4",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/c283db4f19f97293752e653ddce3458e8a1cca40",
+                "reference": "c283db4f19f97293752e653ddce3458e8a1cca40",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1422,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2020-09-07T15:43:59+00:00"
+            "time": "2020-09-07T15:52:12+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58094c4d738393c834bc5bee7110627f",
+    "content-hash": "af8812f35e6b32794a8f937eb888aae7",
     "packages": [
         {
             "name": "2dotstwice/collection",
@@ -1348,16 +1348,16 @@
         },
         {
             "name": "cultuurnet/udb3",
-            "version": "dev-feature/III-3433",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "c283db4f19f97293752e653ddce3458e8a1cca40"
+                "reference": "d252f04d389c772cc5e114e9a3126a521b5dfd6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/c283db4f19f97293752e653ddce3458e8a1cca40",
-                "reference": "c283db4f19f97293752e653ddce3458e8a1cca40",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/d252f04d389c772cc5e114e9a3126a521b5dfd6b",
+                "reference": "d252f04d389c772cc5e114e9a3126a521b5dfd6b",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1422,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2020-09-07T15:52:12+00:00"
+            "time": "2020-09-08T10:18:41+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",
@@ -9120,12 +9120,6 @@
         {
             "alias": "0.1",
             "alias_normalized": "0.1.0.0",
-            "version": "dev-feature/III-3433",
-            "package": "cultuurnet/udb3"
-        },
-        {
-            "alias": "0.1",
-            "alias_normalized": "0.1.0.0",
             "version": "0.9999999.9999999.9999999-dev",
             "package": "cultuurnet/udb3-api-guard"
         },
@@ -9141,7 +9135,6 @@
         "chrisboulton/php-resque": 20,
         "cultuurnet/calendar-summary-v3": 20,
         "cultuurnet/search-v3": 20,
-        "cultuurnet/udb3": 20,
         "cultuurnet/udb3-api-guard": 20,
         "doctrine/migrations": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1352,12 +1352,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-php.git",
-                "reference": "7ed4b785ee515f32d4bfb3f2d337550fd778aa8b"
+                "reference": "886cf694fba563226db2e14fdb4a25ec427b79f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/7ed4b785ee515f32d4bfb3f2d337550fd778aa8b",
-                "reference": "7ed4b785ee515f32d4bfb3f2d337550fd778aa8b",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-php/zipball/886cf694fba563226db2e14fdb4a25ec427b79f4",
+                "reference": "886cf694fba563226db2e14fdb4a25ec427b79f4",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1422,7 @@
                 }
             ],
             "description": "UDB3 PHP libraries",
-            "time": "2020-09-07T15:06:58+00:00"
+            "time": "2020-09-07T15:43:59+00:00"
         },
         {
             "name": "cultuurnet/udb3-api-guard",

--- a/src/Http/Deserializer/Calendar/CalendarForEventDataValidator.php
+++ b/src/Http/Deserializer/Calendar/CalendarForEventDataValidator.php
@@ -44,18 +44,6 @@ class CalendarForEventDataValidator implements DataValidatorInterface
             $messages['opening_hours'] = 'When opening hours are given no time spans are allowed.';
         }
 
-        if (count($timeSpans) > 0 &&
-            $calendarJSONParser->getStartDate($data) &&
-            $calendarJSONParser->getEndDate($data)) {
-            if ($calendarJSONParser->getStartDate($data) != $timeSpans[0]->getStart()) {
-                $messages['start_time_span'] = 'The start date is different from the start of the first time span.';
-            }
-
-            if ($calendarJSONParser->getEndDate($data) != $timeSpans[count($timeSpans) - 1]->getEnd()) {
-                $messages['end_time_span'] = 'The end date is different from the end of the last time span.';
-            }
-        }
-
         if (!empty($messages)) {
             $e = new DataValidationException();
             $e->setValidationMessages($messages);

--- a/src/Http/Deserializer/Calendar/CalendarForEventDataValidator.php
+++ b/src/Http/Deserializer/Calendar/CalendarForEventDataValidator.php
@@ -31,15 +31,21 @@ class CalendarForEventDataValidator implements DataValidatorInterface
 
         $messages = array_merge(
             $messages,
-            (new StartDateEndDateValidator())->validate($data)
-        );
-
-        $messages = array_merge(
-            $messages,
             (new TimeSpanValidator())->validate($data)
         );
 
         $timeSpans = $calendarJSONParser->getTimeSpans($data);
+
+        // Single and multiple calendar types always have `timeSpans` from which the start and end date are dynamically
+        // determined. If there are no timespans though, and a start and end date are given (ie. periodic calendar), the
+        // start and end date SHOULD be validated.
+        if (count($timeSpans) === 0) {
+            $messages = array_merge(
+                $messages,
+                (new StartDateEndDateValidator())->validate($data)
+            );
+        }
+
         if (count($timeSpans) > 0 && count($calendarJSONParser->getOpeningHours($data)) > 0) {
             $messages['opening_hours'] = 'When opening hours are given no time spans are allowed.';
         }

--- a/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
+++ b/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
@@ -117,13 +117,13 @@ class CalendarJSONDeserializer extends JSONDeserializer
      */
     private function getStartDate(array $data)
     {
-        if ($this->calendarJSONParser->getStartDate($data)) {
-            return $this->calendarJSONParser->getStartDate($data);
-        }
-
         $timeSpans = $this->calendarJSONParser->getTimeSpans($data);
         if (count($timeSpans)) {
-            return $timeSpans[0]->getStart();
+            return null;
+        }
+
+        if ($this->calendarJSONParser->getStartDate($data)) {
+            return $this->calendarJSONParser->getStartDate($data);
         }
 
         return null;
@@ -136,13 +136,13 @@ class CalendarJSONDeserializer extends JSONDeserializer
      */
     private function getEndDate(array $data)
     {
-        if ($this->calendarJSONParser->getEndDate($data)) {
-            return $this->calendarJSONParser->getEndDate($data);
-        }
-
         $timeSpans = $this->calendarJSONParser->getTimeSpans($data);
         if (count($timeSpans)) {
-            return $timeSpans[count($timeSpans) - 1]->getEnd();
+            return null;
+        }
+
+        if ($this->calendarJSONParser->getEndDate($data)) {
+            return $this->calendarJSONParser->getEndDate($data);
         }
 
         return null;

--- a/tests/Event/Commands/UpdateCalendarTest.php
+++ b/tests/Event/Commands/UpdateCalendarTest.php
@@ -29,7 +29,7 @@ class UpdateCalendarTest extends TestCase
         $this->eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $this->calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Event/EventCommandHandlerTest.php
+++ b/tests/Event/EventCommandHandlerTest.php
@@ -391,7 +391,7 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
         $eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Event/EventEditingServiceTest.php
+++ b/tests/Event/EventEditingServiceTest.php
@@ -493,7 +493,7 @@ class EventEditingServiceTest extends TestCase
         $eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -164,8 +164,7 @@ class EventTest extends AggregateRootScenarioTestCase
     {
         $newEventId = 'e49430ca-5729-4768-8364-02ddb385517a';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERMANENT()
         );
 
         $event = $this->event;
@@ -272,7 +271,7 @@ class EventTest extends AggregateRootScenarioTestCase
         $createEvent = $this->getCreationEvent();
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
@@ -1028,8 +1027,7 @@ class EventTest extends AggregateRootScenarioTestCase
         $event->copy(
             'e49430ca-5729-4768-8364-02ddb385517a',
             new Calendar(
-                CalendarType::SINGLE(),
-                new \DateTime()
+                CalendarType::PERMANENT()
             )
         );
     }
@@ -1042,8 +1040,7 @@ class EventTest extends AggregateRootScenarioTestCase
     {
         $newEventId = 'e49430ca-5729-4768-8364-02ddb385517a';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERMANENT()
         );
         $label = new Label('ABC');
 
@@ -1086,8 +1083,7 @@ class EventTest extends AggregateRootScenarioTestCase
     {
         $newEventId = 'e49430ca-5729-4768-8364-02ddb385517a';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERMANENT()
         );
         $audience = new Audience(AudienceType::EDUCATION());
 
@@ -1126,8 +1122,7 @@ class EventTest extends AggregateRootScenarioTestCase
     {
         $newEventId = 'e49430ca-5729-4768-8364-02ddb385517a';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERMANENT()
         );
 
         $publicationDate = new \DateTimeImmutable();

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -175,7 +175,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '1';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
         );
 
@@ -209,7 +210,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     {
         $eventId = '1';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
@@ -256,7 +258,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     {
         $eventId = '1';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
@@ -333,8 +336,9 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     {
         $originalEventId = '1';
         $originalCalendar = new Calendar(
-            CalendarType::SINGLE(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
+            CalendarType::PERIODIC(),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($originalEventId, $originalCalendar, null);
 
@@ -522,8 +526,9 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         // First make sure there is already an event, so it is a real update.
         $eventId = 'a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
+            CalendarType::PERIODIC(),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(\DateTime::ATOM, '2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($eventId, $calendar, null);
         $this->mockPlaceService();
@@ -825,7 +830,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $location = new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e');
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
         );
@@ -866,7 +871,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@type' => 'Place',
             '@id' => 'http://example.com/entity/395fe7eb-9bac-4647-acae-316b6446a85e',
         ];
-        $expectedJsonLD->calendarType = 'single';
+        $expectedJsonLD->calendarType = 'periodic';
         $expectedJsonLD->terms = [
             (object)[
                 'id' => '0.50.4.0.1',
@@ -899,7 +904,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
@@ -917,7 +922,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@id' => 'http://example.com/entity/' . $eventId,
             '@context' => '/contexts/event',
         ];
-        $expectedJsonLD->calendarType = 'single';
+        $expectedJsonLD->calendarType = 'periodic';
         $expectedJsonLD->startDate = '2020-01-26T11:11:11+01:00';
         $expectedJsonLD->endDate = '2020-01-27T12:12:12+01:00';
         $expectedJsonLD->availableTo = '2020-01-27T12:12:12+01:00';
@@ -1038,7 +1043,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $location = new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e');
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
         );
@@ -1247,8 +1252,9 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@type' => 'Place',
             '@id' => 'http://example.com/entity/395fe7eb-9bac-4647-acae-316b6446a85e',
         ];
-        $jsonLD->calendarType = 'single';
+        $jsonLD->calendarType = 'periodic';
         $jsonLD->startDate = '2015-01-26T13:25:21+01:00';
+        $jsonLD->endDate = '2015-01-26T13:25:21+01:00';
         $jsonLD->availableTo = $jsonLD->startDate;
         $jsonLD->sameAs = [
             'http://www.uitinvlaanderen.be/agenda/e/some-representative-title/1',

--- a/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarForEventDataValidatorTest.php
@@ -164,26 +164,6 @@ class CalendarForEventDataValidatorTest extends TestCase
                     'opening_hours' => 'When opening hours are given no time spans are allowed.',
                 ],
             ],
-            'it_throws_when_dates_different_from_time_spans' => [
-                'data' => [
-                    'timeSpans' => [
-                        [
-                            'start' => '2020-01-26T09:00:00+01:00',
-                            'end' => '2020-02-01T16:00:00+01:00',
-                        ],
-                        [
-                            'start' => '2020-02-03T09:00:00+01:00',
-                            'end' => '2020-02-10T16:00:00+01:00',
-                        ],
-                    ],
-                    'startDate' => '2020-01-27T09:00:00+01:00',
-                    'endDate' => '2020-02-11T09:00:00+01:00',
-                ],
-                'messages' => [
-                    'start_time_span' => 'The start date is different from the start of the first time span.',
-                    'end_time_span' => 'The end date is different from the end of the last time span.'
-                ],
-            ],
         ];
     }
 }

--- a/tests/Offer/AvailableToTest.php
+++ b/tests/Offer/AvailableToTest.php
@@ -5,6 +5,7 @@ namespace CultuurNet\UDB3\Offer;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarInterface;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Timestamp;
 use PHPUnit\Framework\TestCase;
 
 class AvailableToTest extends TestCase
@@ -45,11 +46,11 @@ class AvailableToTest extends TestCase
                 new \DateTime('2100-01-01T00:00:00Z'),
             ],
             [
-                new Calendar(CalendarType::SINGLE(), $startDate),
+                new Calendar(CalendarType::SINGLE(), null, null, [new Timestamp($startDate, $startDate)]),
                 $startDate,
             ],
             [
-                new Calendar(CalendarType::SINGLE(), $startDate, $endDate),
+                new Calendar(CalendarType::SINGLE(), null, null, [new Timestamp($startDate, $endDate)]),
                 $endDate,
             ],
             [
@@ -57,15 +58,15 @@ class AvailableToTest extends TestCase
                 $endDate,
             ],
             [
-                new Calendar(CalendarType::MULTIPLE(), $startDate, $endDate),
+                new Calendar(CalendarType::MULTIPLE(), $startDate, $endDate, [new Timestamp($startDate, $endDate)]),
                 $endDate,
             ],
             [
-                new Calendar(CalendarType::SINGLE(), $startDateNoHours),
+                new Calendar(CalendarType::SINGLE(), null, null, [new Timestamp($startDateNoHours, $startDateNoHours)]),
                 $startDateAlmostMidnight,
             ],
             [
-                new Calendar(CalendarType::SINGLE(), $startDateNoHours, $endDateNoHours),
+                new Calendar(CalendarType::SINGLE(), null, null, [new Timestamp($startDateNoHours, $endDateNoHours)]),
                 $endDateAlmostMidnight,
             ],
             [
@@ -73,7 +74,7 @@ class AvailableToTest extends TestCase
                 $endDateAlmostMidnight,
             ],
             [
-                new Calendar(CalendarType::MULTIPLE(), $startDate, $endDateNoHours),
+                new Calendar(CalendarType::MULTIPLE(), null, null, [new Timestamp($startDate, $endDateNoHours)]),
                 $endDateAlmostMidnight,
             ],
         ];

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -1356,19 +1356,19 @@ class OfferTest extends AggregateRootScenarioTestCase
         $itemId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $sameCalendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $otherCalendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-28T12:12:12+01:00')
         );

--- a/tests/Place/Commands/UpdateCalendarTest.php
+++ b/tests/Place/Commands/UpdateCalendarTest.php
@@ -29,7 +29,7 @@ class UpdateCalendarTest extends TestCase
         $this->placeId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $this->calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Place/DefaultPlaceEditingServiceTest.php
+++ b/tests/Place/DefaultPlaceEditingServiceTest.php
@@ -275,7 +275,7 @@ class DefaultPlaceEditingServiceTest extends TestCase
         $placeId = 'ad93103d-1395-4af7-a52a-2829d466c232';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Place/PlaceCommandHandlerTest.php
+++ b/tests/Place/PlaceCommandHandlerTest.php
@@ -398,7 +398,7 @@ class PlaceHandlerTest extends CommandHandlerScenarioTestCase
         $placeId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -145,7 +145,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
         $placeId = $placeCreated->getPlaceId();
 
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -712,7 +712,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $title = new Title('new title');
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
         );
@@ -759,7 +759,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
                 'streetAddress' => 'Kerkstraat 69',
             ],
         ];
-        $expectedJsonLD->calendarType = 'single';
+        $expectedJsonLD->calendarType = 'periodic';
         $expectedJsonLD->terms = [
             (object)[
                 'id' => '0.50.4.0.1',

--- a/tests/samples/serialized_event_major_info_updated_class.json
+++ b/tests/samples/serialized_event_major_info_updated_class.json
@@ -26,7 +26,7 @@
     "calendar": {
       "type": "single",
       "startDate": "2015-10-30T12:00:00+01:00",
-      "endDate": "2015-10-30T10:00:00+01:00",
+      "endDate": "2015-10-30T13:00:00+01:00",
       "timestamps": [],
       "openingHours": []
     }


### PR DESCRIPTION
### Removed

- Removed requirement for start and end date for `single` and `multiple` calendar types.

### Fixed

- Fixed broken tests after `cultuurnet/udb3` update

---
Ticket: https://jira.uitdatabank.be/browse/III-3433

Related PR: https://github.com/cultuurnet/udb3-php/pull/471
