### PR TITLE
Fix update status of udb2 imported events

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -6,6 +6,7 @@ use Broadway\EventSourcing\EventSourcedAggregateRoot;
 use CultuurNet\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Cdb\UpdateableWithCdbXmlInterface;
 use CultuurNet\UDB3\ContactPoint;
@@ -265,8 +266,10 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
         // Just clear the contact point.
         $this->contactPoint = null;
 
-        // Just clear the calendar.
-        $this->calendar = null;
+        // Correctly set the Calendar
+        // We need this for future Status updates
+        $calendarFactory = new CalendarFactory();
+        $this->calendar = $calendarFactory->createFromCdbCalendar($udb2Event->getCalendar());
 
         // Correctly set the age range to avoid issues with deleting age range.
         // after an update from UDB2.

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -6,6 +6,7 @@ use CultuurNet\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\UpdateableWithCdbXmlInterface;
 use CultuurNet\UDB3\ContactPoint;
@@ -281,8 +282,10 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
         // Just clear the contact point.
         $this->contactPoint = null;
 
-        // Just clear the calendar.
-        $this->calendar = null;
+        // Correctly set the Calendar
+        // We need this for future Status updates
+        $calendarFactory = new CalendarFactory();
+        $this->calendar = $calendarFactory->createFromWeekScheme($udb2Actor->getWeekScheme());
 
         // Note: an actor has no typical age range so after it can't be changed
         // by an UDB2 update. Nothing has to be done.


### PR DESCRIPTION
### Fixed
- Updating the status of events and places imported from UDB2 was not possible because their calendars weren't set properly in the aggregate

---
Ticket: https://jira.uitdatabank.be/browse/III-3655
