### PR TITLE
III-3733 Add uitpas service endpoints

### DIFF
--- a/app/UiTPASService/UiTPASServiceEventControllerProvider.php
+++ b/app/UiTPASService/UiTPASServiceEventControllerProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\UiTPASService;
+
+use CultuurNet\UDB3\UiTPASService\Controller\EventCardSystemsController;
+use CultuurNet\UDB3\UiTPASService\Controller\EventDetailController;
+use Silex\Application;
+use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
+
+class UiTPASServiceEventControllerProvider implements ControllerProviderInterface
+{
+    const EVENT_DETAIL = 'uitpas-service.event.detail';
+    const EVENT_CARD_SYSTEMS = 'uitpas-service.event.card_systems';
+
+    public function connect(Application $app)
+    {
+        $app['uitpas.event_detail_controller'] = $app->share(
+            function (Application $app) {
+                return new EventDetailController(
+                    $app['uitpas'],
+                    $app['url_generator'],
+                    self::EVENT_DETAIL,
+                    self::EVENT_CARD_SYSTEMS
+                );
+            }
+        );
+
+        $app['uitpas.event_card_systems_controller'] = $app->share(
+            function (Application $app) {
+                return new EventCardSystemsController(
+                    $app['uitpas']
+                );
+            }
+        );
+
+        /** @var ControllerCollection $controllers */
+        $controllers = $app['controllers_factory'];
+
+        $controllers->get(
+            '/{eventId}',
+            'uitpas.event_detail_controller:get'
+        )->bind(self::EVENT_DETAIL);
+
+        $controllers->get(
+            '/{eventId}/cardSystems/',
+            'uitpas.event_card_systems_controller:get'
+        )->bind(self::EVENT_CARD_SYSTEMS);
+
+        $controllers->put(
+            '/{eventId}/cardSystems/',
+            'uitpas.event_card_systems_controller:set'
+        );
+        $controllers->put(
+            '/{eventId}/cardSystems/{cardSystemId}',
+            'uitpas.event_card_systems_controller:add'
+        );
+        $controllers->put(
+            '/{eventId}/cardSystems/{cardSystemId}/distributionKey/{distributionKeyId}',
+            'uitpas.event_card_systems_controller:add'
+        );
+
+        $controllers->delete(
+            '/{eventId}/cardSystems/{cardSystemId}',
+            'uitpas.event_card_systems_controller:delete'
+        );
+
+        return $controllers;
+    }
+}

--- a/app/UiTPASService/UiTPASServiceLabelsControllerProvider.php
+++ b/app/UiTPASService/UiTPASServiceLabelsControllerProvider.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\UiTPAS;
+namespace CultuurNet\UDB3\Silex\UiTPASService;
 
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-final class UiTPASControllerProvider implements ControllerProviderInterface
+final class UiTPASServiceLabelsControllerProvider implements ControllerProviderInterface
 {
     public function connect(Application $app): ControllerCollection
     {
@@ -17,7 +17,7 @@ final class UiTPASControllerProvider implements ControllerProviderInterface
         $controllers = $app['controllers_factory'];
 
         $controllers->get(
-            '/labels',
+            '/',
             function (Application $app) {
                 return new JsonResponse(
                     $app['config']['uitpas']['labels']

--- a/app/UiTPASService/UiTPASServiceOrganizerControllerProvider.php
+++ b/app/UiTPASService/UiTPASServiceOrganizerControllerProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CultuurNet\UDB3\Silex\UiTPASService;
+
+use CultuurNet\UDB3\UiTPASService\Controller\OrganizerCardSystemsController;
+use Silex\Application;
+use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
+
+class UiTPASServiceOrganizerControllerProvider implements ControllerProviderInterface
+{
+    public function connect(Application $app)
+    {
+        $app['uitpas.organizer_card_systems_controller'] = $app->share(
+            function (Application $app) {
+                return new OrganizerCardSystemsController(
+                    $app['uitpas']
+                );
+            }
+        );
+
+        /** @var ControllerCollection $controllers */
+        $controllers = $app['controllers_factory'];
+
+        $controllers->get(
+            '/{organizerId}/cardSystems/',
+            'uitpas.organizer_card_systems_controller:get'
+        );
+
+        return $controllers;
+    }
+}

--- a/src/UiTPASService/Controller/EventCardSystemsController.php
+++ b/src/UiTPASService/Controller/EventCardSystemsController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use CultuurNet\UDB3\UiTPASService\Controller\Response\CardSystemsJsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EventCardSystemsController
+{
+    /**
+     * @var CultureFeed_Uitpas
+     */
+    private $uitpas;
+
+    public function __construct(CultureFeed_Uitpas $uitpas)
+    {
+        $this->uitpas = $uitpas;
+    }
+
+    public function get(string $eventId): CardSystemsJsonResponse
+    {
+        $cardSystems = $this->uitpas->getCardSystemsForEvent($eventId);
+        return new CardSystemsJsonResponse($cardSystems->objects);
+    }
+
+    public function set(string $eventId, Request $request): Response
+    {
+        $cardSystemIds = json_decode($request->getContent(), true);
+        if (!is_array($cardSystemIds)) {
+            return new Response('Payload should be an array of card system ids', 400);
+        }
+
+        $this->uitpas->setCardSystemsForEvent($eventId, $cardSystemIds);
+        return new Response('OK', 200);
+    }
+
+    public function add(string $eventId, string $cardSystemId, string $distributionKeyId = null): Response
+    {
+        $this->uitpas->addCardSystemToEvent($eventId, $cardSystemId, $distributionKeyId);
+        return new Response('OK', 200);
+    }
+
+    public function delete(string $eventId, string $cardSystemId): Response
+    {
+        $this->uitpas->deleteCardSystemFromEvent($eventId, $cardSystemId);
+        return new Response('OK', 200);
+    }
+}

--- a/src/UiTPASService/Controller/EventDetailController.php
+++ b/src/UiTPASService/Controller/EventDetailController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class EventDetailController
+{
+    /**
+     * @var CultureFeed_Uitpas
+     */
+    private $uitpas;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var string
+     */
+    private $eventDetailRouteName;
+
+    /**
+     * @var string
+     */
+    private $eventCardSystemsRouteName;
+
+    /**
+     * @param CultureFeed_Uitpas $uitpas
+     * @param UrlGeneratorInterface $urlGenerator
+     * @param string $eventDetailRouteName
+     * @param string $eventCardSystemsRouteName
+     */
+    public function __construct(
+        CultureFeed_Uitpas $uitpas,
+        UrlGeneratorInterface $urlGenerator,
+        string $eventDetailRouteName,
+        string $eventCardSystemsRouteName
+    ) {
+        $this->uitpas = $uitpas;
+        $this->urlGenerator = $urlGenerator;
+        $this->eventDetailRouteName = $eventDetailRouteName;
+        $this->eventCardSystemsRouteName = $eventCardSystemsRouteName;
+    }
+
+    public function get(string $eventId): JsonResponse
+    {
+        $data = [
+            '@id' => $this->urlGenerator->generate(
+                $this->eventDetailRouteName,
+                ['eventId' => $eventId],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
+            'cardSystems' => $this->urlGenerator->generate(
+                $this->eventCardSystemsRouteName,
+                ['eventId' => $eventId],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ),
+            'hasTicketSales' => $this->uitpas->eventHasTicketSales($eventId),
+        ];
+
+        return new JsonResponse($data);
+    }
+}

--- a/src/UiTPASService/Controller/OrganizerCardSystemsController.php
+++ b/src/UiTPASService/Controller/OrganizerCardSystemsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use CultuurNet\UDB3\UiTPASService\Controller\Response\CardSystemsJsonResponse;
+
+class OrganizerCardSystemsController
+{
+    /**
+     * @var CultureFeed_Uitpas
+     */
+    private $uitpas;
+
+    public function __construct(CultureFeed_Uitpas $uitpas)
+    {
+        $this->uitpas = $uitpas;
+    }
+
+    public function get(string $organizerId): CardSystemsJsonResponse
+    {
+        $cardSystems = $this->uitpas->getCardSystemsForOrganizer($organizerId);
+        return new CardSystemsJsonResponse($cardSystems->objects);
+    }
+}

--- a/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
+++ b/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller\Response;
+
+use CultureFeed_Uitpas_CardSystem;
+use CultureFeed_Uitpas_DistributionKey;
+use Symfony\Component\HttpFoundation\Response;
+
+class CardSystemsJsonResponse extends Response
+{
+    /**
+     * @param CultureFeed_Uitpas_CardSystem[] $cardSystems
+     * @param int $status
+     * @param array $headers
+     */
+    public function __construct(array $cardSystems, int $status = 200, array $headers = array())
+    {
+        $data = [];
+        foreach ($cardSystems as $cardSystem) {
+            $data[$cardSystem->id] = $this->convertCardSystemToArray($cardSystem);
+        }
+
+        $content = json_encode($data);
+
+        parent::__construct($content, $status, $headers);
+    }
+
+    private function convertCardSystemToArray(CultureFeed_Uitpas_CardSystem $cardSystem): array
+    {
+        $distributionKeys = [];
+        foreach ($cardSystem->distributionKeys as $distributionKey) {
+            $distributionKeys[$distributionKey->id] = $this->convertDistributionKeyToArray($distributionKey);
+        }
+
+        return [
+            'id' => $cardSystem->id,
+            'name' => $cardSystem->name,
+            'distributionKeys' => $distributionKeys,
+        ];
+    }
+
+    private function convertDistributionKeyToArray(CultureFeed_Uitpas_DistributionKey $distributionKey): array
+    {
+        return [
+            'id' => $distributionKey->id,
+            'name' => $distributionKey->name,
+        ];
+    }
+}

--- a/tests/UiTPASService/Controller/EventCardSystemsControllerTest.php
+++ b/tests/UiTPASService/Controller/EventCardSystemsControllerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use CultureFeed_Uitpas_CardSystem;
+use CultureFeed_Uitpas_DistributionKey;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class EventCardSystemsControllerTest extends TestCase
+{
+    /**
+     * @var CultureFeed_Uitpas|MockObject
+     */
+    private $uitpas;
+
+    /**
+     * @var EventCardSystemsController
+     */
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->uitpas = $this->createMock(CultureFeed_Uitpas::class);
+        $this->controller = new EventCardSystemsController($this->uitpas);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_card_systems_of_an_event()
+    {
+        $eventId = 'db93a8d0-331a-4575-a23d-2c78d4ceb925';
+
+        $cardSystem1 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem1->id = 'card-system-1';
+        $cardSystem1->name = 'Card system 1';
+
+        $distributionKey1 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey1->id = 'distribution-key-1';
+        $distributionKey1->name = 'Distribution key 1';
+
+        $distributionKey2 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey2->id = 'distribution-key-2';
+        $distributionKey2->name = 'Distribution key 2';
+
+        $cardSystem1->distributionKeys = [
+            $distributionKey1,
+            $distributionKey2,
+        ];
+
+        $cardSystem2 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem2->id = 'card-system-2';
+        $cardSystem2->name = 'Card system 2';
+
+        $distributionKey3 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey3->id = 'distribution-key-3';
+        $distributionKey3->name = 'Distribution key 3';
+
+        $distributionKey4 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey4->id = 'distribution-key-4';
+        $distributionKey4->name = 'Distribution key 4';
+
+        $cardSystem2->distributionKeys = [
+            $distributionKey3,
+            $distributionKey4,
+        ];
+
+        $cardSystems = [
+            $cardSystem1,
+            $cardSystem2,
+        ];
+
+        $resultSet = new \CultureFeed_ResultSet();
+        $resultSet->objects = $cardSystems;
+        $resultSet->total = 2;
+
+        $this->uitpas->expects($this->once())
+            ->method('getCardSystemsForEvent')
+            ->with($eventId)
+            ->willReturn($resultSet);
+
+        $expectedResponseContent = (object) [
+            'card-system-1' => (object) [
+                'id' => 'card-system-1',
+                'name' => 'Card system 1',
+                'distributionKeys' => (object) [
+                    'distribution-key-1' => (object) [
+                        'id' => 'distribution-key-1',
+                        'name' => 'Distribution key 1',
+                    ],
+                    'distribution-key-2' => (object) [
+                        'id' => 'distribution-key-2',
+                        'name' => 'Distribution key 2',
+                    ],
+                ],
+            ],
+            'card-system-2' => (object) [
+                'id' => 'card-system-2',
+                'name' => 'Card system 2',
+                'distributionKeys' => (object) [
+                    'distribution-key-3' => (object) [
+                        'id' => 'distribution-key-3',
+                        'name' => 'Distribution key 3',
+                    ],
+                    'distribution-key-4' => (object) [
+                        'id' => 'distribution-key-4',
+                        'name' => 'Distribution key 4',
+                    ],
+                ],
+            ],
+        ];
+
+        $actualResponseContent = json_decode(
+            $this->controller->get($eventId)->getContent()
+        );
+
+        $this->assertEquals($expectedResponseContent, $actualResponseContent);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_set_a_list_of_card_systems_to_an_event()
+    {
+        $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
+        $cardSystemIds = ['3', '15'];
+
+        $request = new Request([], [], [], [], [], [], json_encode($cardSystemIds));
+
+        $this->uitpas->expects($this->once())
+            ->method('setCardSystemsForEvent')
+            ->with($eventId, $cardSystemIds)
+            ->willReturn(null);
+
+        $response = $this->controller->set($eventId, $request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_response_if_the_list_of_card_system_ids_is_not_an_array()
+    {
+        $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
+        $cardSystemIds = 3;
+
+        $request = new Request([], [], [], [], [], [], json_encode($cardSystemIds));
+
+        $this->uitpas->expects($this->never())
+            ->method('setCardSystemsForEvent')
+            ->willReturn(null);
+
+        $response = $this->controller->set($eventId, $request);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_card_system_with_an_automatic_distribution_key_to_an_event()
+    {
+        $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
+        $cardSystemId = '15';
+
+        $this->uitpas->expects($this->once())
+            ->method('addCardSystemToEvent')
+            ->with($eventId, $cardSystemId)
+            ->willReturn(null);
+
+        $response = $this->controller->add($eventId, $cardSystemId);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_card_system_with_a_manual_distribution_key_to_an_event()
+    {
+        $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
+        $cardSystemId = '27';
+        $distributionKey = '1';
+
+        $this->uitpas->expects($this->once())
+            ->method('addCardSystemToEvent')
+            ->with($eventId, $cardSystemId, $distributionKey)
+            ->willReturn(null);
+
+        $response = $this->controller->add($eventId, $cardSystemId, $distributionKey);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_remove_a_card_system_from_an_event()
+    {
+        $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
+        $cardSystemId = '15';
+
+        $this->uitpas->expects($this->once())
+            ->method('deleteCardSystemFromEvent')
+            ->with($eventId, $cardSystemId)
+            ->willReturn(null);
+
+        $response = $this->controller->delete($eventId, $cardSystemId);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/UiTPASService/Controller/EventDetailControllerTest.php
+++ b/tests/UiTPASService/Controller/EventDetailControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class EventDetailControllerTest extends TestCase
+{
+    private const EVENT_DETAIL = 'mock.event.detail';
+    private const EVENT_CARD_SYSTEMS = 'mock.event.card_systems';
+
+    /**
+     * @var CultureFeed_Uitpas|MockObject
+     */
+    private $uitpas;
+
+    /**
+     * @var UrlGeneratorInterface|MockObject
+     */
+    private $urlGenerator;
+
+    /**
+     * @var EventDetailController
+     */
+    private $controller;
+
+    public function setUp()
+    {
+        $this->uitpas = $this->createMock(CultureFeed_Uitpas::class);
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->controller = new EventDetailController(
+            $this->uitpas,
+            $this->urlGenerator,
+            self::EVENT_DETAIL,
+            self::EVENT_CARD_SYSTEMS
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_a_composed_event_detail()
+    {
+        $eventId = 'e2b91aab-b6e4-4b88-9883-8a4e653dc6e1';
+        $hasTicketSales = true;
+
+        $expected = [
+            '@id' => 'http://uitpas.mock/events/e2b91aab-b6e4-4b88-9883-8a4e653dc6e1',
+            'cardSystems' => 'http://uitpas.mock/events/e2b91aab-b6e4-4b88-9883-8a4e653dc6e1/cardSystems/',
+            'hasTicketSales' => $hasTicketSales,
+        ];
+
+        $this->uitpas->expects($this->once())
+            ->method('eventHasTicketSales')
+            ->with($eventId)
+            ->willReturn($hasTicketSales);
+
+        $this->urlGenerator->expects($this->any())
+            ->method('generate')
+            ->willReturnCallback(
+                function ($routeName, $parameters, $referenceType) {
+                    if (!isset($parameters['eventId'])) {
+                        throw new \InvalidArgumentException('Expected eventId parameter.');
+                    }
+
+                    $url = '';
+                    switch ($routeName) {
+                        case self::EVENT_DETAIL:
+                            $url = '/events/' . $parameters['eventId'];
+                            break;
+                        case self::EVENT_CARD_SYSTEMS:
+                            $url = '/events/' . $parameters['eventId'] . '/cardSystems/';
+                            break;
+                    }
+
+                    if ($referenceType === UrlGeneratorInterface::ABSOLUTE_URL) {
+                        $url = 'http://uitpas.mock' . $url;
+                    }
+
+                    return $url;
+                }
+            );
+
+        $response = $this->controller->get($eventId);
+        $actual = json_decode($response->getContent(), true);
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/UiTPASService/Controller/OrganizerCardSystemsControllerTest.php
+++ b/tests/UiTPASService/Controller/OrganizerCardSystemsControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_ResultSet;
+use CultureFeed_Uitpas;
+use CultureFeed_Uitpas_CardSystem;
+use CultureFeed_Uitpas_DistributionKey;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class OrganizerCardSystemsControllerTest extends TestCase
+{
+    /**
+     * @var CultureFeed_Uitpas|MockObject
+     */
+    private $uitPas;
+
+    /**
+     * @var OrganizerCardSystemsController
+     */
+    private $controller;
+
+    public function setUp()
+    {
+        $this->uitPas = $this->createMock(CultureFeed_Uitpas::class);
+        $this->controller = new OrganizerCardSystemsController($this->uitPas);
+    }
+
+    /**
+     * @test
+     */
+    public function it_responds_with_a_list_of_card_systems_with_distribution_keys_for_a_given_organizer()
+    {
+        $organizerId = 'db93a8d0-331a-4575-a23d-2c78d4ceb925';
+
+        $cardSystem1 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem1->id = 'card-system-1';
+        $cardSystem1->name = 'Card system 1';
+
+        $distributionKey1 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey1->id = 'distribution-key-1';
+        $distributionKey1->name = 'Distribution key 1';
+
+        $distributionKey2 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey2->id = 'distribution-key-2';
+        $distributionKey2->name = 'Distribution key 2';
+
+        $cardSystem1->distributionKeys = [
+            $distributionKey1,
+            $distributionKey2,
+        ];
+
+        $cardSystem2 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem2->id = 'card-system-2';
+        $cardSystem2->name = 'Card system 2';
+
+        $distributionKey3 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey3->id = 'distribution-key-3';
+        $distributionKey3->name = 'Distribution key 3';
+
+        $distributionKey4 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey4->id = 'distribution-key-4';
+        $distributionKey4->name = 'Distribution key 4';
+
+        $cardSystem2->distributionKeys = [
+            $distributionKey3,
+            $distributionKey4,
+        ];
+
+        $cardSystems = [
+            $cardSystem1,
+            $cardSystem2,
+        ];
+
+        $resultSet = new CultureFeed_ResultSet();
+        $resultSet->objects = $cardSystems;
+        $resultSet->total = 2;
+
+        $this->uitPas->expects($this->once())
+            ->method('getCardSystemsForOrganizer')
+            ->with($organizerId)
+            ->willReturn($resultSet);
+
+        $expectedResponseContent = (object) [
+            'card-system-1' => (object) [
+                'id' => 'card-system-1',
+                'name' => 'Card system 1',
+                'distributionKeys' => (object) [
+                    'distribution-key-1' => (object) [
+                        'id' => 'distribution-key-1',
+                        'name' => 'Distribution key 1',
+                    ],
+                    'distribution-key-2' => (object) [
+                        'id' => 'distribution-key-2',
+                        'name' => 'Distribution key 2',
+                    ],
+                ],
+            ],
+            'card-system-2' => (object) [
+                'id' => 'card-system-2',
+                'name' => 'Card system 2',
+                'distributionKeys' => (object) [
+                    'distribution-key-3' => (object) [
+                        'id' => 'distribution-key-3',
+                        'name' => 'Distribution key 3',
+                    ],
+                    'distribution-key-4' => (object) [
+                        'id' => 'distribution-key-4',
+                        'name' => 'Distribution key 4',
+                    ],
+                ],
+            ],
+        ];
+
+        $actualResponseContent = json_decode(
+            $this->controller->get($organizerId)->getContent()
+        );
+
+        $this->assertEquals($expectedResponseContent, $actualResponseContent);
+    }
+}

--- a/tests/UiTPASService/Controller/Response/CardSystemsJsonResponseTest.php
+++ b/tests/UiTPASService/Controller/Response/CardSystemsJsonResponseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace CultuurNet\UDB3\UiTPASService\Controller\Response;
+
+use CultureFeed_Uitpas_CardSystem;
+use CultureFeed_Uitpas_DistributionKey;
+use PHPUnit\Framework\TestCase;
+
+class CardSystemsJsonResponseTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_encode_the_injected_card_systems_to_json()
+    {
+        $cardSystem1 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem1->id = 1;
+        $cardSystem1->name = 'Card system 1';
+
+        $dk1 = new CultureFeed_Uitpas_DistributionKey();
+        $dk1->id = 1;
+        $dk1->name = 'Distribution key 1';
+
+        $dk2 = new CultureFeed_Uitpas_DistributionKey();
+        $dk2->id = 2;
+        $dk2->name = 'Distribution key 2';
+
+        $cardSystem1->distributionKeys = [$dk1, $dk2];
+
+        $cardSystem2 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem2->id = 2;
+        $cardSystem2->name = 'Card system 2';
+
+        $dk3 = new CultureFeed_Uitpas_DistributionKey();
+        $dk3->id = 3;
+        $dk3->name = 'Distribution key 3';
+
+        $cardSystem2->distributionKeys = [$dk3];
+
+        $cardSystem3 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem3->id = 3;
+        $cardSystem3->name = 'Card system 3';
+
+        $cardSystems = [
+            $cardSystem1,
+            $cardSystem2,
+            $cardSystem3,
+        ];
+
+        $response = new CardSystemsJsonResponse($cardSystems);
+
+        $expected = json_decode(file_get_contents(__DIR__ . '/data/cardSystems.json'));
+        $actual = json_decode($response->getContent());
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_an_empty_json_array_if_no_card_systems_were_injected()
+    {
+        $response = new CardSystemsJsonResponse([]);
+
+        $expected = '[]';
+        $actual = $response->getContent();
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/UiTPASService/Controller/Response/data/cardSystems.json
+++ b/tests/UiTPASService/Controller/Response/data/cardSystems.json
@@ -1,0 +1,31 @@
+{
+    "1": {
+        "id": 1,
+        "name": "Card system 1",
+        "distributionKeys": {
+            "1": {
+                "id": 1,
+                "name": "Distribution key 1"
+            },
+            "2": {
+                "id": 2,
+                "name": "Distribution key 2"
+            }
+        }
+    },
+    "2": {
+        "id": 2,
+        "name": "Card system 2",
+        "distributionKeys": {
+            "3": {
+                "id": 3,
+                "name": "Distribution key 3"
+            }
+        }
+    },
+    "3": {
+        "id": 3,
+        "name": "Card system 3",
+        "distributionKeys": []
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -11,8 +11,8 @@ use CultuurNet\UDB3\Silex\Role\UserPermissionsServiceProvider;
 use CultuurNet\UDB3\Http\Management\PermissionsVoter;
 use CultuurNet\UDB3\Http\Management\UserPermissionsVoter;
 use CultuurNet\UDB3\Silex\SentryErrorHandler;
-use CultuurNet\UDB3\Silex\UiTPAS\UiTPASControllerProvider;
 use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceEventControllerProvider;
+use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceLabelsControllerProvider;
 use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceOrganizerControllerProvider;
 use Sentry\State\HubInterface;
 use Silex\Application;
@@ -220,7 +220,7 @@ $app->mount('/labels', new \CultuurNet\UDB3\Silex\Labels\LabelsControllerProvide
 $app->mount('/jobs', new \CultuurNet\UDB3\Silex\Jobs\JobsControllerProvider());
 $app->mount('/contexts', new \CultuurNet\UDB3\Silex\JSONLD\ContextControllerProvider());
 $app->mount('/productions', new \CultuurNet\UDB3\Silex\Event\ProductionControllerProvider());
-$app->mount('/uitpas', new UiTPASControllerProvider());
+$app->mount('/uitpas/labels', new UiTPASServiceLabelsControllerProvider());
 $app->mount('/uitpas/events', new UiTPASServiceEventControllerProvider());
 $app->mount('/uitpas/organizers', new UiTPASServiceOrganizerControllerProvider());
 

--- a/web/index.php
+++ b/web/index.php
@@ -12,6 +12,8 @@ use CultuurNet\UDB3\Http\Management\PermissionsVoter;
 use CultuurNet\UDB3\Http\Management\UserPermissionsVoter;
 use CultuurNet\UDB3\Silex\SentryErrorHandler;
 use CultuurNet\UDB3\Silex\UiTPAS\UiTPASControllerProvider;
+use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceEventControllerProvider;
+use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceOrganizerControllerProvider;
 use Sentry\State\HubInterface;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -219,6 +221,8 @@ $app->mount('/jobs', new \CultuurNet\UDB3\Silex\Jobs\JobsControllerProvider());
 $app->mount('/contexts', new \CultuurNet\UDB3\Silex\JSONLD\ContextControllerProvider());
 $app->mount('/productions', new \CultuurNet\UDB3\Silex\Event\ProductionControllerProvider());
 $app->mount('/uitpas', new UiTPASControllerProvider());
+$app->mount('/uitpas/events', new UiTPASServiceEventControllerProvider());
+$app->mount('/uitpas/organizers', new UiTPASServiceOrganizerControllerProvider());
 
 $app->get(
     '/user',

--- a/web/index.php
+++ b/web/index.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\AnyOfRequestMatcher;
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\PreflightRequestMatcher;
 use CultuurNet\UDB3\Jwt\Silex\JwtServiceProvider;
+use CultuurNet\UDB3\Jwt\Symfony\Authentication\JwtAuthenticationEntryPoint;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Silex\Import\ImportControllerProvider;
 use CultuurNet\UDB3\Silex\Role\UserPermissionsServiceProvider;
@@ -126,6 +127,16 @@ $app['security.access_rules'] = array(
         Permission::LABELS_BEHEREN
     ),
     array('^/(roles|permissions|users)/.*', Permission::GEBRUIKERS_BEHEREN),
+);
+
+$app['security.entry_point.form._proto'] = $app::protect(
+    function () use ($app) {
+        return $app->share(
+            function () {
+                return new JwtAuthenticationEntryPoint();
+            }
+        );
+    }
 );
 
 // Enable CORS.


### PR DESCRIPTION
### Added

- Added `/uitpas/events/` endpoints from udb3-uitpas-service
- Added `/uitpas/organizers/` endpoints from udb3-uitpas-service
- Added better error handling for CultureFeed exceptions, based on udb3-uitpas-service
- Added 401 status code for response when a token is missing in a request that needs one, using a custom "EntryPoint" in the firewall configuration (also based on udb3-uitpas-service and an improvement over the default redirect to `/login` which doesn't exist)

### Changed

- Refactored code of existing `/uitpas/labels/` endpoint a bit for consistency

---
Ticket: https://jira.uitdatabank.be/browse/III-3733
