### PR TITLE
Remove all PHP extensions from GitHub Actions steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
               with:
                   php-version: ${{ matrix.php-versions }}
                   ini-values: xdebug.mode=coverage
-                  extensions: intl, tidy, bcmath
                   tools: composer
 
             - name: ✌️ Check PHP Version
@@ -54,7 +53,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.1
-                  extensions: intl, tidy, bcmath, zip
                   tools: composer
 
             - name: 📩 Cache Composer packages
@@ -84,7 +82,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.1
-                  extensions: intl, tidy, bcmath, zip
                   tools: composer
 
             - name: 📩 Cache Composer packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-versions }}
                   ini-values: xdebug.mode=coverage
-                  extensions: bcmath
+                  extensions: bcmath, tidy
                   tools: composer
 
             - name: ✌️ Check PHP Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-versions }}
                   ini-values: xdebug.mode=coverage
+                  extensions: bcmath
                   tools: composer
 
             - name: ✌️ Check PHP Version


### PR DESCRIPTION
### Changed
- Only require the bcmath and tidy extensions for the test step