### PR TITLE
Fix id argument in role delete method

### DIFF
--- a/src/Http/Role/EditRoleRestController.php
+++ b/src/Http/Role/EditRoleRestController.php
@@ -127,7 +127,7 @@ class EditRoleRestController
     public function delete(string $id): Response
     {
         if (empty($id)) {
-            throw new InvalidArgumentException('Required field roleId is missing');
+            throw new InvalidArgumentException('Required field id is missing');
         }
 
         $this->service->delete(new UUID($id));

--- a/src/Http/Role/EditRoleRestController.php
+++ b/src/Http/Role/EditRoleRestController.php
@@ -124,13 +124,13 @@ class EditRoleRestController
         return new NoContent();
     }
 
-    public function delete(string $roleId): Response
+    public function delete(string $id): Response
     {
-        if (empty($roleId)) {
+        if (empty($id)) {
             throw new InvalidArgumentException('Required field roleId is missing');
         }
 
-        $this->service->delete(new UUID($roleId));
+        $this->service->delete(new UUID($id));
 
         return new NoContent();
     }

--- a/tests/Http/Role/EditRoleRestControllerTest.php
+++ b/tests/Http/Role/EditRoleRestControllerTest.php
@@ -230,7 +230,7 @@ class EditRoleRestControllerTest extends TestCase
     public function it_throws_an_exception_when_no_roleId_is_given_to_delete()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Required field roleId is missing');
+        $this->expectExceptionMessage('Required field id is missing');
         $this->controller->delete('');
     }
 


### PR DESCRIPTION
### Fixed

- Fixed fatal error when trying to delete a role because of a "missing" $roleId argument. This was caused by a name change from `$id` to `$roleId` in 22b95460cd22d7b0dadf9b1f2d224550a978dc44 and 87452c49b1c29e2a1310cb5ea4ad3b35d80c72b6. This change results in a fatal error because the `RoleControllerProvider` defines the parameter name as `{id}`, not `{roleId}`. And changing it to `{roleId}` in the ControllerProvider results in CORS issues, because other HTTP methods on the same path (`get`, `patch`) use `{id}` as well so this confuses Silex it seems. We could also fix it by making all of these controller methods use `$roleId` instead of `$id` but that's a bigger change and I think in this context it should be clear that it's a role id.

---
Ticket: https://jira.uitdatabank.be/browse/III-3523

(There are no tests in PHP for this because we'd need integration tests that can do HTTP requests to do that. It's covered by the cucumber tests for now though.)
