### PR TITLE
Remove event variation search index table

### DIFF
--- a/app/Migrations/Version20201015095142.php
+++ b/app/Migrations/Version20201015095142.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20201015095142 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->dropTable('event_variation_search_index');
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/app/PurgeServiceProvider.php
+++ b/app/PurgeServiceProvider.php
@@ -61,7 +61,6 @@ class PurgeServiceProvider implements ServiceProviderInterface
             'event_permission_readmodel',
             'event_relations',
             'place_relations',
-            'event_variation_search_index',
             'index_readmodel',
             'place_permission_readmodel',
         ];


### PR DESCRIPTION
### Removed
- Unused read model table `event_variation_search_index`

---
Ticket: https://jira.uitdatabank.be/browse/III-3502
