### PR TITLE
Export status field in OOXML format

### DIFF
--- a/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
+++ b/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
@@ -668,6 +668,13 @@ class TabularDataEventFormatter
                 },
                 'property' => 'audience',
             ],
+            'status' => [
+                'name' => 'status',
+                'include' => function ($event) {
+                    return $this->formatStatus($event->status);
+                },
+                'property' => 'status',
+            ],
         ];
     }
 
@@ -799,5 +806,20 @@ class TabularDataEventFormatter
         $mainLanguage = $event->mainLanguage ?? 'nl';
 
         return $event->location->address->{$mainLanguage}->{$addressField} ?? '';
+    }
+
+    private function formatStatus(stdClass $status): string
+    {
+        $map = [
+            'Available' => 'Gaat door',
+            'TemporarilyUnavailable' => 'Uitgesteld',
+            'Unavailable' => 'Geannuleerd',
+        ];
+
+        if (!array_key_exists($status->type, $map)) {
+            return '';
+        }
+
+        return $map[$status->type];
     }
 }

--- a/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
+++ b/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
@@ -696,4 +696,28 @@ class TabularDataEventFormatterTest extends TestCase
 
         $this->assertEquals($expectedFormattedEvent, $formattedEvent);
     }
+
+    /**
+     * @test
+     *
+     * @group issue-III-1791
+     */
+    public function it_formats_status()
+    {
+        $includedProperties = [
+            'id',
+            'status',
+        ];
+
+        $event = $this->getJSONEventFromFile('event_with_status.json');
+        $formatter = new TabularDataEventFormatter($includedProperties);
+        $formattedEvent = $formatter->formatEvent($event);
+
+        $expectedFormattedEvent = [
+            'id' => 'd1f0e71d-a9a8-4069-81fb-530134502c58',
+            'status' => 'Gaat door',
+        ];
+
+        $this->assertEquals($expectedFormattedEvent, $formattedEvent);
+    }
 }

--- a/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
+++ b/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
@@ -699,8 +699,6 @@ class TabularDataEventFormatterTest extends TestCase
 
     /**
      * @test
-     *
-     * @group issue-III-1791
      */
     public function it_formats_status()
     {


### PR DESCRIPTION
### Added
- Event status field can now be exported in ooxml with this mapping

ooxml value | status type in jsonld
-- | --
Gaat door | Available
Uitgesteld | TemporarilyUnavailable
Geannuleerd | Unavailable

---
Ticket: https://jira.uitdatabank.be/browse/III-3860
