### PR TITLE
III-3766 Preserve `-` as al ages

### DIFF
--- a/src/Model/ValueObject/Audience/AgeRange.php
+++ b/src/Model/ValueObject/Audience/AgeRange.php
@@ -10,15 +10,11 @@ class AgeRange
     private $from;
 
     /**
-     * @var Age
+     * @var ?Age
      */
     private $to;
 
-    /**
-     * @param Age|null $from
-     * @param Age|null $to
-     */
-    public function __construct(Age $from = null, Age $to = null)
+    public function __construct(?Age $from = null, ?Age $to = null)
     {
         $from = $from ?: new Age(0);
 
@@ -30,63 +26,37 @@ class AgeRange
         $this->to = $to;
     }
 
-    /**
-     * @return Age
-     */
-    public function getFrom()
+    public function getFrom(): Age
     {
         return $this->from;
     }
 
-    /**
-     * @return Age|null
-     */
-    public function getTo()
+    public function getTo():? Age
     {
         return $this->to;
     }
 
-    /**
-     * @param Age $from
-     * @return AgeRange
-     */
-    public static function from(Age $from)
+    public static function from(Age $from): AgeRange
     {
         return new self($from, null);
     }
 
-    /**
-     * @param Age $to
-     * @return AgeRange
-     */
-    public static function to(Age $to)
+    public static function to(Age $to): AgeRange
     {
         return new self(null, $to);
     }
 
-    /**
-     * @param Age $age
-     * @return AgeRange
-     */
-    public static function exactly(Age $age)
+    public static function exactly(Age $age): AgeRange
     {
         return new self($age, $age);
     }
 
-    /**
-     * @param Age $from
-     * @param Age $to
-     * @return AgeRange
-     */
-    public static function fromTo(Age $from, Age $to)
+    public static function fromTo(Age $from, Age $to): AgeRange
     {
         return new self($from, $to);
     }
-
-    /**
-     * @return AgeRange
-     */
-    public static function any()
+    
+    public static function any(): AgeRange
     {
         return new self();
     }

--- a/src/Model/ValueObject/Audience/AgeRange.php
+++ b/src/Model/ValueObject/Audience/AgeRange.php
@@ -31,7 +31,7 @@ class AgeRange
         return $this->from;
     }
 
-    public function getTo():? Age
+    public function getTo(): ?Age
     {
         return $this->to;
     }

--- a/src/Model/ValueObject/Audience/AgeRange.php
+++ b/src/Model/ValueObject/Audience/AgeRange.php
@@ -5,7 +5,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Audience;
 class AgeRange
 {
     /**
-     * @var Age
+     * @var ?Age
      */
     private $from;
 
@@ -16,7 +16,11 @@ class AgeRange
 
     public function __construct(?Age $from = null, ?Age $to = null)
     {
-        $from = $from ?: new Age(0);
+        // Make sure not to convert " - " which is all ages to "0- " which would apply to Vlieg
+        // So only convert " -X" to "0-X"
+        if ($from === null && $to !== null) {
+            $from = new Age(0);
+        }
 
         if ($from && $to && $from->gt($to)) {
             throw new \InvalidArgumentException('"From" age should not be greater than the "to" age.');
@@ -26,7 +30,7 @@ class AgeRange
         $this->to = $to;
     }
 
-    public function getFrom(): Age
+    public function getFrom(): ?Age
     {
         return $this->from;
     }
@@ -55,7 +59,7 @@ class AgeRange
     {
         return new self($from, $to);
     }
-    
+
     public static function any(): AgeRange
     {
         return new self();

--- a/src/Offer/AgeRange.php
+++ b/src/Offer/AgeRange.php
@@ -61,14 +61,8 @@ class AgeRange
     /**
      * @throws InvalidAgeRangeException
      */
-    public static function fromString($ageRangeString): AgeRange
+    public static function fromString(string $ageRangeString): AgeRange
     {
-        if (!is_string($ageRangeString)) {
-            throw new InvalidAgeRangeException(
-                'Date-range should be of type string.'
-            );
-        }
-
         $stringValues = explode('-', $ageRangeString);
 
         if (empty($stringValues) || !isset($stringValues[1])) {

--- a/src/Offer/AgeRange.php
+++ b/src/Offer/AgeRange.php
@@ -8,7 +8,7 @@ use ValueObjects\Person\Age;
 class AgeRange
 {
     /**
-     * @var Age
+     * @var ?Age
      */
     private $from;
 
@@ -22,7 +22,11 @@ class AgeRange
      */
     public function __construct(?Age $from = null, ?Age $to = null)
     {
-        $from = $from ?: new Age(0);
+        // Make sure not to convert " - " which is all ages to "0- " which would apply to Vlieg
+        // So only convert " -X" to "0-X"
+        if ($from === null && $to !== null) {
+            $from = new Age(0);
+        }
 
         $this->guardValidAgeRange($from, $to);
 
@@ -33,14 +37,14 @@ class AgeRange
     /**
      * @throws InvalidAgeRangeException
      */
-    private function guardValidAgeRange(Age $from, ?Age $to = null): void
+    private function guardValidAgeRange(?Age $from, ?Age $to = null): void
     {
         if ($from && $to && $from > $to) {
             throw new InvalidAgeRangeException('"from" age should not exceed "to" age');
         }
     }
 
-    public function getFrom(): Age
+    public function getFrom(): ?Age
     {
         return $this->from;
     }

--- a/src/Offer/AgeRange.php
+++ b/src/Offer/AgeRange.php
@@ -83,8 +83,7 @@ class AgeRange
             );
         }
 
-        $fromString = $stringValues[0];
-        $toString = $stringValues[1];
+        [$fromString, $toString] = $stringValues;
 
         if (is_numeric($fromString) || empty($fromString)) {
             $from = is_numeric($fromString) ? new Age($fromString) : null;

--- a/src/Offer/AgeRange.php
+++ b/src/Offer/AgeRange.php
@@ -8,21 +8,19 @@ use ValueObjects\Person\Age;
 class AgeRange
 {
     /**
-     * @var null|Age
+     * @var Age
      */
     private $from;
 
     /**
-     * @var null|Age
+     * @var ?Age
      */
     private $to;
 
     /**
-     * AgeRange constructor.
-     * @param null|Age $from
-     * @param null|Age $to
+     * @throws InvalidAgeRangeException
      */
-    public function __construct(Age $from = null, Age $to = null)
+    public function __construct(?Age $from = null, ?Age $to = null)
     {
         $from = $from ?: new Age(0);
 
@@ -33,38 +31,26 @@ class AgeRange
     }
 
     /**
-     * @param Age $from
-     * @param null|Age $to
-     *
      * @throws InvalidAgeRangeException
      */
-    private function guardValidAgeRange(Age $from, Age $to = null)
+    private function guardValidAgeRange(Age $from, ?Age $to = null): void
     {
         if ($from && $to && $from > $to) {
             throw new InvalidAgeRangeException('"from" age should not exceed "to" age');
         }
     }
 
-    /**
-     * @return Age
-     */
-    public function getFrom()
+    public function getFrom(): Age
     {
         return $this->from;
     }
 
-    /**
-     * @return null|Age
-     */
-    public function getTo()
+    public function getTo(): ?Age
     {
         return $this->to;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         $from = $this->from ? (string) $this->from : '';
         $to = $this->to ? (string) $this->to : '';
@@ -73,12 +59,9 @@ class AgeRange
     }
 
     /**
-     * @param string $ageRangeString
-     * @return AgeRange
-     *
      * @throws InvalidAgeRangeException
      */
-    public static function fromString($ageRangeString)
+    public static function fromString($ageRangeString): AgeRange
     {
         if (!is_string($ageRangeString)) {
             throw new InvalidAgeRangeException(
@@ -122,20 +105,12 @@ class AgeRange
         return new self($from, $to);
     }
 
-    /**
-     * @param AgeRange $otherAgeRange
-     * @return bool
-     */
-    public function sameAs(AgeRange $otherAgeRange)
+    public function sameAs(AgeRange $otherAgeRange): bool
     {
         return "$this" === "$otherAgeRange";
     }
 
-    /**
-     * @param Udb3ModelAgeRange $udb3ModelAgeRange
-     * @return AgeRange
-     */
-    public static function fromUbd3ModelAgeRange(Udb3ModelAgeRange $udb3ModelAgeRange)
+    public static function fromUbd3ModelAgeRange(Udb3ModelAgeRange $udb3ModelAgeRange): AgeRange
     {
         $from = null;
         if ($from = $udb3ModelAgeRange->getFrom()) {

--- a/src/Offer/AgeRange.php
+++ b/src/Offer/AgeRange.php
@@ -107,7 +107,7 @@ class AgeRange
 
     public function sameAs(AgeRange $otherAgeRange): bool
     {
-        return "$this" === "$otherAgeRange";
+        return (string) $this === (string) $otherAgeRange;
     }
 
     public static function fromUbd3ModelAgeRange(Udb3ModelAgeRange $udb3ModelAgeRange): AgeRange

--- a/tests/Model/ValueObject/Audience/AgeRangeTest.php
+++ b/tests/Model/ValueObject/Audience/AgeRangeTest.php
@@ -89,7 +89,7 @@ class AgeRangeTest extends TestCase
     {
         $range = AgeRange::any();
 
-        $this->assertEquals(new Age(0), $range->getFrom());
+        $this->assertNull($range->getFrom());
         $this->assertNull($range->getTo());
     }
 }

--- a/tests/Offer/AgeRangeTest.php
+++ b/tests/Offer/AgeRangeTest.php
@@ -49,7 +49,7 @@ class AgeRangeTest extends TestCase
             [
                 'ageRangeString' => '-',
                 'expectedRange' => new AgeRange(),
-                'expectedRangeString' => '0-',
+                'expectedRangeString' => '-',
             ],
             'TODDLERS' =>
             [

--- a/tests/Offer/AgeRangeTest.php
+++ b/tests/Offer/AgeRangeTest.php
@@ -125,11 +125,6 @@ class AgeRangeTest extends TestCase
     public function invalidAgeRangeStringProvider()
     {
         return [
-            'not a string' => [
-                'ageRangeString' => 5-6,
-                'exception' => InvalidAgeRangeException::class,
-                'Date-range should be of type string.',
-            ],
             'dat boi' => [
                 'ageRangeString' => '🐸-🚲',
                 'exception' => InvalidAgeRangeException::class,


### PR DESCRIPTION
### Changed

- Make sure to preserve ` - ` as all ages and don't convert it to `0- `

---
Ticket: https://jira.uitdatabank.be/browse/III-3766
