### PR TITLE
III-3570 Polyfill new status property

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Event\ReadModel\JSONLD\RelatedEventLDProjector;
 use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use Silex\Application;
@@ -32,14 +33,16 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
         $app['event_jsonld_repository'] = $app->share(
             function ($app) {
                 return new BroadcastingDocumentRepositoryDecorator(
-                    new PopularityEnrichedOfferRepository(
-                        $app[PopularityRepository::class],
-                        new ProductionEnrichedEventRepository(
-                            new CacheDocumentRepository(
-                                $app['event_jsonld_cache']
-                            ),
-                            $app[ProductionRepository::class],
-                            $app['event_iri_generator']
+                    new NewPropertyPolyfillOfferRepository(
+                        new PopularityEnrichedOfferRepository(
+                            $app[PopularityRepository::class],
+                            new ProductionEnrichedEventRepository(
+                                new CacheDocumentRepository(
+                                    $app['event_jsonld_cache']
+                                ),
+                                $app[ProductionRepository::class],
+                                $app['event_iri_generator']
+                            )
                         )
                     ),
                     $app['event_bus'],

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
 use CultuurNet\UDB3\Place\DummyPlaceProjectionEnricher;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\CdbXMLImporter;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\EventFactory;
@@ -85,6 +86,8 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                     $app[PopularityRepository::class],
                     $repository
                 );
+
+                $repository = new NewPropertyPolyfillOfferRepository($repository);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -20,8 +20,8 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
     {
         $document = parent::get($id, $includeMetadata);
 
-        if (!is_null($document)) {
-            return $document;
+        if (is_null($document)) {
+            return null;
         }
 
         return $this->polyfillNewProperties($document);

--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -46,7 +46,8 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
         return $json;
     }
 
-    private function polyfillSubEventStatus(array $json): array {
+    private function polyfillSubEventStatus(array $json): array
+    {
         if (!isset($json['subEvent']) || !is_array($json['subEvent'])) {
             return $json;
         }

--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\Event\ValueObjects\StatusType;
+use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+
+final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
+{
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        $document = parent::fetch($id, $includeMetadata);
+        return $this->polyfillNewProperties($document);
+    }
+
+    public function get(string $id, bool $includeMetadata = false): ?JsonDocument
+    {
+        $document = parent::get($id, $includeMetadata);
+
+        if (!is_null($document)) {
+            return $document;
+        }
+
+        return $this->polyfillNewProperties($document);
+    }
+
+    private function polyfillNewProperties(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                $json = $this->polyfillStatus($json);
+                $json = $this->polyfillSubEventStatus($json);
+                return $json;
+            }
+        );
+    }
+
+    private function polyfillStatus(array $json): array
+    {
+        if (!isset($json['status'])) {
+            $json['status'] = StatusType::available()->toNative();
+        }
+        return $json;
+    }
+
+    private function polyfillSubEventStatus(array $json): array {
+        if (!isset($json['subEvent']) || !is_array($json['subEvent'])) {
+            return $json;
+        }
+
+        $json['subEvent'] = array_map(
+            function (array $subEvent) {
+                return array_merge(
+                    [
+                        'status' => [
+                            'type' => StatusType::available()->toNative(),
+                        ],
+                    ],
+                    $subEvent
+                );
+            },
+            $json['subEvent']
+        );
+
+        return $json;
+    }
+}

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+
+class NewPropertyPolyfillOfferRepositoryTest extends TestCase
+{
+    const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
+
+    /**
+     * @var NewPropertyPolyfillOfferRepository
+     */
+    private $repository;
+
+    protected function setUp()
+    {
+        $this->repository = new NewPropertyPolyfillOfferRepository(
+            new InMemoryDocumentRepository()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_polyfill_a_default_status_if_not_set(): void
+    {
+        $this
+            ->given([])
+            ->assertReturnedDocumentContains(['status' => 'Available']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_change_status_if_already_set(): void
+    {
+        $this
+            ->given(['status' => 'Unavailable'])
+            ->assertReturnedDocumentContains(['status' => 'Unavailable']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_polyfill_a_default_status_on_subEvent_if_not_set(): void
+    {
+        $this
+            ->given(
+                [
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-01T16:00:00+01:00',
+                            'endDate' => '2020-01-01T20:00:00+01:00',
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-02T16:00:00+01:00',
+                            'endDate' => '2020-01-02T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Unavailable',
+                            ]
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-03T16:00:00+01:00',
+                            'endDate' => '2020-01-03T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'TemporarilyUnavailable',
+                                'reason' => [
+                                    'nl' => 'Tijdelijk uitgesteld'
+                                ],
+                            ]
+                        ],
+                    ]
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-01T16:00:00+01:00',
+                            'endDate' => '2020-01-01T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Available',
+                            ]
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-02T16:00:00+01:00',
+                            'endDate' => '2020-01-02T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'Unavailable',
+                            ]
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-01-03T16:00:00+01:00',
+                            'endDate' => '2020-01-03T20:00:00+01:00',
+                            'status' => [
+                                'type' => 'TemporarilyUnavailable',
+                                'reason' => [
+                                    'nl' => 'Tijdelijk uitgesteld'
+                                ],
+                            ]
+                        ],
+                    ]
+                ]
+            );
+    }
+
+    private function given(array $given): self
+    {
+        $this->repository->save(
+            new JsonDocument(
+                self::DOCUMENT_ID,
+                json_encode($given)
+            )
+        );
+        return $this;
+    }
+
+    private function assertReturnedDocumentContains(array $expected): void
+    {
+        $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
+        $actualFromGet = $this->repository->get(self::DOCUMENT_ID)->getAssocBody();
+        $this->assertArrayContainsExpectedKeys($expected, $actualFromFetch);
+        $this->assertArrayContainsExpectedKeys($expected, $actualFromGet);
+    }
+
+    private function assertArrayContainsExpectedKeys(array $expected, array $actual): void
+    {
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $actual);
+            $this->assertEquals($value, $actual[$key]);
+        }
+    }
+}


### PR DESCRIPTION
### Added

- Added an offer repository decorator that can polyfill new properties with default values.

---
Ticket: https://jira.uitdatabank.be/browse/III-3570

I went with a generic polyfilling decorator because these polyfills are only relevant until we do a new replay, so we can use this to do all the polyfills in one place and then remove them all once we do a replay. That way we also don't have to duplicate all the bootstrapping and boilerplate code.
