### PR TITLE
III-3677 Prevent truncated production search

### DIFF
--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -195,7 +195,7 @@ class ProductionRepository extends AbstractDBALRepository
         }
 
         return array_map(
-            function (array $data) use ($forEventId) {
+            static function (array $data) use ($forEventId) {
                 return new SimilarEventPair($forEventId, $data['event_id']);
             },
             $results

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -18,14 +18,14 @@ class ProductionRepository extends AbstractDBALRepository
         parent::__construct($connection, new StringLiteral(self::TABLE_NAME));
     }
 
-    public function add(Production $production)
+    public function add(Production $production): void
     {
         foreach ($production->getEventIds() as $eventId) {
             $this->addEvent($eventId, $production);
         }
     }
 
-    public function find(ProductionId $productionId)
+    public function find(ProductionId $productionId): Production
     {
         $results = $this->getConnection()->fetchAll(
             'SELECT * FROM productions WHERE production_id = :productionId',
@@ -51,7 +51,7 @@ class ProductionRepository extends AbstractDBALRepository
         return $production;
     }
 
-    public function addEvent(string $eventId, Production $production)
+    public function addEvent(string $eventId, Production $production): void
     {
         $addedAt = Chronos::now();
         $this->getConnection()->insert(
@@ -65,7 +65,7 @@ class ProductionRepository extends AbstractDBALRepository
         );
     }
 
-    public function removeEvent(string $eventId, ProductionId $productionId)
+    public function removeEvent(string $eventId, ProductionId $productionId): void
     {
         $this->getConnection()->delete(
             $this->getTableName()->toNative(),
@@ -76,7 +76,7 @@ class ProductionRepository extends AbstractDBALRepository
         );
     }
 
-    public function moveEvents(ProductionId $from, Production $to)
+    public function moveEvents(ProductionId $from, Production $to): void
     {
         $addedAt = Chronos::now();
         $this->getConnection()->update(

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -6,7 +6,6 @@ use Cake\Chronos\Chronos;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use ValueObjects\StringLiteral\StringLiteral;
 

--- a/src/Event/Productions/ProductionRepository.php
+++ b/src/Event/Productions/ProductionRepository.php
@@ -93,9 +93,6 @@ class ProductionRepository extends AbstractDBALRepository
     }
 
     /**
-     * @param string $keyword
-     * @param int $start
-     * @param int $limit
      * @return Production[]
      */
     public function search(string $keyword, int $start, int $limit): array
@@ -177,9 +174,6 @@ class ProductionRepository extends AbstractDBALRepository
     }
 
     /**
-     * @param string $forEventId
-     * @param ProductionId $inProductionId
-     *
      * @return SimilarEventPair[]
      * @throws EntityNotFoundException
      */


### PR DESCRIPTION
### Changed

- Using `GROUP_CONCAT` can lead to clipping when the result is bigger than the column size. This was removed and an iteration is used to create the productions which their events.

---
Ticket: https://jira.uitdatabank.be/browse/III-3677
