### PR TITLE
III-3838 Keep setting status on offers in case of exceptions

### DIFF
--- a/app/Console/UpdateOfferStatusCommand.php
+++ b/app/Console/UpdateOfferStatusCommand.php
@@ -67,7 +67,7 @@ class UpdateOfferStatusCommand extends AbstractCommand
                 $output,
                 new ConfirmationQuestion(
                     "This action will update the status of {$count} {$this->getPluralOfferType()} to {$statusType->toNative()}, continue? [y/N] ",
-                    true
+                    false
                 )
             );
 

--- a/app/Console/UpdateOfferStatusCommand.php
+++ b/app/Console/UpdateOfferStatusCommand.php
@@ -99,6 +99,11 @@ class UpdateOfferStatusCommand extends AbstractCommand
 
         $progressBar->finish();
 
+        $output->writeln('');
+        foreach ($exceptions as $exception) {
+            $output->writeln($exception);
+        }
+
         return 0;
     }
 

--- a/app/Console/UpdateOfferStatusCommand.php
+++ b/app/Console/UpdateOfferStatusCommand.php
@@ -61,6 +61,11 @@ class UpdateOfferStatusCommand extends AbstractCommand
 
         $status = new Status($statusType, $reasons);
 
+        if ($count <= 0) {
+            $output->writeln('Query found 0 ' . $this->getPluralOfferType() . ' to update');
+            return 0;
+        }
+
         $confirmation = $this->getHelper('question')
             ->ask(
                 $input,

--- a/app/Console/UpdateOfferStatusCommand.php
+++ b/app/Console/UpdateOfferStatusCommand.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Offer\Commands\Status\UpdateStatus;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
+use Exception;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -80,13 +81,19 @@ class UpdateOfferStatusCommand extends AbstractCommand
             return 0;
         }
 
+        $exceptions = [];
         $offers = $this->searchResultsGenerator->search($query);
         $progressBar = new ProgressBar($output, $count);
 
         foreach ($offers as $id => $offer) {
-            $this->commandBus->dispatch(
-                new UpdateStatus($id, $status)
-            );
+            try {
+                $this->commandBus->dispatch(
+                    new UpdateStatus($id, $status)
+                );
+            } catch(Exception $exception) {
+                $exceptions[$id] = 'Offer with id: ' . $id . ' caused an exception: ' . $exception->getMessage();
+            }
+
             $progressBar->advance();
         }
 

--- a/app/Console/UpdateOfferStatusCommand.php
+++ b/app/Console/UpdateOfferStatusCommand.php
@@ -90,7 +90,7 @@ class UpdateOfferStatusCommand extends AbstractCommand
                 $this->commandBus->dispatch(
                     new UpdateStatus($id, $status)
                 );
-            } catch(Exception $exception) {
+            } catch (Exception $exception) {
                 $exceptions[$id] = 'Offer with id: ' . $id . ' caused an exception: ' . $exception->getMessage();
             }
 


### PR DESCRIPTION
### Changed
- Catch exceptions when updating the status of events instead of bailing out. These exceptions will be dumped when the command finishes
- Stop the command when no offers were found
- Default answer for update is false.

---
Ticket: https://jira.uitdatabank.be/browse/III-3838
