### PR TITLE
III-3583 use document repository in place read controller

### DIFF
--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -23,7 +23,7 @@ class PlaceControllerProvider implements ControllerProviderInterface
         $app['place_controller'] = $app->share(
             function (Application $app) {
                 return new ReadPlaceRestController(
-                    $app['place_service'],
+                    $app['place_jsonld_repository'],
                     $app['search_serializer']
                 );
             }

--- a/src/Doctrine/ReadModel/CacheDocumentRepository.php
+++ b/src/Doctrine/ReadModel/CacheDocumentRepository.php
@@ -3,7 +3,7 @@
 namespace CultuurNet\UDB3\Doctrine\ReadModel;
 
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use Doctrine\Common\Cache\Cache;
@@ -22,11 +22,11 @@ class CacheDocumentRepository implements DocumentRepository
         $value = $this->cache->fetch($id);
 
         if ($value === 'GONE') {
-            throw DocumentDoesNotExistException::gone($id);
+            throw DocumentDoesNotExist::gone($id);
         }
 
         if ($value === false) {
-            throw DocumentDoesNotExistException::notFound($id);
+            throw DocumentDoesNotExist::notFound($id);
         }
 
         return new JsonDocument($id, $value);

--- a/src/Doctrine/ReadModel/CacheDocumentRepository.php
+++ b/src/Doctrine/ReadModel/CacheDocumentRepository.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3\Doctrine\ReadModel;
 
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use Doctrine\Common\Cache\Cache;
@@ -14,6 +15,21 @@ class CacheDocumentRepository implements DocumentRepository
     public function __construct(Cache $cache)
     {
         $this->cache = $cache;
+    }
+
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        $value = $this->cache->fetch($id);
+
+        if ($value === 'GONE') {
+            throw DocumentDoesNotExistException::gone($id);
+        }
+
+        if ($value === false) {
+            throw DocumentDoesNotExistException::notFound($id);
+        }
+
+        return new JsonDocument($id, $value);
     }
 
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument

--- a/src/Event/Productions/ProductionEnrichedEventRepository.php
+++ b/src/Event/Productions/ProductionEnrichedEventRepository.php
@@ -30,6 +30,13 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
         $this->iriGenerator = $iriGenerator;
     }
 
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        return $this->enrich(
+            parent::fetch($id, $includeMetadata)
+        );
+    }
+
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
         $document = parent::get($id);
@@ -38,7 +45,13 @@ class ProductionEnrichedEventRepository extends DocumentRepositoryDecorator
             return null;
         }
 
+        return $this->enrich($document);
+    }
+
+    private function enrich(JsonDocument $document): JsonDocument
+    {
         $jsonObject = $document->getBody();
+        $id = $document->getId();
 
         try {
             $production = $this->productionRepository->findProductionForEventId($id);

--- a/src/Event/ReadModel/DocumentGoneException.php
+++ b/src/Event/ReadModel/DocumentGoneException.php
@@ -2,6 +2,9 @@
 
 namespace CultuurNet\UDB3\Event\ReadModel;
 
+/**
+ * @deprecated Use DocumentDoesNotExistException::gone() instead.
+ */
 class DocumentGoneException extends \RuntimeException
 {
     public function __construct($message = '', $code = 410, \Exception $previous = null)

--- a/src/Http/Event/ReadEventRestController.php
+++ b/src/Http/Event/ReadEventRestController.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\Http\ApiProblemJsonResponseTrait;
 use CultuurNet\UDB3\Http\Management\User\UserIdentificationInterface;
 use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -63,7 +63,7 @@ class ReadEventRestController
 
         try {
             $event = $this->jsonRepository->fetch($cdbid, $includeMetadata);
-        } catch (DocumentDoesNotExistException $e) {
+        } catch (DocumentDoesNotExist $e) {
             return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
         }
 

--- a/src/Http/Event/ReadEventRestController.php
+++ b/src/Http/Event/ReadEventRestController.php
@@ -6,13 +6,12 @@ use CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\CalendarPlainTextFormatter;
 use CultuurNet\SearchV3\Serializer\SerializerInterface;
 use CultuurNet\SearchV3\ValueObjects\Event;
-use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\Http\ApiProblemJsonResponseTrait;
 use CultuurNet\UDB3\Http\Management\User\UserIdentificationInterface;
 use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
-use CultuurNet\UDB3\ReadModel\JsonDocument;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -63,8 +62,8 @@ class ReadEventRestController
         $includeMetadata = (bool) $request->query->get('includeMetadata', false);
 
         try {
-            $event = $this->getEventDocument($cdbid, $includeMetadata);
-        } catch (EntityNotFoundException $e) {
+            $event = $this->jsonRepository->fetch($cdbid, $includeMetadata);
+        } catch (DocumentDoesNotExistException $e) {
             return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
         }
 
@@ -123,7 +122,7 @@ class ReadEventRestController
         $timeZone = $request->query->get('timeZone', 'Europe/Brussels');
         $format = $request->query->get('format', 'lg');
 
-        $eventDocument = $this->getEventDocument($cdbid);
+        $eventDocument = $this->jsonRepository->fetch($cdbid);
         $event = $this->serializer->deserialize($eventDocument->getRawBody(), Event::class);
 
         if ($style !== 'html' && $style !== 'text') {
@@ -139,25 +138,5 @@ class ReadEventRestController
 
 
         return $response;
-    }
-
-    /**
-     * @throws EntityNotFoundException
-     */
-    private function getEventDocument(string $id, bool $includeMetadata = false): JsonDocument
-    {
-        $notFoundException = new EntityNotFoundException("Event with id: {$id} not found");
-
-        try {
-            $document = $this->jsonRepository->get($id, $includeMetadata);
-        } catch (DocumentGoneException $e) {
-            throw $notFoundException;
-        }
-
-        if (!$document) {
-            throw $notFoundException;
-        }
-
-        return $document;
     }
 }

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -8,7 +8,7 @@ use CultuurNet\SearchV3\Serializer\SerializerInterface;
 use CultuurNet\SearchV3\ValueObjects\Place;
 use CultuurNet\UDB3\Http\ApiProblemJsonResponseTrait;
 use CultuurNet\UDB3\Http\JsonLdResponse;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,7 +45,7 @@ class ReadPlaceRestController
 
         try {
             $place = $this->documentRepository->fetch($cdbid, $includeMetadata);
-        } catch (DocumentDoesNotExistException $e) {
+        } catch (DocumentDoesNotExist $e) {
             return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
         }
 

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -40,10 +40,12 @@ class ReadPlaceRestController
         $this->serializer = $serializer;
     }
 
-    public function get(string $cdbid): JsonResponse
+    public function get(string $cdbid, Request $request): JsonResponse
     {
+        $includeMetadata = $request->query->get('includeMetadata', false);
+
         try {
-            $place = $this->getEventDocument($cdbid, false);
+            $place = $this->getEventDocument($cdbid, $includeMetadata);
         } catch (EntityNotFoundException $e) {
             return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
         }

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -46,7 +46,7 @@ class ReadPlaceRestController
         $includeMetadata = $request->query->get('includeMetadata', false);
 
         try {
-            $place = $this->getEventDocument($cdbid, $includeMetadata);
+            $place = $this->getPlaceDocument($cdbid, $includeMetadata);
         } catch (EntityNotFoundException $e) {
             return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
         }
@@ -67,7 +67,7 @@ class ReadPlaceRestController
         $timeZone = $request->query->get('timeZone', 'Europe/Brussels');
         $format = $request->query->get('format', 'lg');
 
-        $data = $this->getEventDocument($cdbid, false);
+        $data = $this->getPlaceDocument($cdbid, false);
         $place = $this->serializer->deserialize($data->getRawBody(), Place::class);
 
         if ($style !== 'html' && $style !== 'text') {
@@ -86,7 +86,7 @@ class ReadPlaceRestController
     /**
      * @throws EntityNotFoundException
      */
-    private function getEventDocument(string $id, bool $includeMetadata): JsonDocument
+    private function getPlaceDocument(string $id, bool $includeMetadata): JsonDocument
     {
         $notFoundException = new EntityNotFoundException("Event with id: {$id} not found");
 

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpFoundation\Request;
 class ReadPlaceRestController
 {
     const GET_ERROR_NOT_FOUND = 'An error occurred while getting the event with id %s!';
-    const GET_ERROR_GONE = 'An error occurred while getting the event with id %s which was removed!';
 
     use ApiProblemJsonResponseTrait;
 

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -6,6 +6,7 @@ use CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\CalendarPlainTextFormatter;
 use CultuurNet\SearchV3\Serializer\SerializerInterface;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Http\ApiProblemJsonResponseTrait;
 use CultuurNet\UDB3\Http\JsonLdResponse;
@@ -42,18 +43,16 @@ class ReadPlaceRestController
 
     public function get(string $cdbid): JsonResponse
     {
-        $response = null;
+        try {
+            $place = $this->service->getEntity($cdbid);
+        } catch (EntityNotFoundException $e) {
+            return $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
+        }
 
-        $place = $this->service->getEntity($cdbid);
-
-        if ($place) {
-            $response = JsonLdResponse::create()
-                ->setContent($place);
+        $response = JsonLdResponse::create()
+            ->setContent($place);
 
             $response->headers->set('Vary', 'Origin');
-        } else {
-            $response = $this->createApiProblemJsonResponseNotFound(self::GET_ERROR_NOT_FOUND, $cdbid);
-        }
 
         return $response;
     }

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -14,10 +14,11 @@ use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class ReadPlaceRestController
 {
-    const GET_ERROR_NOT_FOUND = 'An error occurred while getting the event with id %s!';
+    private const GET_ERROR_NOT_FOUND = 'An error occurred while getting the event with id %s!';
 
     use ApiProblemJsonResponseTrait;
 
@@ -58,16 +59,8 @@ class ReadPlaceRestController
         return $response;
     }
 
-    /**
-     * @param string $cdbid
-     *
-     * @return string
-     */
-    public function getCalendarSummary($cdbid, Request $request)
+    public function getCalendarSummary($cdbid, Request $request): Response
     {
-        $data = null;
-        $response = null;
-
         $style = $request->query->get('style', 'text');
         $langCode = $request->query->get('langCode', 'nl_BE');
         $hidePastDates = $request->query->get('hidePast', false);
@@ -78,17 +71,16 @@ class ReadPlaceRestController
         $place = $this->serializer->deserialize($data->getRawBody(), Place::class);
 
         if ($style !== 'html' && $style !== 'text') {
-            $response = $this->createApiProblemJsonResponseNotFound('No style found for ' . $style, $cdbid);
-        } else {
-            if ($style === 'html') {
-                $calSum = new CalendarHTMLFormatter($langCode, $hidePastDates, $timeZone);
-            } else {
-                $calSum = new CalendarPlainTextFormatter($langCode, $hidePastDates, $timeZone);
-            }
-            $response = $calSum->format($place, $format);
+            return $this->createApiProblemJsonResponseNotFound('No style found for ' . $style, $cdbid);
         }
 
-        return $response;
+        if ($style === 'html') {
+            $calSum = new CalendarHTMLFormatter($langCode, $hidePastDates, $timeZone);
+        } else {
+            $calSum = new CalendarPlainTextFormatter($langCode, $hidePastDates, $timeZone);
+        }
+
+        return new Response($calSum->format($place, $format));
     }
 
     /**

--- a/src/Place/DummyPlaceProjectionEnricher.php
+++ b/src/Place/DummyPlaceProjectionEnricher.php
@@ -27,7 +27,7 @@ class DummyPlaceProjectionEnricher implements DocumentRepository
 
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
-        $readModel = $this->repository->get($id);
+        $readModel = $this->repository->get($id, $includeMetadata);
         if (!$readModel) {
             return $readModel;
         }

--- a/src/Place/DummyPlaceProjectionEnricher.php
+++ b/src/Place/DummyPlaceProjectionEnricher.php
@@ -15,7 +15,7 @@ class DummyPlaceProjectionEnricher implements DocumentRepository
     /**
      * @var string[]
      */
-    private $dummyPlaceIds = [];
+    private $dummyPlaceIds;
 
     public function __construct(
         DocumentRepository $repository,
@@ -25,6 +25,13 @@ class DummyPlaceProjectionEnricher implements DocumentRepository
         $this->dummyPlaceIds = $dummyPlaceIds;
     }
 
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        return $this->enrich(
+            $this->repository->fetch($id)
+        );
+    }
+
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
         $readModel = $this->repository->get($id, $includeMetadata);
@@ -32,14 +39,7 @@ class DummyPlaceProjectionEnricher implements DocumentRepository
             return $readModel;
         }
 
-        foreach ($this->dummyPlaceIds as $dummyPlaceId) {
-            $body = $readModel->getBody();
-            if (strpos($body->{'@id'}, $dummyPlaceId) !== false) {
-                $body->isDummyPlaceForEducationEvents = true;
-                return $readModel->withBody($body);
-            }
-        }
-        return $readModel;
+        return $this->enrich($readModel);
     }
 
     public function save(JsonDocument $readModel): void
@@ -50,5 +50,17 @@ class DummyPlaceProjectionEnricher implements DocumentRepository
     public function remove($id): void
     {
         $this->repository->remove($id);
+    }
+
+    private function enrich(JsonDocument $readModel): JsonDocument
+    {
+        foreach ($this->dummyPlaceIds as $dummyPlaceId) {
+            $body = $readModel->getBody();
+            if (strpos($body->{'@id'}, $dummyPlaceId) !== false) {
+                $body->isDummyPlaceForEducationEvents = true;
+                return $readModel->withBody($body);
+            }
+        }
+        return $readModel;
     }
 }

--- a/src/ReadModel/DocumentDoesNotExist.php
+++ b/src/ReadModel/DocumentDoesNotExist.php
@@ -6,17 +6,17 @@ namespace CultuurNet\UDB3\ReadModel;
 
 use Exception;
 
-final class DocumentDoesNotExistException extends Exception
+final class DocumentDoesNotExist extends Exception
 {
     private const NOT_FOUND = 404;
     private const GONE = 410;
 
-    public static function notFound(string $id): DocumentDoesNotExistException
+    public static function notFound(string $id): DocumentDoesNotExist
     {
         return new self("Document with id ${id} not found.", self::NOT_FOUND);
     }
 
-    public static function gone(string $id): DocumentDoesNotExistException
+    public static function gone(string $id): DocumentDoesNotExist
     {
         return new self("Document with id ${id} was removed.", self::GONE);
     }

--- a/src/ReadModel/DocumentDoesNotExistException.php
+++ b/src/ReadModel/DocumentDoesNotExistException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\ReadModel;
+
+use Exception;
+
+final class DocumentDoesNotExistException extends Exception
+{
+    private const NOT_FOUND = 404;
+    private const GONE = 410;
+
+    public static function notFound(string $id): DocumentDoesNotExistException
+    {
+        return new self("Document with id ${id} not found.", self::NOT_FOUND);
+    }
+
+    public static function gone(string $id): DocumentDoesNotExistException
+    {
+        return new self("Document with id ${id} was removed.", self::GONE);
+    }
+
+    public function isNotFound(): bool
+    {
+        return $this->code === self::NOT_FOUND;
+    }
+
+    public function isGone(): bool
+    {
+        return $this->code === self::GONE;
+    }
+}

--- a/src/ReadModel/DocumentRepository.php
+++ b/src/ReadModel/DocumentRepository.php
@@ -7,7 +7,7 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 interface DocumentRepository
 {
     /**
-     * @throws DocumentDoesNotExistException
+     * @throws DocumentDoesNotExist
      */
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument;
 

--- a/src/ReadModel/DocumentRepository.php
+++ b/src/ReadModel/DocumentRepository.php
@@ -7,6 +7,13 @@ use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 interface DocumentRepository
 {
     /**
+     * @throws DocumentDoesNotExistException
+     */
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument;
+
+    /**
+     * @deprecated use DocumentRepository::fetch() instead for easier error handling in case the document does not
+     *   exist.
      * @throws DocumentGoneException
      */
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument;

--- a/src/ReadModel/DocumentRepositoryDecorator.php
+++ b/src/ReadModel/DocumentRepositoryDecorator.php
@@ -16,7 +16,7 @@ abstract class DocumentRepositoryDecorator implements DocumentRepository
 
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
-        return $this->decoratedRepository->get($id);
+        return $this->decoratedRepository->get($id, $includeMetadata);
     }
 
     public function save(JsonDocument $readModel): void

--- a/src/ReadModel/DocumentRepositoryDecorator.php
+++ b/src/ReadModel/DocumentRepositoryDecorator.php
@@ -14,6 +14,11 @@ abstract class DocumentRepositoryDecorator implements DocumentRepository
         $this->decoratedRepository = $repository;
     }
 
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        return $this->decoratedRepository->fetch($id, $includeMetadata);
+    }
+
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
         return $this->decoratedRepository->get($id, $includeMetadata);

--- a/src/ReadModel/InMemoryDocumentRepository.php
+++ b/src/ReadModel/InMemoryDocumentRepository.php
@@ -11,6 +11,19 @@ class InMemoryDocumentRepository implements DocumentRepository
      */
     private $documents;
 
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        if (!isset($this->documents[$id])) {
+            throw DocumentDoesNotExistException::notFound($id);
+        }
+
+        if ('GONE' === $this->documents[$id]) {
+            throw DocumentDoesNotExistException::gone($id);
+        }
+
+        return $this->documents[$id];
+    }
+
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
     {
         if (isset($this->documents[$id])) {

--- a/src/ReadModel/InMemoryDocumentRepository.php
+++ b/src/ReadModel/InMemoryDocumentRepository.php
@@ -14,11 +14,11 @@ class InMemoryDocumentRepository implements DocumentRepository
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
     {
         if (!isset($this->documents[$id])) {
-            throw DocumentDoesNotExistException::notFound($id);
+            throw DocumentDoesNotExist::notFound($id);
         }
 
         if ('GONE' === $this->documents[$id]) {
-            throw DocumentDoesNotExistException::gone($id);
+            throw DocumentDoesNotExist::gone($id);
         }
 
         return $this->documents[$id];

--- a/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
+++ b/tests/Event/Productions/ProductionEnrichedEventRepositoryTest.php
@@ -57,15 +57,21 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
         );
 
 
-        $this->eventRepository->method('get')->willReturn($originalJsonDocument);
+        $this->eventRepository->method('fetch')->with($eventId)->willReturn($originalJsonDocument);
+        $this->eventRepository->method('get')->with($eventId)->willReturn($originalJsonDocument);
+
         $this->productionRepository->method('findProductionForEventId')->willThrowException(
             new EntityNotFoundException()
         );
 
-        $actual = $this->productionEnrichedEventRepository->get($eventId);
+        $fetchActual = $this->productionEnrichedEventRepository->fetch($eventId);
+        $getActual = $this->productionEnrichedEventRepository->get($eventId);
 
-        $this->assertEquals($eventId, $actual->getBody()->{'@id'});
-        $this->assertNull($actual->getBody()->production);
+        $this->assertEquals($eventId, $fetchActual->getBody()->{'@id'});
+        $this->assertEquals($eventId, $getActual->getBody()->{'@id'});
+
+        $this->assertNull($fetchActual->getBody()->production);
+        $this->assertNull($getActual->getBody()->production);
     }
 
     /**
@@ -91,22 +97,31 @@ class ProductionEnrichedEventRepositoryTest extends TestCase
             ]
         );
 
-        $this->eventRepository->method('get')->willReturn($originalJsonDocument);
+        $this->eventRepository->method('fetch')->with($eventId)->willReturn($originalJsonDocument);
+        $this->eventRepository->method('get')->with($eventId)->willReturn($originalJsonDocument);
         $this->productionRepository->method('findProductionForEventId')->willReturn($production);
         $this->iriGenerator->method('iri')->with($otherEventId)->willReturn('foo/' . $otherEventId);
 
-        $actual = $this->productionEnrichedEventRepository->get($eventId);
+        $fetchActual = $this->productionEnrichedEventRepository->fetch($eventId);
+        $getActual = $this->productionEnrichedEventRepository->get($eventId);
 
-        $this->assertEquals($eventId, $actual->getBody()->{'@id'});
-        $this->assertEquals($productionId->toNative(), $actual->getBody()->production->id);
-        $this->assertEquals($productionName, $actual->getBody()->production->title);
-        $this->assertEquals(['foo/' . $otherEventId], $actual->getBody()->production->otherEvents);
+        $this->assertEquals($eventId, $fetchActual->getBody()->{'@id'});
+        $this->assertEquals($eventId, $getActual->getBody()->{'@id'});
+
+        $this->assertEquals($productionId->toNative(), $fetchActual->getBody()->production->id);
+        $this->assertEquals($productionId->toNative(), $getActual->getBody()->production->id);
+
+        $this->assertEquals($productionName, $fetchActual->getBody()->production->title);
+        $this->assertEquals($productionName, $getActual->getBody()->production->title);
+
+        $this->assertEquals(['foo/' . $otherEventId], $fetchActual->getBody()->production->otherEvents);
+        $this->assertEquals(['foo/' . $otherEventId], $getActual->getBody()->production->otherEvents);
     }
 
     /**
      * @test
      */
-    public function it_will_return_null_for_a_non_existing_document(): void
+    public function it_will_return_null_when_getting_a_non_existing_document(): void
     {
         $eventId = Uuid::uuid4()->toString();
         $this->eventRepository->method('get')->willReturn(null);

--- a/tests/Http/Event/ReadEventRestControllerTest.php
+++ b/tests/Http/Event/ReadEventRestControllerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\EventServiceInterface;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\Http\Management\User\UserIdentificationInterface;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use DateTimeZone;
@@ -128,9 +128,9 @@ class ReadEventRestControllerTest extends TestCase
                         case self::EXISTING_ID:
                             return $includeMetadata ? $this->jsonDocumentWithMetadata : $this->jsonDocument;
                         case self::REMOVED_ID:
-                            throw DocumentDoesNotExistException::gone($id);
+                            throw DocumentDoesNotExist::gone($id);
                         default:
-                            throw DocumentDoesNotExistException::notFound($id);
+                            throw DocumentDoesNotExist::notFound($id);
                     }
                 }
             );
@@ -268,7 +268,7 @@ class ReadEventRestControllerTest extends TestCase
      */
     public function it_returns_a_http_response_with_error_NOT_FOUND_for_calendar_summary_for_non_existing_event(): void
     {
-        $this->expectException(DocumentDoesNotExistException::class);
+        $this->expectException(DocumentDoesNotExist::class);
 
         $request = new Request(array('style' => 'text', 'format' => 'lg'));
         $this->eventRestController->getCalendarSummary(self::NON_EXISTING_ID, $request);

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -148,6 +148,6 @@ class ReadPlaceRestControllerTest extends TestCase
         $request = new Request(['style' => 'text', 'format' => 'lg']);
         $calSumResponse = $this->placeRestController->getCalendarSummary(self::EXISTING_ID, $request);
 
-        $this->assertEquals($this->calSum, $calSumResponse);
+        $this->assertEquals($this->calSum, $calSumResponse->getContent());
     }
 }

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -6,6 +6,7 @@ use CultuurNet\SearchV3\Serializer\SerializerInterface;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -79,16 +80,16 @@ class ReadPlaceRestControllerTest extends TestCase
 
         /** @var DocumentRepository|MockObject $jsonRepository */
         $jsonRepository = $this->createMock(DocumentRepository::class);
-        $jsonRepository->method('get')
+        $jsonRepository->method('fetch')
             ->willReturnCallback(
                 function (string $id, bool $includeMetadata = false) {
                     switch ($id) {
                         case self::EXISTING_ID:
                             return $includeMetadata ? $this->jsonDocumentWithMetadata : $this->jsonDocument;
                         case self::REMOVED_ID:
-                            throw new DocumentGoneException();
+                            throw DocumentDoesNotExistException::gone($id);
                         default:
-                            return null;
+                            throw DocumentDoesNotExistException::notFound($id);
                     }
                 }
             );

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -6,7 +6,7 @@ use CultuurNet\SearchV3\Serializer\SerializerInterface;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExistException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -87,9 +87,9 @@ class ReadPlaceRestControllerTest extends TestCase
                         case self::EXISTING_ID:
                             return $includeMetadata ? $this->jsonDocumentWithMetadata : $this->jsonDocument;
                         case self::REMOVED_ID:
-                            throw DocumentDoesNotExistException::gone($id);
+                            throw DocumentDoesNotExist::gone($id);
                         default:
-                            throw DocumentDoesNotExistException::notFound($id);
+                            throw DocumentDoesNotExist::notFound($id);
                     }
                 }
             );

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -16,9 +16,9 @@ use CultuurNet\SearchV3\ValueObjects\Place;
 
 class ReadPlaceRestControllerTest extends TestCase
 {
-    const EXISTING_ID = 'existingId';
-    const NON_EXISTING_ID = 'nonExistingId';
-    const REMOVED_ID = 'removedId';
+    private const EXISTING_ID = 'existingId';
+    private const NON_EXISTING_ID = 'nonExistingId';
+    private const REMOVED_ID = 'removedId';
 
     /**
      * @var ReadPlaceRestController
@@ -110,7 +110,7 @@ class ReadPlaceRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_http_response_with_json_get_for_an_event()
+    public function it_returns_a_http_response_with_json_get_for_an_event(): void
     {
         $jsonResponse = $this->placeRestController->get(self::EXISTING_ID, new Request());
 
@@ -133,7 +133,7 @@ class ReadPlaceRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_http_response_with_error_NOT_FOUND_for_getting_a_non_existing_event()
+    public function it_returns_a_http_response_with_error_NOT_FOUND_for_getting_a_non_existing_event(): void
     {
         $jsonResponse = $this->placeRestController->get(self::NON_EXISTING_ID, new Request());
 
@@ -143,9 +143,9 @@ class ReadPlaceRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_http_response_with_a_calendar_summary_for_a_place()
+    public function it_returns_a_http_response_with_a_calendar_summary_for_a_place(): void
     {
-        $request = new Request(array('style' => 'text', 'format' => 'lg'));
+        $request = new Request(['style' => 'text', 'format' => 'lg']);
         $calSumResponse = $this->placeRestController->getCalendarSummary(self::EXISTING_ID, $request);
 
         $this->assertEquals($this->calSum, $calSumResponse);

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -53,8 +53,6 @@ class ReadPlaceRestControllerTest extends TestCase
         $this->place->setEndDate(new \DateTime('2018-10-07 18:00:00'));
         $this->place->setCalendarType('single');
 
-        $entityServiceInterface = $this->createMock(EntityServiceInterface::class);
-
         $serializerInterface = $this->createMock(SerializerInterface::class);
 
         /** @var DocumentRepository|MockObject $jsonRepository */

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3\Http\Place;
 
 use CultuurNet\SearchV3\Serializer\SerializerInterface;
+use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\EntityServiceInterface;
 use CultuurNet\UDB3\Event\ReadModel\DocumentGoneException;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -63,7 +64,7 @@ class ReadPlaceRestControllerTest extends TestCase
                         case self::REMOVED_ID:
                             throw new DocumentGoneException();
                         default:
-                            return null;
+                            throw new EntityNotFoundException();
                     }
                 }
             );

--- a/tests/Place/DummyPlaceProjectionEnricherTest.php
+++ b/tests/Place/DummyPlaceProjectionEnricherTest.php
@@ -53,10 +53,18 @@ class DummyPlaceProjectionEnricherTest extends TestCase
         $id = Uuid::uuid4()->toString();
         $eventJson = $this->getEventJsonForPlace($this->dummyPlaceId);
         $readModel = new JsonDocument($id, $eventJson);
+
+        $this->repository->expects($this->once())->method('fetch')->with($id)->willReturn($readModel);
         $this->repository->expects($this->once())->method('get')->with($id)->willReturn($readModel);
-        $enrichedReadModel = $this->enricher->get($id);
-        $this->assertNotEquals($readModel, $enrichedReadModel);
-        $this->assertTrue($enrichedReadModel->getBody()->isDummyPlaceForEducationEvents);
+
+        $fetchEnrichedReadModel = $this->enricher->fetch($id);
+        $getEnrichedReadModel = $this->enricher->get($id);
+
+        $this->assertNotEquals($readModel, $fetchEnrichedReadModel);
+        $this->assertNotEquals($readModel, $getEnrichedReadModel);
+
+        $this->assertTrue($fetchEnrichedReadModel->getBody()->isDummyPlaceForEducationEvents);
+        $this->assertTrue($getEnrichedReadModel->getBody()->isDummyPlaceForEducationEvents);
     }
 
     private function getEventJsonForPlace(string $placeId): string


### PR DESCRIPTION
### Changed

- Refactored place read controller to use document repository directly instead of a service in-between
- Deprecated `DocumentRepository::get()` in favor of a new `DocumentRepository::fetch()` which has more consistent error-handling

### Added

- Added `DocumentRepository::fetch()` which always throws if a document is not found, instead of either returning `null` if it's not found or throwing if it was deleted. The difference can still be deduced based on the `isNotFound()` and `isGone()` methods on the new exception type. 

---
Ticket: https://jira.uitdatabank.be/browse/III-3583

---

Note: The new `fetch()` method should also be useful for https://jira.uitdatabank.be/browse/III-3593 in which we want to remove a service that converts the `null` return value to an exception
