### PR TITLE
III-3813 Avoid "cascading" replay

### DIFF
--- a/app/Console/ReindexOffersWithPopularityScore.php
+++ b/app/Console/ReindexOffersWithPopularityScore.php
@@ -2,8 +2,7 @@
 
 namespace CultuurNet\UDB3\Silex\Console;
 
-use Broadway\Domain\DomainEventStream;
-use CultuurNet\UDB3\Broadway\EventHandling\ReplayModeEventBusInterface;
+use CultuurNet\UDB3\Broadway\AMQP\AMQPPublisher;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
@@ -28,9 +27,9 @@ class ReindexOffersWithPopularityScore extends Command
     private $connection;
 
     /**
-     * @var ReplayModeEventBusInterface
+     * @var AMQPPublisher
      */
-    private $eventBus;
+    private $amqpPublisher;
 
     /**
      * @var DocumentEventFactory
@@ -40,12 +39,12 @@ class ReindexOffersWithPopularityScore extends Command
     public function __construct(
         OfferType $type,
         Connection $connection,
-        ReplayModeEventBusInterface $eventBus,
+        AMQPPublisher $AMQPPublisher,
         DocumentEventFactory $eventFactoryForEvents
     ) {
         $this->type = \strtolower($type->toNative());
         $this->connection = $connection;
-        $this->eventBus = $eventBus;
+        $this->amqpPublisher = $AMQPPublisher;
         $this->eventFactoryForEvents = $eventFactoryForEvents;
 
         // It's important to call the parent constructor after setting the properties.
@@ -79,13 +78,9 @@ class ReindexOffersWithPopularityScore extends Command
             return 0;
         }
 
-        $this->eventBus->startReplayMode();
-
         foreach ($offerIds as $offerId) {
-            $this->dispatchEvent($offerId);
+            $this->handleEvent($offerId);
         }
-
-        $this->eventBus->stopReplayMode();
 
         return 0;
     }
@@ -116,14 +111,12 @@ class ReindexOffersWithPopularityScore extends Command
             );
     }
 
-    private function dispatchEvent(string $id): void
+    private function handleEvent(string $id): void
     {
         $projectedEvent = $this->eventFactoryForEvents->createEvent($id);
 
-        $this->eventBus->publish(
-            new DomainEventStream([
-                (new DomainMessageBuilder())->create($projectedEvent),
-            ])
+        $this->amqpPublisher->handle(
+            (new DomainMessageBuilder())->create($projectedEvent)
         );
     }
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -107,7 +107,7 @@ $consoleApp->add(
     new ReindexOffersWithPopularityScore(
         OfferType::EVENT(),
         $app['dbal_connection'],
-        $app['event_bus'],
+        $app['amqp.publisher'],
         $app[EventJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY]
     )
 );
@@ -115,7 +115,7 @@ $consoleApp->add(
     new ReindexOffersWithPopularityScore(
         OfferType::PLACE(),
         $app['dbal_connection'],
-        $app['event_bus'],
+        $app['amqp.publisher'],
         $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY]
     )
 );


### PR DESCRIPTION
### Changed
- Avoid re-indexing related events when updating the popularity of a place. This was fixed by injecting the `AMQPPublisher` inside the command and directly pushing the projected events to the queue.

---
Ticket: https://jira.uitdatabank.be/browse/III-3813
