### PR TITLE
III-3511

### DIFF
--- a/src/Timestamp.php
+++ b/src/Timestamp.php
@@ -72,11 +72,14 @@ final class Timestamp implements Serializable
             $status = Status::deserialize($data['status']);
         }
 
-        return new static(
-            DateTime::createFromFormat(DateTime::ATOM, $data['startDate']),
-            DateTime::createFromFormat(DateTime::ATOM, $data['endDate']),
-            $status
-        );
+        $startDate = DateTime::createFromFormat(DateTime::ATOM, $data['startDate']);
+        $endDate = DateTime::createFromFormat(DateTime::ATOM, $data['endDate']);
+
+        if ($startDate > $endDate) {
+            $endDate = $startDate;
+        }
+
+        return new self($startDate, $endDate, $status);
     }
 
     public function serialize(): array

--- a/tests/TimestampTest.php
+++ b/tests/TimestampTest.php
@@ -140,4 +140,26 @@ class TimestampTest extends TestCase
             $timestamp->withStatus($newStatus)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_will_set_end_date_to_start_date_when_deserializing_incorrect_events(): void
+    {
+        $expected = new Timestamp(
+            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            new Status(StatusType::available(), [])
+        );
+
+        $serialized = [
+            'startDate' => self::END_DATE,
+            'endDate' => self::START_DATE,
+            'status' => [
+                'type' => 'Available',
+            ],
+        ];
+
+        $this->assertEquals($expected, Timestamp::deserialize($serialized));
+    }
 }


### PR DESCRIPTION
### Fixed
- Deserializing events where a timestamp had an end date that was earlier than a start date no longer throws an exception but applies a patch instead.

---
Ticket: https://jira.uitdatabank.be/browse/III-3511
