### PR TITLE
Omit deleted & rejected events/places from geocoding

### DIFF
--- a/app/Console/GeocodeEventCommand.php
+++ b/app/Console/GeocodeEventCommand.php
@@ -20,7 +20,7 @@ class GeocodeEventCommand extends AbstractGeocodeCommand
     {
         // Only geo-code events without location id. Events with a location id can only be geo-coded by geo-coding the
         // linked place.
-        return 'NOT(_exists_:geo) AND NOT(_exists_:location.id)';
+        return 'NOT(_exists_:geo OR _exists_:location.id OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
     }
 
     protected function dispatchGeocodingCommand(string $eventId, OutputInterface $output): void

--- a/app/Console/GeocodePlaceCommand.php
+++ b/app/Console/GeocodePlaceCommand.php
@@ -18,7 +18,7 @@ class GeocodePlaceCommand extends AbstractGeocodeCommand
 
     protected function getQueryForMissingCoordinates(): string
     {
-        return 'NOT(_exists_:geo)';
+        return 'NOT(_exists_:geo OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
     }
 
     protected function dispatchGeocodingCommand(string $placeId, OutputInterface $output): void


### PR DESCRIPTION
### Changed

- Changed the `event:geocode` and `place:geocode` commands to not geocode deleted or rejected events and places

---
Ticket: https://jira.uitdatabank.be/browse/III-3634
