### PR TITLE
Avoid purging of the index_readmodel table

### DIFF
--- a/app/PurgeServiceProvider.php
+++ b/app/PurgeServiceProvider.php
@@ -60,8 +60,14 @@ class PurgeServiceProvider implements ServiceProviderInterface
         $dbalReadModels = [
             'event_permission_readmodel',
             'event_relations',
-            'place_relations',
+            'label_roles',
+            'labels_relations',
+            'organizer_permission_readmodel',
             'place_permission_readmodel',
+            'place_relations',
+            'role_permissions',
+            'roles_search_v3',
+            'user_roles'
         ];
 
         foreach ($dbalReadModels as $dbalReadModel) {

--- a/app/PurgeServiceProvider.php
+++ b/app/PurgeServiceProvider.php
@@ -67,7 +67,7 @@ class PurgeServiceProvider implements ServiceProviderInterface
             'place_relations',
             'role_permissions',
             'roles_search_v3',
-            'user_roles'
+            'user_roles',
         ];
 
         foreach ($dbalReadModels as $dbalReadModel) {

--- a/app/PurgeServiceProvider.php
+++ b/app/PurgeServiceProvider.php
@@ -61,7 +61,6 @@ class PurgeServiceProvider implements ServiceProviderInterface
             'event_permission_readmodel',
             'event_relations',
             'place_relations',
-            'index_readmodel',
             'place_permission_readmodel',
         ];
 

--- a/app/PurgeServiceProvider.php
+++ b/app/PurgeServiceProvider.php
@@ -60,6 +60,7 @@ class PurgeServiceProvider implements ServiceProviderInterface
         $dbalReadModels = [
             'event_permission_readmodel',
             'event_relations',
+            'labels_json',
             'label_roles',
             'labels_relations',
             'organizer_permission_readmodel',


### PR DESCRIPTION
### Removed
- The table `index_readmodel` no longer exists so no purge is needed
### Added
- Added missing read models to purge

---

Ticket: https://jira.uitdatabank.be/browse/III-3500