### PR TITLE
III-3584 Fix incorrect organizer name in events imported from XML

### DIFF
--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -217,7 +217,8 @@ class CdbXMLImporter
             $organizer = (array)$organizerManager->organizerJSONLD($organizerId);
         } elseif ($organizerCdb && $contactInfoCdb) {
             $organizer = array();
-            $organizer['name'] = $organizerCdb->getLabel();
+            $organizer['mainLanguage'] = 'nl';
+            $organizer['name']['nl'] = $organizerCdb->getLabel();
 
             $emailsCdb = $contactInfoCdb->getMails();
             if (count($emailsCdb) > 0) {

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -172,6 +172,25 @@ class CdbXMLImporterTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_a_dummy_organizer_if_an_organizer_without_id_is_included(): void
+    {
+        $jsonEvent = $this->createJsonEventFromCdbXml('event_with_dummy_organizer.cdbxml.xml');
+
+        $this->assertEquals(
+            [
+                '@type' => 'Organizer',
+                'mainLanguage' => 'nl',
+                'name' => [
+                    'nl' => 'Test organizer',
+                ],
+            ],
+            $jsonEvent->organizer
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_adds_an_email_property_when_cdbxml_has_no_organizer_but_has_contact_with_email()
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_email_and_phone_number.cdbxml.xml');

--- a/tests/Event/ReadModel/JSONLD/event_with_dummy_organizer.cdbxml.xml
+++ b/tests/Event/ReadModel/JSONLD/event_with_dummy_organizer.cdbxml.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0"?>
+<cdb:event xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL"
+           availablefrom="2014-08-12T00:00:00" availableto="2016-12-17T00:00:00"
+           cdbid="7614f22c-e4ec-445b-9f8d-9cae60c262a2"
+           createdby="kgielens@kanker.be" creationdate="2014-08-12T14:37:58"
+           externalid="CDB:85fbe2b6-024f-4e5c-b61a-339b02a064a6"
+           isparent="false" lastupdated="2014-10-21T16:47:23"
+           lastupdatedby="karen.vaneynde@mechelen.be" pctcomplete="90"
+           published="true" owner="Invoerders Algemeen " private="false"
+           validator="Mechelen Validatoren" wfstatus="approved">
+    <cdb:activities>
+        <cdb:activity count="0" type="like"/>
+        <cdb:activity count="0" type="attend"/>
+        <cdb:activity count="0" type="comment"/>
+        <cdb:activity count="0" type="recommend"/>
+        <cdb:activity count="0" type="facebook_share"/>
+        <cdb:activity count="0" type="review"/>
+    </cdb:activities>
+    <cdb:agefrom>18</cdb:agefrom>
+    <cdb:calendar>
+        <cdb:periods>
+            <cdb:period>
+                <cdb:datefrom>2014-08-22</cdb:datefrom>
+                <cdb:dateto>2016-12-16</cdb:dateto>
+            </cdb:period>
+        </cdb:periods>
+    </cdb:calendar>
+    <cdb:categories>
+        <cdb:category catid="1.51.12.0.0" type="theme">Omnisport en andere
+        </cdb:category>
+        <cdb:category catid="reg.368" type="flanderstouristregion">Kunststad
+            Mechelen
+        </cdb:category>
+        <cdb:category catid="0.59.0.0.0" type="eventtype">Sportactiviteit
+        </cdb:category>
+        <cdb:category catid="reg.592" type="flandersregion">2800 Mechelen
+        </cdb:category>
+    </cdb:categories>
+    <cdb:comments/>
+    <cdb:contactinfo>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Mechelen</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>4.485984</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.015051</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>57</cdb:housenr>
+                <cdb:street>Bautersemstraat</cdb:street>
+                <cdb:zipcode>2800</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:url>http://www.rekanto.be</cdb:url>
+        <cdb:url reservation="true">http://www.reservatiesite.be</cdb:url>
+    </cdb:contactinfo>
+    <cdb:eventdetails>
+        <cdb:eventdetail lang="nl">
+            <cdb:calendarsummary>van 22/08/14 tot 16/12/16</cdb:calendarsummary>
+            <cdb:longdescription>
+                Stichting tegen Kanker helpt patiënten hun energie terug te
+                vinden
+                <br/>
+                <br/>Het Rekanto-programma van de Stichting tegen Kanker biedt
+                (ex-) kankerpatiënten gratis fysieke activiteiten aan tot één
+                jaar na hun behandeling. Vandaag genieten meer dan 1000 mensen
+                in heel België van de voordelen van het programma, waarvan het
+                doel is de vermoeidheid tegen te gaan, de levenskwaliteit te
+                verhogen en mensen te helpen opnieuw een zo normaal mogelijk
+                dagelijks leven te kunnen hernemen. Deelnemers hebben de keuze
+                uit een waaier aan activiteiten om hun fysieke en psychisch
+                evenwicht terug te vinden: omnisport, aquagym en nordic walking
+                om zich fitter te voelen, taï chi en yoga om te ontspannen….
+                <br/>
+                <br/>Opnieuw op krachten komen voor een betere levenskwaliteit
+                <br/>
+                <br/>Na een behandeling met chemo- of radiotherapie kampen
+                mensen vaak met bijwerkingen, waarvan zware fysieke vermoeidheid
+                de meest voorkomende is. 60 à 90% van de patiënten ondervindt
+                deze hinder. De minste activiteit veroorzaakt een gevoel van
+                totale uitputting, waarbij rusten niet veel soelaas biedt. Deze
+                vermoeidheid heeft een enorme impact op de levenskwaliteit van
+                de patiënten, met gevolgen op fysiek, psychisch en sociaal vlak.
+                <br/>
+                <br/>Met het bewegingsprogramma Rekanto wil Stichting tegen
+                Kanker geleidelijk aan de fysieke conditie van (ex-) patiënten
+                verbeteren opdat ze opnieuw de krachten terugwinnen die ze nodig
+                hebben voor hun dagelijkse bezigheden, hun sociale en
+                professioneel leven. Talrijke wetenschappelijke studies tonen de
+                positieve impact aan van fysieke activiteiten op mensen met
+                kanker. Zo neemt hun spierkracht toe en neemt de vermoeidheid af
+                doordat ze hun uithoudingsvermogen progressief trainen. Dat
+                heeft op zijn beurt positieve effecten op het psychisch
+                evenwicht: de patiënt gaat zich beter in zijn vel voelen, terug
+                vertrouwen krijgen in zijn eigen fysieke kunnen, terug een
+                regelmatige sociale activiteit uitoefenen en zich minder
+                depressief en angstig voelen. Zo vertelt Brenda (41): “Tijdens
+                de yoga voel ik mijn lichaam heel sterk. Sinds de kanker ben ik
+                snel ongerust als ik plots ergens pijn voel bijvoorbeeld. Door
+                de yoga verdwijnt die ongerustheid wat. Ik weet dan: dat is
+                normaal, dat komt door de sport.” Karin (42) vindt: “De groep en
+                de saamhorigheid zijn voor mij ook heel belangrijk. Ja, het feit
+                dat we allemaal hetzelfde meegemaakt hebben, terwijl het daar
+                niet altijd over hoeft te gaan, hé. Ik wilde niet in het
+                ziekzijn blijven zitten!”
+                <br/>
+                <br/>Een professioneel omkaderd overgangsprogramma
+                <br/>
+                <br/>Patiënten kunnen bij Rekanto starten tijdens en tot één
+                jaar na het einde van hun behandeling. De activiteiten zijn op
+                maat ontwikkeld door specialisten in de oncologie en
+                revalidatie. Zo worden ze als een ‘overgangsprogramma’
+                aangeboden, dat de patiënt in staat stelt om geleidelijk aan de
+                energie terug te vinden die hij nodig heeft om dagelijkse
+                bezigheden opnieuw aan te kunnen:<br/>Anne (49) “Ik kan terug
+                iets! Ik recupereer ook sneller. In het begin voelde ik me echt
+                een vod en kwam ik zeer onregelmatig. Nu kom ik veel
+                regelmatiger. Ik voel me ook mentaal sterker. In het begin lag
+                ik na een sessie twee dagen in bed. Nu kan ik de volgende dag al
+                dingen doen … En ik ben er ook mondiger door geworden!”<br/>Het
+                doel van Rekanto is, dat deelnemers na enkele maanden of een
+                jaar uit het programma kunnen stappen en in staat zijn om een zo
+                normaal mogelijk leven te leiden.
+                <br/>
+                <br/>Een waaier aan activiteiten op maat
+                <br/>
+                <br/>Om aan de behoeften van zoveel mogelijk patiënten te
+                voldoen, biedt Rekanto een waaier aan activiteiten aan,
+                aangepast aan de situatie en de fysieke beperkingen van
+                eenieder: omnisport, aquagym en nordic walking om de fysieke
+                conditie te verhogen; taï chi en yoga om te ontspannen en op een
+                zachte manier terug in vorm te komen.
+                <br/>
+                <br/>Paul, yoga-instructeur in Aartselaar, legt uit hoe
+                belangrijk het is om het programma aan elke deelnemer aan te
+                passen: “Ze willen zo veel: ze willen genezen, ze willen terug
+                een normaal leven, ze willen snel een hoog niveau bereiken. Ze
+                ‘overwillen’ zich wel eens. En zo verliezen ze energie. Ik daag
+                hen wel uit, maar het is belangrijk dat iedereen de oefeningen
+                doet volgens wat hij zelf aankan. En dat is voor iedereen
+                anders. Tegelijk werk ik opbouwend. Ik wissel veel af, maar laat
+                ook vaak dezelfde oefeningen terugkomen. Zo zie ik en zien zij
+                zelf hoe ze vooruitgaan.”
+                <br/>
+                <p class="uiv-source">Bron:
+                    <a href="http://www.uitinvlaanderen.be/agenda/e/rekanto-taiqi/7614f22c-e4ec-445b-9f8d-9cae60c262a2">
+                        UiTinVlaanderen.be
+                    </a>
+                </p>
+            </cdb:longdescription>
+            <cdb:media>
+                <cdb:file>
+                    <cdb:hlink>http://www.rekanto.be</cdb:hlink>
+                    <cdb:mediatype>webresource</cdb:mediatype>
+                </cdb:file>
+                <cdb:file creationdate="14/08/2014 16:29:28" main="true">
+                    <cdb:copyright>StK</cdb:copyright>
+                    <cdb:filename>d9cd0795-2e68-40cb-acc1-7900945f5d0d.jpg
+                    </cdb:filename>
+                    <cdb:filetype>jpeg</cdb:filetype>
+                    <cdb:hlink>
+                        //media.uitdatabank.be/20140812/d9cd0795-2e68-40cb-acc1-7900945f5d0d.jpg
+                    </cdb:hlink>
+                    <cdb:mediatype>photo</cdb:mediatype>
+                </cdb:file>
+            </cdb:media>
+            <cdb:price>
+                <cdb:pricevalue>0.0</cdb:pricevalue>
+            </cdb:price>
+            <cdb:shortdescription>
+                • fysieke activiteiten, speciaal ontworpen voor volwassenen die
+                af te rekenen hebben of onlangs af te rekenen hadden met een
+                kanker.• Rekanto helpt om een betere lichamelijke conditie te
+                herwinnen en op die manier de vermoeidheid te overwinnen,
+                dankzij activiteiten in groep• Patiënten in behandeling of tot
+                een jaar na het einde daarvan kunnen gedurende één jaar gratis
+                deelnemen.
+            </cdb:shortdescription>
+            <cdb:title>Rekanto - TaiQi</cdb:title>
+        </cdb:eventdetail>
+        <cdb:eventdetail lang="fr">
+            <cdb:calendarsummary>de 22/08/14 à 16/12/16</cdb:calendarsummary>
+            <cdb:longdescription>
+                La Fondation contre le Cancer aide les patients à retrouver leur
+                énergie ! La Fondation contre le Cancer propose Raviva : des
+                activités physiques accessibles gratuitement, jusqu’à un an
+                après la fin des traitements contre le cancer. Aujourd’hui, plus
+                de 1 000 personnes à travers toute la Belgique bénéficient de ce
+                programme spécifique conçu pour réduire la fatigue, contribuer à
+                leur bien-être et faciliter la reprise d’une vie quotidienne
+                aussi normale que possible. Les participants peuvent choisir
+                parmi plusieurs types d’activités pour retrouver un équilibre
+                physique et psychologique : gymnastique, aquagym et marche
+                nordique pour le tonus, taï chi et yoga pour la détente et la
+                relaxation… Retrouver du tonus pour une meilleure qualité de vie
+                Les personnes traitées par chimiothérapie ou radiothérapie sont
+                souvent confrontées à des effets secondaires, dont le plus
+                fréquent est une fatigue physique intense. 60 à 90 % des
+                patients en font l’expérience. Chaque activité, même minime,
+                peut alors provoquer une sensation d’épuisement que le repos ne
+                vient pas soulager. Une telle fatigue altère la qualité de vie
+                des patients de par ses conséquences physiques, psychologiques
+                et sociales. Avec le programme Raviva, la Fondation contre le
+                Cancer a pour objectif d’améliorer progressivement la condition
+                physique des (ex-)patients pour leur permettre de retrouver le
+                tonus indispensable à leurs activités quotidiennes, sociales ou
+                professionnelles. De nombreuses études ont montré l’impact
+                positif des exercices physiques chez les personnes atteintes
+                d’un cancer, pour leur permettre de retrouver de la force et de
+                la masse musculaire, mais aussi de réduire la fatigue physique
+                grâce à l’entraînement progressif de leur endurance. Il y a bien
+                sûr aussi des atouts pour le bien-être psychologique du patient,
+                qui se sent mieux dans son corps, reprend confiance en ses
+                capacités physiques, retrouve une activité sociale régulière, se
+                sent moins déprimé et moins anxieux. C’est de cette manière
+                qu’Arnold, 50 ans, apprécie le programme Raviva : « Avec le
+                sport, je m’évade, je m’éloigne de la maladie. C’est pour moi la
+                preuve que je suis sur la voie de la guérison, car je retrouve
+                progressivement les capacités physiques d’avant mon traitement
+                ». Un programme de transition élaboré par des professionnels Les
+                patients peuvent accéder à Raviva pendant et jusqu’à un an après
+                la fin de leurs traitements : sur l’ensemble du pays, plus de
+                900 personnes participent aujourd’hui au programme, dont 94 % de
+                femmes (pour trois quarts d’entre elles après un cancer du
+                sein). Les activités du programme sont élaborées sur mesure par
+                des professionnels de la rééducation physique, en collaboration
+                avec des spécialistes en cancérologie. Proposé comme activité
+                physique de transition, le programme permet de retrouver
+                progressivement l’énergie nécessaire pour assurer la reprise des
+                tâches quotidiennes, comme l’explique Marianne : « Je participe
+                au programme deux fois par semaine, et je combine plusieurs
+                types d’activités : vélo, rameur, marche sur le tapis, et
+                quelques exercices des bras. Je ressens les effets dans ma vie
+                quotidienne : je peux maintenant à nouveau monter les escaliers
+                avec un panier de linge ! ». Le but est donc clairement que les
+                participants à Raviva puissent, au terme de quelques mois ou
+                d’un an de pratique, quitter cette structure spécifique pour
+                reprendre une vie active aussi normale que possible. Une palette
+                d’activités sur mesure Pour satisfaire aux besoins d’un maximum
+                de patients, Raviva propose une offre adaptée à la situation et
+                aux contraintes physiques de chacun : gymnastique, aquagym et
+                marche nordique pour améliorer la condition physique, taï chi et
+                yoga pour se détendre et retrouver la forme en douceur. Un
+                moniteur du programme Raviva témoigne de l’importance d’un
+                programme adapté à chaque participant : « Les sessions sont
+                établies en fonction des capacités de chacun et évoluent
+                progressivement : certaines personnes viennent la première fois
+                pour faire 5 minutes de course sur le tapis, et parviendront à
+                faire 20 minutes après quelques séances. Ils ont un objectif et
+                c’est très stimulant ! ».
+            </cdb:longdescription>
+            <cdb:shortdescription>
+                • un programme d’activités physiques spécialement conçu pour les
+                personnes majeures atteintes, ou ayant été récemment atteintes,
+                d’un cancer. • RaViva vous aide à retrouver une meilleure
+                condition physique et ainsi combattre la fatigue par des
+                activités pratiquées en groupe). • Patients en cours de
+                traitement ou un an après la fin de celui-ci peuvent participer
+                gratuitement pendant un an.
+            </cdb:shortdescription>
+            <cdb:title>Raviva - TaiQi</cdb:title>
+        </cdb:eventdetail>
+    </cdb:eventdetails>
+    <cdb:languages>
+        <cdb:language type="spoken">Nederlands</cdb:language>
+        <cdb:language type="spoken">Frans</cdb:language>
+        <cdb:language type="spoken">Engels</cdb:language>
+    </cdb:languages>
+    <cdb:keywords>
+        beweging;kanker;vermoeidheid;herstel;Rekanto;TaiQi;wijk__arsenaal
+    </cdb:keywords>
+    <cdb:location>
+        <cdb:address>
+            <cdb:physical>
+                <cdb:city>Mechelen</cdb:city>
+                <cdb:country>BE</cdb:country>
+                <cdb:gis>
+                    <cdb:xcoordinate>4.485984</cdb:xcoordinate>
+                    <cdb:ycoordinate>51.015051</cdb:ycoordinate>
+                </cdb:gis>
+                <cdb:housenr>57</cdb:housenr>
+                <cdb:street>Bautersemstraat</cdb:street>
+                <cdb:zipcode>2800</cdb:zipcode>
+            </cdb:physical>
+        </cdb:address>
+        <cdb:label>Sporthal IHAM</cdb:label>
+    </cdb:location>
+    <cdb:organiser>
+        <cdb:label>Test organizer</cdb:label>
+    </cdb:organiser>
+</cdb:event>

--- a/tests/Event/samples/event_with_all_icon_labels.json
+++ b/tests/Event/samples/event_with_all_icon_labels.json
@@ -10,12 +10,16 @@
     "@id": "http:\/\/culudb-silex.dev:8080\/place\/A871DB85-01DB-DBD3-DAF62CDB2DD7B871",
     "@context": "\/api\/1.0\/place.jsonld",
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
-    "name": "Cultuurcentrum De Kruisboog",
+    "name": {
+      "nl": "Cultuurcentrum De Kruisboog"
+    },
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +31,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/Event/samples/event_with_typical_age_range.json
+++ b/tests/Event/samples/event_with_typical_age_range.json
@@ -10,12 +10,16 @@
     "@id": "http:\/\/culudb-silex.dev:8080\/place\/A871DB85-01DB-DBD3-DAF62CDB2DD7B871",
     "@context": "\/api\/1.0\/place.jsonld",
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
-    "name": "Cultuurcentrum De Kruisboog",
+    "name": {
+      "nl": "Cultuurcentrum De Kruisboog"
+    },
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +31,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/Event/samples/event_with_udb3_place.json
+++ b/tests/Event/samples/event_with_udb3_place.json
@@ -24,10 +24,12 @@
     "available": "2016-04-13T10:41:57+02:00",
     "sameAs": [],
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Leuven",
-      "postalCode": "3000",
-      "streetAddress": "teststraat 44"
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Leuven",
+        "postalCode": "3000",
+        "streetAddress": "teststraat 44"
+      }
     },
     "bookingInfo": {
       "description": "",

--- a/tests/EventExport/samples/event_with_all_icon_labels.json
+++ b/tests/EventExport/samples/event_with_all_icon_labels.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl":"Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_booking_info.json
+++ b/tests/EventExport/samples/event_with_booking_info.json
@@ -12,10 +12,12 @@
       "nl": "SMAK"
     },
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Gent",
-      "postalCode": "9000",
-      "streetAddress": "Jan Hoetplein 1"
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Gent",
+        "postalCode": "9000",
+        "streetAddress": "Jan Hoetplein 1"
+      }
     },
     "calendarType": "permanent",
     "availableTo": "2100-01-01T00:00:00+00:00",
@@ -59,7 +61,9 @@
     "@id": "https:\/\/udb-silex-test.uitdatabank.be\/organizers\/6bd731a8-598d-460f-b534-98a604fc4983",
     "@context": "\/contexts\/organizer",
     "url": "http:\/\/smak.be",
-    "name": "SMAK",
+    "name": {
+      "nl": "SMAK"
+    },
     "created": "2016-12-01T09:13:26+00:00",
     "creator": "83b90b27-0ce3-449a-9816-2cf1e44ab56e (BLE)",
     "address": {

--- a/tests/EventExport/samples/event_with_dates.json
+++ b/tests/EventExport/samples/event_with_dates.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_dummy_location.json
+++ b/tests/EventExport/samples/event_with_dummy_location.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "isDummyPlaceForEducationEvents": true
   },
@@ -30,15 +32,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_html_description.json
+++ b/tests/EventExport/samples/event_with_html_description.json
@@ -13,10 +13,12 @@
     "description": "De Wildeman is een gezellig gemeenschapscentrum in Herent aan de rand van leuven. Al meer dan tien jaar komen hier grote namen en lokale sterren. Theater, Muziek, Cabaret,.. De Wildeman biedt, vanop de eerste rij, cultuur aan democratische prijzen. Kortom: een gezellige avond uit!",
     "name": {"nl": "GC De Wildeman"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Herent",
-      "postalCode": "3020",
-      "streetAddress": "Schoolstraat 15"
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Herent",
+        "postalCode": "3020",
+        "streetAddress": "Schoolstraat 15"
+      }
     },
     "priceInfo": [
       {
@@ -55,7 +57,9 @@
     ]
   },
   "organizer": {
-    "name": "gc de wildeman",
+    "name": {
+      "nl": "gc de wildeman"
+    },
     "email": ["info@gcdewildeman.be"],
     "phone": ["016 211 431"],
     "@type": "Organizer"

--- a/tests/EventExport/samples/event_with_icon_label.json
+++ b/tests/EventExport/samples/event_with_icon_label.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_incorrect_start_and_end_date_format.json
+++ b/tests/EventExport/samples/event_with_incorrect_start_and_end_date_format.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_location_coordinates.json
+++ b/tests/EventExport/samples/event_with_location_coordinates.json
@@ -22,15 +22,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_main_image.json
+++ b/tests/EventExport/samples/event_with_main_image.json
@@ -38,10 +38,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -53,15 +55,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_outdated_start_and_end_date_format.json
+++ b/tests/EventExport/samples/event_with_outdated_start_and_end_date_format.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_price.json
+++ b/tests/EventExport/samples/event_with_price.json
@@ -13,10 +13,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     }
   },
   "priceInfo": [
@@ -36,15 +38,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_see_also_imported_from_udb2.json
+++ b/tests/EventExport/samples/event_with_see_also_imported_from_udb2.json
@@ -12,26 +12,32 @@
   "calendarSummary": "do 21\/04\/16 om 20:00 ",
   "location": {
     "@type": "Place",
-    "name": "Rode Zaal",
+    "name": {
+      "nl": "Rode Zaal"
+    },
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Scherpenheuvel",
-      "postalCode": "3270",
-      "streetAddress": "August Nihoulstraat 74"
-    }
-  },
-  "organizer": {
-    "@id": "https:\/\/io.uitdatabank.be\/organizer\/289C4681-EE51-8AD8-A7851C6434767415",
-    "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "GC Den Egger",
-    "addresses": [
-      {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Scherpenheuvel",
         "postalCode": "3270",
         "streetAddress": "August Nihoulstraat 74"
       }
-    ],
+    }
+  },
+  "organizer": {
+    "@id": "https:\/\/io.uitdatabank.be\/organizer\/289C4681-EE51-8AD8-A7851C6434767415",
+    "@context": "\/api\/1.0\/organizer.jsonld",
+    "name": {
+      "nl": "GC Den Egger"
+    },
+    "address": {
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Scherpenheuvel",
+        "postalCode": "3270",
+        "streetAddress": "August Nihoulstraat 74"
+      }
+    },
     "email": [
       "info@denegger.be"
     ],

--- a/tests/EventExport/samples/event_with_terms.json
+++ b/tests/EventExport/samples/event_with_terms.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     }
   },
   "priceInfo": [
@@ -29,15 +31,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_translated_address.json
+++ b/tests/EventExport/samples/event_with_translated_address.json
@@ -31,15 +31,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_translated_address_and_main_language.json
+++ b/tests/EventExport/samples/event_with_translated_address_and_main_language.json
@@ -32,17 +32,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
-        "nl" : {
-          "addressCountry": "BE",
-          "addressLocality": "Leuven",
-          "postalCode": "3000",
-          "streetAddress": "Blijde-Inkomststraat 77"
-        }
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Leuven",
+        "postalCode": "3000",
+        "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_translated_organizer.json
+++ b/tests/EventExport/samples/event_with_translated_organizer.json
@@ -24,14 +24,14 @@
     "name": {
       "nl": "Davidsfonds Academie"
     },
-    "addresses": [
-      {
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_translated_organizer_and_main_language.json
+++ b/tests/EventExport/samples/event_with_translated_organizer_and_main_language.json
@@ -25,14 +25,14 @@
     "name": {
       "es": "Davidsfonds Academie"
     },
-    "addresses": [
-      {
+    "address": {
+      "es": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_with_unwanted_line_breaks.json
+++ b/tests/EventExport/samples/event_with_unwanted_line_breaks.json
@@ -12,16 +12,22 @@
   "calendarSummary": "di 12\/04\/16 van 20:00 tot 22:00 ",
   "location": {
     "@type": "Place",
-    "name": "Merelbeke, Floracenter, Teaterstraat 39",
+    "name": {
+      "nl": "Merelbeke, Floracenter, Teaterstraat 39"
+    },
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Merelbeke",
-      "postalCode": "9820",
-      "streetAddress": "Teaterstraat 39"
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Merelbeke",
+        "postalCode": "9820",
+        "streetAddress": "Teaterstraat 39"
+      }
     }
   },
   "organizer": {
-    "name": "markant Melle Merelbeke",
+    "name": {
+      "nl": "markant Melle Merelbeke"
+    },
     "@type": "Organizer"
   },
   "bookingInfo": [

--- a/tests/EventExport/samples/event_with_visible_and_hidden_labels.json
+++ b/tests/EventExport/samples/event_with_visible_and_hidden_labels.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_description.json
+++ b/tests/EventExport/samples/event_without_description.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     }
   },
   "priceInfo": [
@@ -29,15 +31,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": [
       "academie@davidsfonds.be"
     ],

--- a/tests/EventExport/samples/event_without_end_date.json
+++ b/tests/EventExport/samples/event_without_end_date.json
@@ -12,10 +12,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_eventtype.json
+++ b/tests/EventExport/samples/event_without_eventtype.json
@@ -15,10 +15,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     }
   },
   "priceInfo": [
@@ -32,15 +34,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": [
       "academie@davidsfonds.be"
     ],

--- a/tests/EventExport/samples/event_without_image.json
+++ b/tests/EventExport/samples/event_without_image.json
@@ -11,10 +11,12 @@
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "name": {"nl": "Cultuurcentrum De Kruisboog"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     },
     "bookingInfo": {
       "description": "",
@@ -26,15 +28,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_location.json
+++ b/tests/EventExport/samples/event_without_location.json
@@ -15,15 +15,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_location_address.json
+++ b/tests/EventExport/samples/event_without_location_address.json
@@ -22,15 +22,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_location_name.json
+++ b/tests/EventExport/samples/event_without_location_name.json
@@ -10,10 +10,12 @@
     "@context": "\/api\/1.0\/place.jsonld",
     "description": "Voor een boeiend avondje cultuur, is er in Tienen cultuurcentrum De Kruisboog. Het centrum heeft een eigen programmatie, maar staat ook open voor activiteiten van plaatselijke verenigingen.",
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Tienen",
-      "postalCode": "3300",
-      "streetAddress": "Sint-Jorisplein 20 "
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Tienen",
+        "postalCode": "3300",
+        "streetAddress": "Sint-Jorisplein 20 "
+      }
     }
   },
   "priceInfo": [
@@ -27,15 +29,17 @@
   "organizer": {
     "@id": "http:\/\/culudb-silex.dev:8080\/organizer\/7481A1F9-D5CB-3BC9-D3C308240015B44D",
     "@context": "\/api\/1.0\/organizer.jsonld",
-    "name": "Davidsfonds Academie",
-    "addresses": [
-      {
+    "name": {
+      "nl": "Davidsfonds Academie"
+    },
+    "address": {
+      "nl": {
         "addressCountry": "BE",
         "addressLocality": "Leuven",
         "postalCode": "3000",
         "streetAddress": "Blijde-Inkomststraat 77"
       }
-    ],
+    },
     "email": ["academie@davidsfonds.be"],
     "phone": [
       "+32 16 310670",

--- a/tests/EventExport/samples/event_without_priceinfo.json
+++ b/tests/EventExport/samples/event_without_priceinfo.json
@@ -12,10 +12,12 @@
     "description": "De Wildeman is een gezellig gemeenschapscentrum in Herent aan de rand van leuven. Al meer dan tien jaar komen hier grote namen en lokale sterren. Theater, Muziek, Cabaret,.. De Wildeman biedt, vanop de eerste rij, cultuur aan democratische prijzen. Kortom: een gezellige avond uit!",
     "name": {"nl": "GC De Wildeman"},
     "address": {
-      "addressCountry": "BE",
-      "addressLocality": "Herent",
-      "postalCode": "3020",
-      "streetAddress": "Schoolstraat 15"
+      "nl": {
+        "addressCountry": "BE",
+        "addressLocality": "Herent",
+        "postalCode": "3020",
+        "streetAddress": "Schoolstraat 15"
+      }
     },
     "bookingInfo": {
       "description": "",


### PR DESCRIPTION
### Fixed

- Fixed events imported from XML with an organizer without an id so they have the correct name format.

---
Ticket: https://jira.uitdatabank.be/browse/III-3584

Notes: 
- In the first commit I just fixed the same format in existing test data. However, this didn't break any tests. I think because the tests don't actually do anything with those specific properties in those files.
- I still have to re-add the fallback to deal with this incorrect format in SAPI3, because we cannot do a full replay right away to fix this for all existing events with an organizer like this. The fallbacks were removed in https://github.com/cultuurnet/udb3-search-service/pull/70 because we thought we had cleaned up all of these old formats.
