### PR TITLE
III-3653 Update unique organizers

### DIFF
--- a/app/Console/UpdateUniqueLabels.php
+++ b/app/Console/UpdateUniqueLabels.php
@@ -33,7 +33,7 @@ class UpdateUniqueLabels extends Command
     protected function configure(): void
     {
         $this->setName('label:update-unique')
-            ->setDescription('Updates the table with unique labels based on the `LabelAdded` events inside the event store.');
+            ->setDescription('Updates the table with unique labels based on the `CultuurNet.UDB3.Label.Events.Created` events inside the event store.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/Console/UpdateUniqueLabels.php
+++ b/app/Console/UpdateUniqueLabels.php
@@ -110,6 +110,7 @@ class UpdateUniqueLabels extends Command
             ->select('uuid')
             ->from('event_store')
             ->where('type = "' . self::LABEL_CREATED . '"')
+            ->orderBy('id')
             ->execute()
             ->rowCount();
     }

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -129,7 +129,7 @@ class UpdateUniqueOrganizers extends Command
         // 2. The organizer uuid is not present
         // 3. The organizer uuid is present with another value
 
-        $existingOrganizerUrl = $this->connection->createQueryBuilder()
+        $existingOrganizerUrls = $this->connection->createQueryBuilder()
             ->select('unique_col')
             ->from('organizer_unique_websites')
             ->where('uuid_col = :uuid')
@@ -137,6 +137,7 @@ class UpdateUniqueOrganizers extends Command
             ->execute()
             ->fetchAll(PDO::FETCH_COLUMN);
 
+        $existingOrganizerUrl = \count($existingOrganizerUrls) === 1 ? $existingOrganizerUrls[0] : null;
         if ($existingOrganizerUrl === (string) $organizerUrl) {
             return;
         }

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -63,11 +63,11 @@ class UpdateUniqueOrganizers extends Command
                 $organizerUuid = $this->getOrganizerUuid($organizerEvent);
                 $organizerUrl = $this->getOrganizerWebsite($organizerEvent);
 
-                try {
-                    $this->updateOrganizer($organizerUuid, $organizerUrl);
-                    $messages[] = 'Added organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
-                } catch (UniqueConstraintViolationException $exception) {
-                    $messages[] = 'Unique exception for organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
+                $updated = $this->updateOrganizer($organizerUuid, $organizerUrl);
+                if ($updated) {
+                    $messages[] = 'Added/updated organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
+                } else {
+                    $messages[] = 'Skipped organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
                 }
 
                 $progressBar->advance();

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -113,6 +113,7 @@ class UpdateUniqueOrganizers extends Command
             ->from('event_store')
             ->where('type = "' . self::ORGANIZER_CREATED . '"')
             ->orWhere('type = "' . self::ORGANIZER_WEBSITE_UPDATED . '"')
+            ->orderBy('id')
             ->execute()
             ->rowCount();
     }

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use PDO;
+use Rhumsaa\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use ValueObjects\Web\Url;
+
+class UpdateUniqueOrganizers extends Command
+{
+    private const MAX_RESULTS = 1000;
+    private const ORGANIZER_CREATED = 'CultuurNet.UDB3.Organizer.Events.OrganizerCreatedWithUniqueWebsite';
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        parent::__construct();
+        $this->connection = $connection;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('organizer:update-unique')
+            ->setDescription('Updates the table with organizer unique websites based on the `OrganizerCreated` events inside the event store.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $organizerCreatedEventsCount = $this->getAllOrganizerCreatedEventsCount();
+
+        if ($organizerCreatedEventsCount <= 0) {
+            $output->writeln('No `OrganizerCreated` events found.');
+            return 0;
+        }
+
+        $helper = $this->getHelper('question');
+        $updateQuestion = new ConfirmationQuestion('Update ' . $organizerCreatedEventsCount . ' organizer(s)? [y/N] ', false);
+        if (!$helper->ask($input, $output, $updateQuestion)) {
+            return 0;
+        }
+
+        $progressBar = new ProgressBar($output, $organizerCreatedEventsCount);
+
+        $messages = [];
+        $offset = 0;
+        do {
+            $organizerCreatedEvents = $this->getAllOrganizerCreatedEvents($offset);
+
+            foreach ($organizerCreatedEvents as $organizerCreatedEvent) {
+                $organizerUuid = $this->getOrganizerUuid($organizerCreatedEvent);
+                $organizerUrl = $this->getOrganizerWebsite($organizerCreatedEvent);
+
+                try {
+                    $this->updateOrganizer($organizerUuid, $organizerUrl);
+                    $messages[] = 'Added organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
+                } catch (UniqueConstraintViolationException $exception) {
+                    $messages[] = 'Unique exception for organizer ' . $organizerUrl . ' with uuid ' . $organizerUuid->toString();
+                }
+
+                $progressBar->advance();
+            }
+
+            $offset += count($organizerCreatedEvents);
+        } while ($offset < $organizerCreatedEventsCount);
+
+        $progressBar->finish();
+        $output->writeln('');
+
+        $reportQuestion = new ConfirmationQuestion('Dump update report? [y/N] ', false);
+        if (!$helper->ask($input, $output, $reportQuestion)) {
+            return 0;
+        }
+
+        $reportFile = fopen('update_unique_organizers_report.txt', 'wb');
+        foreach ($messages as $message) {
+            fwrite($reportFile, $message. \PHP_EOL);
+        }
+        \fclose($reportFile);
+
+        return 0;
+    }
+
+    private function getAllOrganizerCreatedEvents(int $offset): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('uuid, payload')
+            ->from('event_store')
+            ->where('type = "' . self::ORGANIZER_CREATED . '"')
+            ->setFirstResult($offset)
+            ->setMaxResults(self::MAX_RESULTS)
+            ->execute()
+            ->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function getAllOrganizerCreatedEventsCount(): int
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('uuid')
+            ->from('event_store')
+            ->where('type = "' . self::ORGANIZER_CREATED . '"')
+            ->execute()
+            ->rowCount();
+    }
+
+    /**
+     * @throws DBALException
+     * @throws UniqueConstraintViolationException
+     */
+    private function updateOrganizer(Uuid $organizerUuid, Url $organizerUrl): void
+    {
+        $this->connection
+            ->insert(
+                'organizer_unique_websites',
+                [
+                    'uuid_col' => $organizerUuid->toString(),
+                    'unique_col' => (string) $organizerUrl,
+                ]
+            );
+    }
+
+    private function getOrganizerUuid(array $organizerCreatedEvent): Uuid
+    {
+        return Uuid::fromString($organizerCreatedEvent['uuid']);
+    }
+
+    private function getOrganizerWebsite(array $organizerCreatedEvent): Url
+    {
+        $payloadArray = json_decode($organizerCreatedEvent['payload'], true);
+        return Url::fromNative($payloadArray['payload']['website']);
+    }
+}

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -86,9 +86,9 @@ class UpdateUniqueOrganizers extends Command
 
         $reportFile = fopen('update_unique_organizers_report.txt', 'wb');
         foreach ($messages as $message) {
-            fwrite($reportFile, $message. \PHP_EOL);
+            fwrite($reportFile, $message. PHP_EOL);
         }
-        \fclose($reportFile);
+        fclose($reportFile);
 
         return 0;
     }
@@ -136,7 +136,7 @@ class UpdateUniqueOrganizers extends Command
             ->execute()
             ->fetchAll(PDO::FETCH_COLUMN);
 
-        $existingOrganizerUrl = \count($existingOrganizerUrls) === 1 ? $existingOrganizerUrls[0] : null;
+        $existingOrganizerUrl = count($existingOrganizerUrls) === 1 ? $existingOrganizerUrls[0] : null;
 
         if ($existingOrganizerUrl === (string) $organizerUrl) {
             return false;

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -4,7 +4,6 @@ namespace CultuurNet\UDB3\Silex\Console;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use PDO;
 use Rhumsaa\Uuid\Uuid;
 use Symfony\Component\Console\Command\Command;

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -120,9 +120,8 @@ class UpdateUniqueOrganizers extends Command
 
     /**
      * @throws DBALException
-     * @throws UniqueConstraintViolationException
      */
-    private function updateOrganizer(Uuid $organizerUuid, Url $organizerUrl): void
+    private function updateOrganizer(Uuid $organizerUuid, Url $organizerUrl): bool
     {
         // There are 3 possible states:
         // 1. The organizer uuid is present with the correct url
@@ -138,8 +137,9 @@ class UpdateUniqueOrganizers extends Command
             ->fetchAll(PDO::FETCH_COLUMN);
 
         $existingOrganizerUrl = \count($existingOrganizerUrls) === 1 ? $existingOrganizerUrls[0] : null;
+
         if ($existingOrganizerUrl === (string) $organizerUrl) {
-            return;
+            return false;
         }
 
         if ($existingOrganizerUrl === null) {
@@ -152,7 +152,7 @@ class UpdateUniqueOrganizers extends Command
                     ]
                 );
 
-            return;
+            return true;
         }
 
         $this->connection
@@ -166,6 +166,8 @@ class UpdateUniqueOrganizers extends Command
                     'uuid_col' => $organizerUuid->toString(),
                 ]
             );
+
+        return true;
     }
 
     private function getOrganizerUuid(array $organizerEvent): Uuid

--- a/app/Console/UpdateUniqueOrganizers.php
+++ b/app/Console/UpdateUniqueOrganizers.php
@@ -166,14 +166,14 @@ class UpdateUniqueOrganizers extends Command
             );
     }
 
-    private function getOrganizerUuid(array $organizerCreatedEvent): Uuid
+    private function getOrganizerUuid(array $organizerEvent): Uuid
     {
-        return Uuid::fromString($organizerCreatedEvent['uuid']);
+        return Uuid::fromString($organizerEvent['uuid']);
     }
 
-    private function getOrganizerWebsite(array $organizerCreatedEvent): Url
+    private function getOrganizerWebsite(array $organizerEvent): Url
     {
-        $payloadArray = json_decode($organizerCreatedEvent['payload'], true);
+        $payloadArray = json_decode($organizerEvent['payload'], true);
         return Url::fromNative($payloadArray['payload']['website']);
     }
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Silex\Console\ReindexOffersWithPopularityScore;
 use CultuurNet\UDB3\Silex\Console\ReplayCommand;
 use CultuurNet\UDB3\Silex\Console\UpdateOfferStatusCommand;
 use CultuurNet\UDB3\Silex\Console\UpdateUniqueLabels;
+use CultuurNet\UDB3\Silex\Console\UpdateUniqueOrganizers;
 use CultuurNet\UDB3\Silex\Console\ValidatePlaceJsonLdCommand;
 use CultuurNet\UDB3\Silex\Event\EventJSONLDServiceProvider;
 use CultuurNet\UDB3\Silex\Organizer\OrganizerJSONLDServiceProvider;
@@ -123,6 +124,7 @@ $consoleApp->add(new UpdateOfferStatusCommand(OfferType::PLACE(), $app['event_co
 $consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
 $consoleApp->add(new ChangeOfferOwnerInBulk($app['event_command_bus'], $app['offer_permission_query']));
 $consoleApp->add(new UpdateUniqueLabels($app['dbal_connection']));
+$consoleApp->add(new UpdateUniqueOrganizers($app['dbal_connection']));
 
 try {
     $consoleApp->run();


### PR DESCRIPTION
### Added
- Add script to update the unique websites of organizers based on the events `OrganizerCreatedWithUniqueWebsite` and `WebsiteUpdated`

Note: An extra select statement was added to verify what is already inside the unique table. This makes it possible to do an update or insert. It also makes it possible to just skip an organizer that is already correctly stored inside the unique table.

---
Ticket: https://jira.uitdatabank.be/browse/III-3653
