### PR TITLE
III-3340 Fix conclude query

### DIFF
--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -29,7 +29,7 @@ class ConcludeCommand extends AbstractConcludeCommand
     }
 
 
-    public function configure()
+    public function configure(): void
     {
         $this
             ->setName('event:conclude')
@@ -55,7 +55,7 @@ class ConcludeCommand extends AbstractConcludeCommand
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         [$lowerDateBoundary, $upperDateBoundary] = $this->processArguments($input);
         $query = $this->createLuceneQuery($lowerDateBoundary, $upperDateBoundary);
@@ -76,20 +76,14 @@ class ConcludeCommand extends AbstractConcludeCommand
         return 0;
     }
 
-    private function createLuceneQuery(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
+    private function createLuceneQuery(Carbon $lowerDateBoundary, Carbon $upperDateBoundary): string
     {
         $sapiDateRange = $this->createLuceneDateRangeString($lowerDateBoundary, $upperDateBoundary);
 
         return "_type:event AND availableRange:{$sapiDateRange}";
     }
 
-    /**
-     * @param Carbon|null $lowerDateBoundary
-     * @param Carbon|null $upperDateBoundary
-     *
-     * @return string
-     */
-    private function createLuceneDateRangeString(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
+    private function createLuceneDateRangeString(Carbon $lowerDateBoundary, Carbon $upperDateBoundary): string
     {
         $from = $lowerDateBoundary ? $this->getLuceneFormattedDateTime($lowerDateBoundary) : '*';
         $to = $this->getLuceneFormattedDateTime($upperDateBoundary);
@@ -97,11 +91,7 @@ class ConcludeCommand extends AbstractConcludeCommand
         return "[{$from} TO {$to}]";
     }
 
-    /**
-     * @param Carbon $date
-     * @return string
-     */
-    private function getLuceneFormattedDateTime(Carbon $date)
+    private function getLuceneFormattedDateTime(Carbon $date): string
     {
         return $date->tz('UTC')->format(self::LUCENE_DATE_TIME_FORMAT);
     }
@@ -115,11 +105,7 @@ class ConcludeCommand extends AbstractConcludeCommand
         );
     }
 
-    /**
-     * @param InputInterface $input
-     * @return array
-     */
-    private function processArguments(InputInterface $input)
+    private function processArguments(InputInterface $input): array
     {
         $lowerBoundaryInput = $input->getArgument('lower-boundary');
 

--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -62,7 +62,7 @@ class ConcludeCommand extends AbstractConcludeCommand
 
         $output->writeln('Executing search query: ' . $query);
 
-        $finder = $this->createFinder(intval($input->getOption('page-size')));
+        $finder = $this->createFinder((int) $input->getOption('page-size'));
 
         /** @var IriOfferIdentifier[] $results */
         $results = $finder->search($query);

--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConcludeCommand extends AbstractConcludeCommand
 {
     const TIMEZONE = 'Europe/Brussels';
-    const SOLR_DATE_TIME_FORMAT = 'Y-m-d\TH:i:s\Z';
+    const LUCENE_DATE_TIME_FORMAT = 'Y-m-d\TH:i:s\Z';
 
     /**
      * @var SearchServiceInterface
@@ -57,8 +57,8 @@ class ConcludeCommand extends AbstractConcludeCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        list($lowerDateBoundary, $upperDateBoundary) = $this->processArguments($input);
-        $query = $this->createSolrQuery($lowerDateBoundary, $upperDateBoundary);
+        [$lowerDateBoundary, $upperDateBoundary] = $this->processArguments($input);
+        $query = $this->createLuceneQuery($lowerDateBoundary, $upperDateBoundary);
 
         $output->writeln('Executing search query: ' . $query);
 
@@ -76,9 +76,9 @@ class ConcludeCommand extends AbstractConcludeCommand
         return 0;
     }
 
-    private function createSolrQuery(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
+    private function createLuceneQuery(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
     {
-        $sapiDateRange = $this->createSolrDateRangeString($lowerDateBoundary, $upperDateBoundary);
+        $sapiDateRange = $this->createLuceneDateRangeString($lowerDateBoundary, $upperDateBoundary);
 
         return "_type:event AND availableRange:{$sapiDateRange}";
     }
@@ -89,10 +89,10 @@ class ConcludeCommand extends AbstractConcludeCommand
      *
      * @return string
      */
-    private function createSolrDateRangeString(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
+    private function createLuceneDateRangeString(Carbon $lowerDateBoundary = null, Carbon $upperDateBoundary = null)
     {
-        $from = $lowerDateBoundary ? $this->getSolrFormattedDateTime($lowerDateBoundary) : '*';
-        $to = $this->getSolrFormattedDateTime($upperDateBoundary);
+        $from = $lowerDateBoundary ? $this->getLuceneFormattedDateTime($lowerDateBoundary) : '*';
+        $to = $this->getLuceneFormattedDateTime($upperDateBoundary);
 
         return "[{$from} TO {$to}]";
     }
@@ -101,9 +101,9 @@ class ConcludeCommand extends AbstractConcludeCommand
      * @param Carbon $date
      * @return string
      */
-    private function getSolrFormattedDateTime(Carbon $date)
+    private function getLuceneFormattedDateTime(Carbon $date)
     {
-        return $date->tz('UTC')->format(self::SOLR_DATE_TIME_FORMAT);
+        return $date->tz('UTC')->format(self::LUCENE_DATE_TIME_FORMAT);
     }
 
     private function createFinder(int $pageSize) : ResultsGenerator

--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -80,7 +80,7 @@ class ConcludeCommand extends AbstractConcludeCommand
     {
         $sapiDateRange = $this->createSolrDateRangeString($lowerDateBoundary, $upperDateBoundary);
 
-        return "type:event AND availableto:{$sapiDateRange}";
+        return "_type:event AND availableRange:{$sapiDateRange}";
     }
 
     /**

--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConcludeCommand extends AbstractConcludeCommand
 {
     const TIMEZONE = 'Europe/Brussels';
-    const LUCENE_DATE_TIME_FORMAT = 'Y-m-d\TH:i:s\Z';
 
     /**
      * @var SearchServiceInterface
@@ -78,22 +77,10 @@ class ConcludeCommand extends AbstractConcludeCommand
 
     private function createLuceneQuery(Carbon $lowerDateBoundary, Carbon $upperDateBoundary): string
     {
-        $sapiDateRange = $this->createLuceneDateRangeString($lowerDateBoundary, $upperDateBoundary);
+        $from = $lowerDateBoundary ? $lowerDateBoundary->format(\DATE_ATOM) : '*';
+        $to = $upperDateBoundary->format(\DATE_ATOM);
 
-        return "_type:event AND availableRange:{$sapiDateRange}";
-    }
-
-    private function createLuceneDateRangeString(Carbon $lowerDateBoundary, Carbon $upperDateBoundary): string
-    {
-        $from = $lowerDateBoundary ? $this->getLuceneFormattedDateTime($lowerDateBoundary) : '*';
-        $to = $this->getLuceneFormattedDateTime($upperDateBoundary);
-
-        return "[{$from} TO {$to}]";
-    }
-
-    private function getLuceneFormattedDateTime(Carbon $date): string
-    {
-        return $date->tz('UTC')->format(self::LUCENE_DATE_TIME_FORMAT);
+        return "_type:event AND availableRange:[{$from} TO {$to}]";
     }
 
     private function createFinder(int $pageSize) : ResultsGenerator

--- a/app/Console/ConcludeCommand.php
+++ b/app/Console/ConcludeCommand.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
+use DateTime;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -77,8 +78,8 @@ class ConcludeCommand extends AbstractConcludeCommand
 
     private function createLuceneQuery(Carbon $lowerDateBoundary, Carbon $upperDateBoundary): string
     {
-        $from = $lowerDateBoundary ? $lowerDateBoundary->format(\DATE_ATOM) : '*';
-        $to = $upperDateBoundary->format(\DATE_ATOM);
+        $from = $lowerDateBoundary ? $lowerDateBoundary->format(DateTime::ATOM) : '*';
+        $to = $upperDateBoundary->format(DateTime::ATOM);
 
         return "_type:event AND availableRange:[{$from} TO {$to}]";
     }


### PR DESCRIPTION
### Changed

- The query to get concluded events still used the SAPI2 syntax and properties instead of the SAPI3 syntax. This was fixed so the conclude command finds again events to conclude.

---

Ticket: https://jira.uitdatabank.be/browse/III-3340
