### PR TITLE
Avoid non-blocking wait statement to improve performance

### DIFF
--- a/app/Console/ConsumeCommand.php
+++ b/app/Console/ConsumeCommand.php
@@ -77,7 +77,7 @@ class ConsumeCommand extends Command
             pcntl_signal_dispatch();
 
             try {
-                $channel->wait(null, true, 4);
+                $channel->wait();
             } catch (AMQPTimeoutException $e) {
                 // Ignore this one.
             }


### PR DESCRIPTION
### Changed
- Avoid non-blocking `wait` statement to improve performance. The wait used to be called in non-blocking mode and with a timeout. But when the mode is set to non-blocking the timeout is discarded.

---

This is the line that causes the discard in `php-amqplib`: https://github.com/php-amqplib/php-amqplib/blob/master/PhpAmqpLib/Channel/AbstractChannel.php#L345

This is the PR that changed it in `php-amqplib`: https://github.com/php-amqplib/php-amqplib/commit/242db8072cb46f3da79e76300140a6e152d04d37

This is the PR that changed it inside `udb3-silex`: https://github.com/cultuurnet/udb3-silex/commit/7a12ad601f60b5bee928feee80c268d6f3e53b7f