### PR TITLE
III-3481

### DIFF
--- a/src/Event/Productions/EventCannotBeAddedToProduction.php
+++ b/src/Event/Productions/EventCannotBeAddedToProduction.php
@@ -26,4 +26,11 @@ final class EventCannotBeAddedToProduction extends Exception
             'Event with id ' . $eventId . ' cannot be added to a production because the event does not exist.'
         );
     }
+
+    public static function becauseItAlreadyBelongsToThatProduction(string $eventId, ProductionId $productionId): self
+    {
+        return new self(
+            'Event with id ' . $eventId . ' cannot be added to production with id ' . $productionId->toNative() . ' because it already belongs to that production.'
+        );
+    }
 }

--- a/src/Event/Productions/ProductionCommandHandler.php
+++ b/src/Event/Productions/ProductionCommandHandler.php
@@ -63,7 +63,10 @@ class ProductionCommandHandler extends Udb3CommandHandler
 
         $production = $this->productionRepository->find($command->getProductionId());
         if ($production->containsEvent($command->getEventId())) {
-            return;
+            throw EventCannotBeAddedToProduction::becauseItAlreadyBelongsToThatProduction(
+                $command->getEventId(),
+                $command->getProductionId()
+            );
         }
 
         try {

--- a/tests/Event/Productions/ProductionCommandHandlerTest.php
+++ b/tests/Event/Productions/ProductionCommandHandlerTest.php
@@ -196,6 +196,24 @@ class ProductionCommandHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_cannot_add_an_event_that_already_belongs_to_that_production(): void
+    {
+        $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));
+
+        $eventBelongingToProduction = Uuid::uuid4()->toString();
+        $name = "A Midsummer Night's Scream 2";
+        $firstProductionCommand = GroupEventsAsProduction::withProductionName([$eventBelongingToProduction], $name);
+        $this->commandHandler->handle($firstProductionCommand);
+
+        $this->expectException(EventCannotBeAddedToProduction::class);
+        $this->commandHandler->handle(
+            new AddEventToProduction($eventBelongingToProduction, $firstProductionCommand->getProductionId())
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_remove_an_event_from_a_production(): void
     {
         $this->eventRepository->method('get')->willReturn(new JsonDocument('foo'));


### PR DESCRIPTION
### Changed
- Trying to add an event to a production to which it already belongs will now result in an exception instead of a no-operation.

---
Ticket: https://jira.uitdatabank.be/browse/III-3481
