### PR TITLE
Updated PHPStan config to include bootstrap.php and web/index.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1058,7 +1058,7 @@ $app['logger.amqp.event_bus_forwarder'] = $app::share(
 
 $app['uitpas'] = $app->share(
     function (Application $app) {
-        /** @var CultureFeed $culturefeed */
+        /** @var CultureFeed $cultureFeed */
         $cultureFeed = $app['culturefeed'];
         return $cultureFeed->uitpas();
     }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -587,8 +587,14 @@ $app['logger.command_bus'] = $app->share(
                         $emitter
                     );
                     break;
+
                 default:
-                    continue 2;
+                    $handler = null;
+                    break;
+            }
+
+            if (!$handler) {
+                continue;
             }
 
             $handler->setLevel($handler_config['level']);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,7 @@ parameters:
 		- app
 		- src
 		- tests
+		- bootstrap.php
+		- web/index.php
 	bootstrapFiles:
 		- tests/bootstrap.php


### PR DESCRIPTION
### Changed

- Updated PHPStan config to also check `bootstrap.php` and `web/index.php` (these were added to `paths` instead of `bootstrapFiles` because `bootstrapFiles` is bootstrapping that needs to happen before phpstan can start its checks, not bootstrapping of the app)

### Fixed

- Fixed two PHPStan errors that popped up after the config changes
