### PR TITLE
III-3815 Do not add a location property on places through polyfill logic

### DIFF
--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -82,6 +82,10 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
 
     private function polyfillEmbeddedPlaceStatus(array $json): array
     {
+        if (!isset($json['location'])) {
+            return $json;
+        }
+
         if (isset($json['location']['status']) && !isset($json['location']['status']['type'])) {
             $json['location']['status'] = [
                 'type' => $json['location']['status'],

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -186,6 +186,16 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
             ]);
     }
 
+    /**
+     * @test
+     */
+    public function it_should_not_add_default_status_of_embedded_location_if_there_is_no_location(): void
+    {
+        $this
+            ->given(['@type' => 'Place'])
+            ->assertReturnedDocumentDoesNotContainKey('location');
+    }
+
     private function given(array $given): self
     {
         $this->repository->save(
@@ -203,6 +213,14 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
         $actualFromGet = $this->repository->get(self::DOCUMENT_ID)->getAssocBody();
         $this->assertArrayContainsExpectedKeys($expected, $actualFromFetch);
         $this->assertArrayContainsExpectedKeys($expected, $actualFromGet);
+    }
+
+    private function assertReturnedDocumentDoesNotContainKey(string $key): void
+    {
+        $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
+        $actualFromGet = $this->repository->get(self::DOCUMENT_ID)->getAssocBody();
+        $this->assertArrayNotHasKey($key, $actualFromFetch);
+        $this->assertArrayNotHasKey($key, $actualFromGet);
     }
 
     private function assertArrayContainsExpectedKeys(array $expected, array $actual): void


### PR DESCRIPTION
### Fixed

- Places no longer accidentally get a `location` property through the polyfill logic

---
Ticket: https://jira.uitdatabank.be/browse/III-3815
