### PR TITLE
III-3608 Drop primary key in labels_import table

### DIFF
--- a/app/Migrations/Version20210302114100.php
+++ b/app/Migrations/Version20210302114100.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20210302114100 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema
+            ->getTable('labels_import')
+            ->dropPrimaryKey();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema
+            ->getTable('labels_import')
+            ->setPrimaryKey(['offer_id'], 'offer_id_index');
+    }
+}


### PR DESCRIPTION
### Removed

- Removed primary key in `labels_import` table. This would prevent multiple rows from being added for the same id, while we do want to allow that to make it possible to add multiple labels to a single event/place through auto-classification by the data team in the future.

---

Ticket: https://jira.uitdatabank.be/browse/III-3608
