### PR TITLE
Fix crash because message is type string and not null

### DIFF
--- a/src/EventSourcing/DBAL/DBALEventStoreException.php
+++ b/src/EventSourcing/DBAL/DBALEventStoreException.php
@@ -12,8 +12,8 @@ use Doctrine\DBAL\DBALException;
  */
 class DBALEventStoreException extends EventStoreException
 {
-    public static function create(DBALException $exception)
+    public static function create(DBALException $exception): DBALEventStoreException
     {
-        return new DBALEventStoreException(null, 0, $exception);
+        return new self('', 0, $exception);
     }
 }


### PR DESCRIPTION
### Changed
- Fix crash because the message is type string and not null. Can be reproduced by adding an existing label.


