### PR TITLE
Use correct table when geocoding events and places

### DIFF
--- a/app/Console/SQL/get_all_events.sql
+++ b/app/Console/SQL/get_all_events.sql
@@ -1,6 +1,8 @@
 SELECT
   uuid
 FROM
-  udb3.events
+  udb3.event_store
+WHERE
+  aggregate_type = 'event'
 GROUP BY
   uuid;

--- a/app/Console/SQL/get_all_places.sql
+++ b/app/Console/SQL/get_all_places.sql
@@ -1,6 +1,8 @@
 SELECT
   uuid
 FROM
-  udb3.places
+  udb3.event_store
+WHERE
+  aggregate_type = 'place'
 GROUP BY
   uuid;

--- a/app/Console/SQL/get_events_with_missing_or_outdated_coordinates.sql
+++ b/app/Console/SQL/get_events_with_missing_or_outdated_coordinates.sql
@@ -2,14 +2,16 @@
 SELECT
 	uuid
 FROM
-	udb3.events
+	udb3.event_store
 WHERE
+    aggregate_type = 'event'
+AND
 	uuid NOT IN
 	(
 		SELECT
 			uuid
 		FROM
-			udb3.events
+			udb3.event_store
 		WHERE
 			type = 'CultuurNet.UDB3.Event.Events.GeoCoordinatesUpdated'
 	)
@@ -22,13 +24,13 @@ UNION
 SELECT
 	DISTINCT (pl.uuid)
 FROM
-	udb3.events AS pl
+	udb3.event_store AS pl
 INNER JOIN
 	(
 		SELECT
 			uuid, MAX(id) AS max_geo
 		FROM
-			udb3.events
+			udb3.event_store
 		WHERE
 			type = 'CultuurNet.UDB3.Event.Events.GeoCoordinatesUpdated'
 		GROUP BY
@@ -41,7 +43,7 @@ INNER JOIN
 		SELECT
 			uuid, MAX(id) AS max_cre
 		FROM
-			udb3.events
+			udb3.event_store
 		WHERE
 			type IN ('CultuurNet.UDB3.Event.Events.EventImportedFromUDB2',
 							 'CultuurNet.UDB3.Event.Events.EventUpdatedFromUDB2')
@@ -52,3 +54,5 @@ ON
 	pl.uuid = pl_cre.uuid
 WHERE
 	pl_cre.max_cre > pl_geo.max_geo;
+AND
+    aggregate_type = 'event'

--- a/app/Console/SQL/get_places_with_missing_or_outdated_coordinates.sql
+++ b/app/Console/SQL/get_places_with_missing_or_outdated_coordinates.sql
@@ -2,14 +2,16 @@
 SELECT
 	uuid
 FROM
-	udb3.places
+	udb3.event_store
 WHERE
+    aggregate_type = 'place'
+AND
 	uuid NOT IN
 	(
 		SELECT
 			uuid
 		FROM
-			udb3.places
+			udb3.event_store
 		WHERE
 			type = 'CultuurNet.UDB3.Place.Events.GeoCoordinatesUpdated'
 	)
@@ -22,13 +24,13 @@ UNION
 SELECT
 	DISTINCT (pl.uuid)
 FROM
-	udb3.places AS pl
+	udb3.event_store AS pl
 INNER JOIN
 	(
 		SELECT
 			uuid, MAX(id) AS max_geo
 		FROM
-			udb3.places
+			udb3.event_store
 		WHERE
 			type = 'CultuurNet.UDB3.Place.Events.GeoCoordinatesUpdated'
 		GROUP BY
@@ -41,7 +43,7 @@ INNER JOIN
 		SELECT
 			uuid, MAX(id) AS max_cre
 		FROM
-			udb3.places
+			udb3.event_store
 		WHERE
 			type IN ('CultuurNet.UDB3.Place.Events.PlaceCreated',
 							 'CultuurNet.UDB3.Place.Events.MajorInfoUpdated',
@@ -55,3 +57,5 @@ ON
 	pl.uuid = pl_cre.uuid
 WHERE
 	pl_cre.max_cre > pl_geo.max_geo;
+AND
+    aggregate_type = 'place'


### PR DESCRIPTION
### Changed
- We now use the correct event_store table when geocoding places and events.

