### PR TITLE
III-3691 Add ability to change the owner of events/places

### DIFF
--- a/app/Console/ChangeOfferOwner.php
+++ b/app/Console/ChangeOfferOwner.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ChangeOfferOwner extends AbstractCommand
+{
+    public function configure(): void
+    {
+        $this->setName('offer:change-owner');
+        $this->setDescription('Change the owner of an offer to a new user id');
+        $this->addArgument('offerId', InputArgument::REQUIRED, 'Uuid of the offer');
+        $this->addArgument(
+            'newOwnerId',
+            InputArgument::REQUIRED,
+            'Id of the new user. '
+            . 'Can either be a v1 id (e.g. "97f0f81d-a2b6-44c5-ab27-e076d6329f91") '
+            . 'or a v2 id (e.g. "auth0|2836d202-1955-40f4-aee4-1b2ea493f17c"). '
+            . 'Always use v1 ids for users migrated from UiTID v1!'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $logger = new ConsoleLogger($output);
+
+        $offerId = $input->getArgument('offerId');
+        $newOwnerId = $input->getArgument('newOwnerId');
+
+        $this->commandBus->dispatch(
+            new ChangeOwner(
+                $offerId,
+                $newOwnerId
+            )
+        );
+        $logger->info('Successfully changed owner of offer "' . $offerId .'" to user with id "' . $newOwnerId . '"');
+
+        return 0;
+    }
+}

--- a/app/Console/ChangeOfferOwnerInBulk.php
+++ b/app/Console/ChangeOfferOwnerInBulk.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Broadway\CommandHandling\CommandBusInterface;
+use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Offer\ReadModel\Permission\PermissionQueryInterface;
+use Error;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use ValueObjects\StringLiteral\StringLiteral;
+
+class ChangeOfferOwnerInBulk extends AbstractCommand
+{
+    /**
+     * @var PermissionQueryInterface
+     */
+    private $permissionQuery;
+
+    public function __construct(
+        CommandBusInterface $commandBus,
+        PermissionQueryInterface $permissionQuery
+    ) {
+        parent::__construct($commandBus);
+        $this->permissionQuery = $permissionQuery;
+    }
+
+    public function configure(): void
+    {
+        $this->setName('offer:change-owner-bulk');
+        $this->setDescription('Change the owner of multiple offers to a new user id');
+        $this->addArgument('originalOwnerId', InputArgument::REQUIRED, 'Id of the original owner');
+        $this->addArgument(
+            'newOwnerId',
+            InputArgument::REQUIRED,
+            'Id of the new user. '
+            . 'Can either be a v1 id (e.g. "97f0f81d-a2b6-44c5-ab27-e076d6329f91") '
+            . 'or a v2 id (e.g. "auth0|2836d202-1955-40f4-aee4-1b2ea493f17c"). '
+            . 'Always use v1 ids for users migrated from UiTID v1!'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $logger = new ConsoleLogger($output);
+
+        $originalOwnerId = $input->getArgument('originalOwnerId');
+        $newOwnerId = $input->getArgument('newOwnerId');
+
+        $success = 0;
+        $errors = 0;
+        foreach ($this->permissionQuery->getEditableOffers(new StringLiteral($originalOwnerId)) as $editableOffer) {
+            $offerId = $editableOffer->toNative();
+            try {
+                $this->commandBus->dispatch(
+                    new ChangeOwner(
+                        $offerId,
+                        $newOwnerId
+                    )
+                );
+                $logger->info(
+                    'Successfully changed owner of offer "' . $offerId .'" to user with id "' . $newOwnerId . '"'
+                );
+                $success++;
+            } catch (Error $error) {
+                $logger->error(
+                    sprintf(
+                        'An error occurred while chaging owner of offer "%s": %s with message %s',
+                        $offerId,
+                        get_class($error),
+                        $error->getMessage()
+                    )
+                );
+                $errors++;
+            }
+        }
+
+        $logger->info('Successfully changed owner ' . $success . ' offers to user with id "' . $newOwnerId . '"');
+
+        if ($errors) {
+            $logger->error('Failed to change owner of ' . $errors . ' offers');
+        }
+
+        return $errors > 0 ? 1 : 0;
+    }
+}

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -4,6 +4,7 @@ namespace CultuurNet\UDB3\Silex\Offer;
 
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\Http\CompositePsr7RequestAuthorizer;
+use CultuurNet\UDB3\Offer\CommandHandlers\ChangeOwnerHandler;
 use CultuurNet\UDB3\Offer\CommandHandlers\UpdateStatusHandler;
 use CultuurNet\UDB3\Offer\DefaultExternalOfferEditingService;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactory;
@@ -80,6 +81,15 @@ class OfferServiceProvider implements ServiceProviderInterface
         $app[UpdateStatusHandler::class] = $app->share(
             function (Application $app) {
                 return new UpdateStatusHandler($app[OfferRepository::class]);
+            }
+        );
+
+        $app[ChangeOwnerHandler::class] = $app->share(
+            function (Application $app) {
+                return new ChangeOwnerHandler(
+                    $app[OfferRepository::class],
+                    $app['offer_permission_query']
+                );
             }
         );
     }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Event\LocationMarkedAsDuplicateProcessManager;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Silex\ApiName;
 use CultuurNet\UDB3\Silex\ConfigWriter;
+use CultuurNet\UDB3\Silex\Console\ChangeOfferOwner;
 use CultuurNet\UDB3\Silex\Console\ConcludeByCdbidCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeCommand;
 use CultuurNet\UDB3\Silex\Console\DispatchMarkedAsDuplicateEventCommand;
@@ -117,6 +118,7 @@ $consoleApp->add(
 );
 $consoleApp->add(new UpdateOfferStatusCommand(OfferType::EVENT(), $app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_EVENTS]));
 $consoleApp->add(new UpdateOfferStatusCommand(OfferType::PLACE(), $app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_PLACES]));
+$consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
 
 
 try {

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Silex\ApiName;
 use CultuurNet\UDB3\Silex\ConfigWriter;
 use CultuurNet\UDB3\Silex\Console\ChangeOfferOwner;
+use CultuurNet\UDB3\Silex\Console\ChangeOfferOwnerInBulk;
 use CultuurNet\UDB3\Silex\Console\ConcludeByCdbidCommand;
 use CultuurNet\UDB3\Silex\Console\ConcludeCommand;
 use CultuurNet\UDB3\Silex\Console\DispatchMarkedAsDuplicateEventCommand;
@@ -119,6 +120,7 @@ $consoleApp->add(
 $consoleApp->add(new UpdateOfferStatusCommand(OfferType::EVENT(), $app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_EVENTS]));
 $consoleApp->add(new UpdateOfferStatusCommand(OfferType::PLACE(), $app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_PLACES]));
 $consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
+$consoleApp->add(new ChangeOfferOwnerInBulk($app['event_command_bus'], $app['offer_permission_query']));
 
 
 try {

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -122,7 +122,6 @@ $consoleApp->add(new UpdateOfferStatusCommand(OfferType::PLACE(), $app['event_co
 $consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
 $consoleApp->add(new ChangeOfferOwnerInBulk($app['event_command_bus'], $app['offer_permission_query']));
 
-
 try {
     $consoleApp->run();
 } catch (\Throwable $throwable) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,8 +13,8 @@ use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Offer\CommandHandlers\ChangeOwnerHandler;
 use CultuurNet\UDB3\Offer\CommandHandlers\UpdateStatusHandler;
-use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
 use CultuurNet\UDB3\Offer\OfferLocator;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUniqueConstraintService;
@@ -664,7 +664,7 @@ $subscribeCoreCommandHandlers = function (CommandBusInterface $commandBus, Appli
         $commandBus->subscribe($app['organizer_geocoordinates_command_handler']);
         $commandBus->subscribe($app[ProductionCommandHandler::class]);
         $commandBus->subscribe($app[UpdateStatusHandler::class]);
-        $commandBus->subscribe($app[ChangeOwner::class]);
+        $commandBus->subscribe($app[ChangeOwnerHandler::class]);
     };
 
     if ($commandBus instanceof LazyLoadingCommandBus) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\EventSourcing\DBAL\AggregateAwareDBALEventStore;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Offer\CommandHandlers\UpdateStatusHandler;
+use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
 use CultuurNet\UDB3\Offer\OfferLocator;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUniqueConstraintService;
@@ -663,6 +664,7 @@ $subscribeCoreCommandHandlers = function (CommandBusInterface $commandBus, Appli
         $commandBus->subscribe($app['organizer_geocoordinates_command_handler']);
         $commandBus->subscribe($app[ProductionCommandHandler::class]);
         $commandBus->subscribe($app[UpdateStatusHandler::class]);
+        $commandBus->subscribe($app[ChangeOwner::class]);
     };
 
     if ($commandBus instanceof LazyLoadingCommandBus) {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -44,6 +44,7 @@ use CultuurNet\UDB3\Event\Events\Moderation\Published;
 use CultuurNet\UDB3\Event\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Event\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Event\Events\OrganizerUpdated;
+use CultuurNet\UDB3\Event\Events\OwnerChanged;
 use CultuurNet\UDB3\Event\Events\PriceInfoUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
@@ -62,6 +63,7 @@ use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Offer\AgeRange;
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
 use CultuurNet\UDB3\Offer\Offer;
 use CultuurNet\UDB3\Offer\WorkflowStatus;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -417,6 +419,11 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     public function applyAudienceUpdated(AudienceUpdated $audienceUpdated)
     {
         $this->audience= $audienceUpdated->getAudience();
+    }
+
+    protected function createOwnerChangedEvent($newOwnerId): AbstractOwnerChanged
+    {
+        return new OwnerChanged($this->eventId, $newOwnerId);
     }
 
     /**

--- a/src/Event/Events/OwnerChanged.php
+++ b/src/Event/Events/OwnerChanged.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
+
+final class OwnerChanged extends AbstractOwnerChanged
+{
+}

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -39,6 +39,7 @@ use CultuurNet\UDB3\Event\Events\Moderation\Published;
 use CultuurNet\UDB3\Event\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Event\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Event\Events\OrganizerUpdated;
+use CultuurNet\UDB3\Event\Events\OwnerChanged;
 use CultuurNet\UDB3\Event\Events\PriceInfoUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
@@ -511,6 +512,17 @@ class EventLDProjector extends OfferLDProjector implements
         $jsonLD->audience = $audienceUpdated->getAudience()->serialize();
 
         return $document->withBody($jsonLD);
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): JsonDocument
+    {
+        return $this->loadDocumentFromRepositoryByItemId($ownerChanged->getOfferId())
+            ->applyAssoc(
+                function (array $jsonLd) use ($ownerChanged) {
+                    $jsonLd['creator'] = $ownerChanged->getNewOwnerId();
+                    return $jsonLd;
+                }
+            );
     }
 
     /**

--- a/src/Event/ReadModel/Permission/Projector.php
+++ b/src/Event/ReadModel/Permission/Projector.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Event\Events\EventCopied;
 use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
+use CultuurNet\UDB3\Event\Events\OwnerChanged;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Offer\ReadModel\Permission\PermissionRepositoryInterface;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -73,6 +74,14 @@ class Projector implements EventListenerInterface
         DomainMessage $domainMessage
     ) {
         $this->makeOfferEditableByUser($eventCopied->getItemId(), $domainMessage);
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
+    {
+        $this->permissionRepository->markOfferEditableByNewUser(
+            new StringLiteral($ownerChanged->getOfferId()),
+            new StringLiteral($ownerChanged->getNewOwnerId())
+        );
     }
 
     /**

--- a/src/Offer/CommandHandlers/ChangeOwnerHandler.php
+++ b/src/Offer/CommandHandlers/ChangeOwnerHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandlerInterface;
+use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Offer\OfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Permission\PermissionQueryInterface;
+use ValueObjects\StringLiteral\StringLiteral;
+
+final class ChangeOwnerHandler implements CommandHandlerInterface
+{
+    /**
+     * @var OfferRepository
+     */
+    private $offerRepository;
+
+    /**
+     * @var PermissionQueryInterface
+     */
+    private $permissionQuery;
+
+    public function __construct(
+        OfferRepository $offerRepository,
+        PermissionQueryInterface $permissionQuery
+    ) {
+        $this->offerRepository = $offerRepository;
+        $this->permissionQuery = $permissionQuery;
+    }
+
+    public function handle($command): void
+    {
+        if (!($command instanceof ChangeOwner)) {
+            return;
+        }
+
+        $offerId = $command->getOfferId();
+        $newOwnerId = $command->getNewOwnerId();
+
+        // The aggregate cannot check who was the initial owner, because that's stored in the metadata (!) of the
+        // EventCreated/PlaceCreated/EventImportedFromUDB2/PlaceImportedFromUDB2 events and the base class of broadway
+        // doesn't pass that info to the applyEventCreated() etc methods.
+        $offersOwnedByNewOwner = $this->permissionQuery->getEditableOffers(new StringLiteral($newOwnerId));
+
+        // Don't use strict comparison here in in_array because getEditableOffers() returns StringLiterals. They will
+        // get cast to strings automatically when comparing.
+        if (!in_array($offerId, $offersOwnedByNewOwner, false)) {
+            $offer = $this->offerRepository->load($command->getOfferId());
+            $offer->changeOwner($command->getNewOwnerId());
+            $this->offerRepository->save($offer);
+        }
+    }
+}

--- a/src/Offer/Commands/ChangeOwner.php
+++ b/src/Offer/Commands/ChangeOwner.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Commands;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+
+final class ChangeOwner implements AuthorizableCommandInterface
+{
+    /**
+     * @var string
+     */
+    private $offerId;
+
+    /**
+     * @var string
+     */
+    private $newOwnerId;
+
+    public function __construct(string $offerId, string $newOwnerId)
+    {
+        $this->offerId = $offerId;
+        $this->newOwnerId = $newOwnerId;
+    }
+
+    public function getOfferId(): string
+    {
+        return $this->offerId;
+    }
+
+    public function getNewOwnerId(): string
+    {
+        return $this->newOwnerId;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->offerId;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::AANBOD_BEWERKEN();
+    }
+}

--- a/src/Offer/Events/AbstractOwnerChanged.php
+++ b/src/Offer/Events/AbstractOwnerChanged.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Events;
+
+use Broadway\Serializer\SerializableInterface;
+
+abstract class AbstractOwnerChanged implements SerializableInterface
+{
+    /**
+     * @var string
+     */
+    private $offerId;
+
+    /**
+     * @var string
+     */
+    private $newCreator;
+
+    final public function __construct(string $offerId, string $newCreator)
+    {
+        $this->offerId = $offerId;
+        $this->newCreator = $newCreator;
+    }
+
+    public function getOfferId(): string
+    {
+        return $this->offerId;
+    }
+
+    public function getNewOwnerId(): string
+    {
+        return $this->newCreator;
+    }
+
+    public function serialize(): array
+    {
+        return array(
+            'offer_id' => $this->offerId,
+            'new_creator' => $this->newCreator,
+        );
+    }
+
+    public static function deserialize(array $data): self
+    {
+        return new static($data['offer_id'], $data['new_creator']);
+    }
+}

--- a/src/Offer/Events/AbstractOwnerChanged.php
+++ b/src/Offer/Events/AbstractOwnerChanged.php
@@ -16,12 +16,12 @@ abstract class AbstractOwnerChanged implements SerializableInterface
     /**
      * @var string
      */
-    private $newCreator;
+    private $newOwnerId;
 
-    final public function __construct(string $offerId, string $newCreator)
+    final public function __construct(string $offerId, string $newOwnerId)
     {
         $this->offerId = $offerId;
-        $this->newCreator = $newCreator;
+        $this->newOwnerId = $newOwnerId;
     }
 
     public function getOfferId(): string
@@ -31,19 +31,19 @@ abstract class AbstractOwnerChanged implements SerializableInterface
 
     public function getNewOwnerId(): string
     {
-        return $this->newCreator;
+        return $this->newOwnerId;
     }
 
     public function serialize(): array
     {
         return array(
             'offer_id' => $this->offerId,
-            'new_creator' => $this->newCreator,
+            'new_owner_id' => $this->newOwnerId,
         );
     }
 
     public static function deserialize(array $data): self
     {
-        return new static($data['offer_id'], $data['new_creator']);
+        return new static($data['offer_id'], $data['new_owner_id']);
     }
 }

--- a/src/Offer/ReadModel/Permission/Doctrine/DBALRepository.php
+++ b/src/Offer/ReadModel/Permission/Doctrine/DBALRepository.php
@@ -85,4 +85,13 @@ class DBALRepository implements PermissionRepositoryInterface, PermissionQueryIn
             // permission record is already in place.
         }
     }
+
+    public function markOfferEditableByNewUser(StringLiteral $eventId, StringLiteral $userId): void
+    {
+        $this->connection->update(
+            $this->tableName->toNative(),
+            ['user_id' => $userId->toNative()],
+            [$this->idField->toNative() => $eventId->toNative(),]
+        );
+    }
 }

--- a/src/Offer/ReadModel/Permission/PermissionRepositoryInterface.php
+++ b/src/Offer/ReadModel/Permission/PermissionRepositoryInterface.php
@@ -15,4 +15,9 @@ interface PermissionRepositoryInterface
         StringLiteral $offerId,
         StringLiteral $uitId
     );
+
+    public function markOfferEditableByNewUser(
+        StringLiteral $offerId,
+        StringLiteral $userId
+    ): void;
 }

--- a/src/Place/Events/OwnerChanged.php
+++ b/src/Place/Events/OwnerChanged.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Place\Events;
+
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
+
+final class OwnerChanged extends AbstractOwnerChanged
+{
+}

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\AgeRange;
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
 use CultuurNet\UDB3\Offer\Offer;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Offer\WorkflowStatus;
@@ -49,6 +50,7 @@ use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Place\Events\OrganizerUpdated;
+use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
@@ -371,6 +373,11 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
                 $cdbXmlNamespaceUri
             )
         );
+    }
+
+    protected function createOwnerChangedEvent($newOwnerId): AbstractOwnerChanged
+    {
+        return new OwnerChanged($this->placeId, $newOwnerId);
     }
 
     /**

--- a/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
+++ b/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Place\Events\Moderation\Published;
 use CultuurNet\UDB3\Place\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Place\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Place\Events\OrganizerUpdated;
+use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
@@ -402,6 +403,17 @@ class PlaceLDProjector extends OfferLDProjector implements EventListenerInterfac
             }
             return $placeLd;
         });
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): JsonDocument
+    {
+        return $this->loadDocumentFromRepositoryByItemId($ownerChanged->getOfferId())
+            ->applyAssoc(
+                function (array $jsonLd) use ($ownerChanged) {
+                    $jsonLd['creator'] = $ownerChanged->getNewOwnerId();
+                    return $jsonLd;
+                }
+            );
     }
 
     /**

--- a/src/Place/ReadModel/Permission/Projector.php
+++ b/src/Place/ReadModel/Permission/Projector.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\CreatedByToUserIdResolverInterface;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Offer\ReadModel\Permission\PermissionRepositoryInterface;
+use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use ValueObjects\StringLiteral\StringLiteral;
@@ -70,6 +71,14 @@ class Projector implements EventListenerInterface
         $this->permissionRepository->markOfferEditableByUser(
             new StringLiteral($placeCreated->getPlaceId()),
             $ownerId
+        );
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
+    {
+        $this->permissionRepository->markOfferEditableByNewUser(
+            new StringLiteral($ownerChanged->getOfferId()),
+            new StringLiteral($ownerChanged->getNewOwnerId())
         );
     }
 }

--- a/tests/Offer/CommandHandlers/ChangeOwnerHandlerTest.php
+++ b/tests/Offer/CommandHandlers/ChangeOwnerHandlerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace CultuurNet\UDB3\Offer\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandlerInterface;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBusInterface;
+use Broadway\EventStore\EventStoreInterface;
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\EventRepository;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\OwnerChanged;
+use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
+use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Offer\OfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Permission\PermissionQueryInterface;
+use CultuurNet\UDB3\Place\PlaceRepository;
+use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
+use ValueObjects\StringLiteral\StringLiteral;
+
+class ChangeOwnerHandlerTest extends CommandHandlerScenarioTestCase
+{
+    /**
+     * @var PermissionQueryInterface|MockObject
+     */
+    private $permissionQuery;
+
+    protected function createCommandHandler(
+        EventStoreInterface $eventStore,
+        EventBusInterface $eventBus
+    ): CommandHandlerInterface {
+        $repository = new OfferRepository(
+            new EventRepository($eventStore, $eventBus),
+            new PlaceRepository($eventStore, $eventBus)
+        );
+
+        $this->permissionQuery = $this->createMock(PermissionQueryInterface::class);
+
+        return new ChangeOwnerHandler($repository, $this->permissionQuery);
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_handles_change_owner_commands(): void
+    {
+        $randomCommand = $this->createMock(AbstractCommand::class);
+
+        $this->permissionQuery->expects($this->never())
+            ->method('getEditableOffers');
+
+        $id = 'f818db49-1484-4513-a534-d22c2ca88026';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([$this->eventCreated($id)])
+            ->when($randomCommand)
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_nothing_if_the_new_owner_is_the_current_owner_based_on_the_permission_read_model(): void
+    {
+        $id = 'f818db49-1484-4513-a534-d22c2ca88026';
+        $newOwner = 'auth0|598e7dc9-523b-4d58-b6ea-b4aad5a4a291';
+
+        $this->permissionQuery
+            ->method('getEditableOffers')
+            ->with($newOwner)
+            ->willReturn([new StringLiteral($id)]);
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([$this->eventCreated($id)])
+            ->when(new ChangeOwner($id, $newOwner))
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_changes_the_owner(): void
+    {
+        $id = 'f818db49-1484-4513-a534-d22c2ca88026';
+        $otherId = '3a97236f-21a6-45ef-9f7c-8ac23d151b45';
+        $newOwner = 'auth0|598e7dc9-523b-4d58-b6ea-b4aad5a4a291';
+
+        $this->permissionQuery
+            ->method('getEditableOffers')
+            ->with($newOwner)
+            ->willReturn([new StringLiteral($otherId)]);
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([$this->eventCreated($id)])
+            ->when(new ChangeOwner($id, $newOwner))
+            ->then([new OwnerChanged($id, $newOwner)]);
+    }
+
+    private function eventCreated(string $id): EventCreated
+    {
+        return new EventCreated(
+            $id,
+            new Language('nl'),
+            new Title('some representative title'),
+            new EventType('0.50.4.0.0', 'concert'),
+            new LocationId('d0cd4e9d-3cf1-4324-9835-2bfba63ac015'),
+            new Calendar(CalendarType::PERMANENT())
+        );
+    }
+}

--- a/tests/Offer/Item/Events/OwnerChanged.php
+++ b/tests/Offer/Item/Events/OwnerChanged.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\Item\Events;
+
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
+
+final class OwnerChanged extends AbstractOwnerChanged
+{
+}

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\AgeRange;
+use CultuurNet\UDB3\Offer\Events\AbstractOwnerChanged;
 use CultuurNet\UDB3\Offer\Item\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\CalendarUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\ContactPointUpdated;
@@ -36,6 +37,7 @@ use CultuurNet\UDB3\Offer\Item\Events\Moderation\Published;
 use CultuurNet\UDB3\Offer\Item\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Offer\Item\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Offer\Item\Events\OrganizerUpdated;
+use CultuurNet\UDB3\Offer\Item\Events\OwnerChanged;
 use CultuurNet\UDB3\Offer\Item\Events\PriceInfoUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\ThemeUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\TitleTranslated;
@@ -74,6 +76,11 @@ class Item extends Offer
     protected function applyItemDeleted(ItemDeleted $event): void
     {
         $this->isDeleted = true;
+    }
+
+    protected function createOwnerChangedEvent($newOwnerId): AbstractOwnerChanged
+    {
+        return new OwnerChanged($this->id, $newOwnerId);
     }
 
     /**

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Offer\Item\Events\DescriptionTranslated;
 use CultuurNet\UDB3\Offer\Item\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\FacilitiesUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\LabelsImported;
+use CultuurNet\UDB3\Offer\Item\Events\OwnerChanged;
 use CultuurNet\UDB3\Offer\Item\Events\ThemeUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\ImageUpdated;
 use CultuurNet\UDB3\Offer\Item\Events\TitleTranslated;
@@ -102,6 +103,36 @@ class OfferTest extends AggregateRootScenarioTestCase
             Url::fromNative('http://foo.bar/media/my_favorite_giphy_gif.gif'),
             new Language('en')
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_only_change_the_owner_with_a_check_after_the_first_change(): void
+    {
+        $itemId = '77b4df58-b7e9-40cf-979f-ec741a072282';
+
+        $newOwner1 = '8d4688f8-ef36-4a65-bac8-00dc846ed624';
+        $newOwner2 = 'abd24691-1cc7-49c7-a85f-8dc4498f8072';
+
+        $this->scenario
+            ->given([
+                new ItemCreated($itemId),
+            ])
+            ->when(
+                function (Item $item) use ($newOwner1, $newOwner2) {
+                    $item->changeOwner($newOwner1);
+                    $item->changeOwner($newOwner1);
+                    $item->changeOwner($newOwner2);
+                    $item->changeOwner($newOwner2);
+                    $item->changeOwner($newOwner1);
+                }
+            )
+            ->then([
+                new OwnerChanged($itemId, $newOwner1),
+                new OwnerChanged($itemId, $newOwner2),
+                new OwnerChanged($itemId, $newOwner1),
+            ]);
     }
 
     /**

--- a/tests/Offer/ReadModel/Permission/Doctrine/DBALRepositoryTest.php
+++ b/tests/Offer/ReadModel/Permission/Doctrine/DBALRepositoryTest.php
@@ -107,4 +107,36 @@ class DBALRepositoryTest extends TestCase
             $this->repository->getEditableOffers($johnDoe)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_updates_the_user_id_if_explicitly_requested(): void
+    {
+        $johnDoe = new StringLiteral('abc');
+        $janeDoe = new StringLiteral('def');
+        $editableByJohnDoe = [
+            new StringLiteral('123'),
+            new StringLiteral('456'),
+            new StringLiteral('789'),
+        ];
+
+        array_walk($editableByJohnDoe, [$this, 'markEditable'], $johnDoe);
+
+        $this->repository->markOfferEditableByNewUser(new StringLiteral('456'), $janeDoe);
+
+        $this->assertEquals(
+            [
+                new StringLiteral('456'),
+            ],
+            $this->repository->getEditableOffers($janeDoe)
+        );
+        $this->assertEquals(
+            [
+                new StringLiteral('123'),
+                new StringLiteral('789'),
+            ],
+            $this->repository->getEditableOffers($johnDoe)
+        );
+    }
 }

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -36,6 +36,7 @@ use CultuurNet\UDB3\Place\Events\LabelRemoved;
 use CultuurNet\UDB3\Place\Events\MajorInfoUpdated;
 use CultuurNet\UDB3\Place\Events\MarkedAsCanonical;
 use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
+use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceDeleted;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
@@ -351,6 +352,31 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         );
 
         $this->assertEquals($jsonLD, $actualJsonLD);
+    }
+
+    /**
+     * @test
+     */
+    public function it_changes_the_creator_if_the_owner_changes(): void
+    {
+        $eventId = '5c83ab42-1a6d-497d-8580-c85681250a94';
+        $originalOwner = 'f7a4c1d9-dd05-40e8-98fe-637265ce8530';
+        $newOwner = '55153b44-c43b-4bcc-80cd-e9beb9f3557d';
+
+        $initialDocument = new JsonDocument(
+            $eventId,
+            json_encode(['creator' => $originalOwner])
+        );
+        $this->documentRepository->save($initialDocument);
+
+        $ownerChanged = new OwnerChanged($eventId, $newOwner);
+
+        $updatedJsonLd = $this->project(
+            $ownerChanged,
+            $eventId
+        );
+
+        $this->assertEquals($updatedJsonLd->creator, $newOwner);
     }
 
     /**


### PR DESCRIPTION
### Added

- Added two CLI commands to change the owner of events/places. Either for one event/place based on its id, or for all events/places that belong to a specific user id.

---
Ticket: https://jira.uitdatabank.be/browse/III-3691

Context is described in the ticket + comments, but a summary:
- When we integrated with Auth0, we refactored UDB3 to determine the user id as follows: If the user has a v1 id in their token, use that to make sure their roles, permissions, entered events/places etc keep working. Also create new events/places with this v1 id. So basically always use the v1 id if there is one. If there's no v1 id, use the v2 (= Auth0) id.
- At one point, there was a bug in Auth0 which caused users that were migrated from v1 and used social media to login to lose their v1 id.
- These users then created events/places with a v2 id. (And complained that they couldn't see or edit their old events/places).
- The bug was fixed in Auth0 and those users now have a v1 id again. However, they now cannot see or edit their events/places created with their v2 id.
- The initial idea of Corneel & Manon was to change the query on the dashboard in the frontend, to also look for events/places created with the v2 id. However that idea would not make it possible to actually edit the events/places.
- The preferred solution now is to have a way to change the "creator"/owner of the events/places to the correct id. So the `creator` in the JSON-LD has to be updated (so the event/place appears on the dashboard), and the user id inside the permission tables need to change so they can actually edit/delete the event/place.
