### PR TITLE
III-3864 Remove old leftover calendarSummary property from JSON-LD

### DIFF
--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -104,8 +104,6 @@ class CdbXMLImporter
         $labelImporter = new LabelImporter();
         $labelImporter->importLabels($event, $jsonLD);
 
-        $jsonLD->calendarSummary = $detail->getCalendarSummary();
-
         $this->importLocation($event, $placeManager, $jsonLD);
 
         $this->importOrganizer($event, $organizerManager, $jsonLD);

--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -13,7 +13,9 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
     {
         $document = parent::fetch($id, $includeMetadata);
-        return $this->polyfillNewProperties($document);
+        $document = $this->polyfillNewProperties($document);
+        $document = $this->removeObsoleteProperties($document);
+        return $document;
     }
 
     public function get(string $id, bool $includeMetadata = false): ?JsonDocument
@@ -24,7 +26,9 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
             return null;
         }
 
-        return $this->polyfillNewProperties($document);
+        $document = $this->polyfillNewProperties($document);
+        $document = $this->removeObsoleteProperties($document);
+        return $document;
     }
 
     private function polyfillNewProperties(JsonDocument $jsonDocument): JsonDocument
@@ -99,5 +103,17 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
         }
 
         return $json;
+    }
+
+    private function removeObsoleteProperties(JsonDocument $jsonDocument): JsonDocument
+    {
+        $obsoleteProperties = ['calendarSummary'];
+
+        return $jsonDocument->applyAssoc(
+            function (array $json) use ($obsoleteProperties) {
+                $json = array_diff_key($json, array_flip($obsoleteProperties));
+                return $json;
+            }
+        );
     }
 }

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -981,6 +981,15 @@ class CdbXMLImporterTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_should_not_import_the_included_calendar_summary(): void
+    {
+        $jsonEvent = $this->createJsonEventFromCalendarSample('event_with_timestamp_and_start_and_end_time.xml');
+        $this->assertArrayNotHasKey('calendarSummary', (array) $jsonEvent);
+    }
+
     public function it_splits_contactinfo_into_contactpoint_and_bookinginfo()
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_all_kinds_of_contact_info_2.cdbxml.xml');

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -198,6 +198,26 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
             ->assertReturnedDocumentDoesNotContainKey('location');
     }
 
+    /**
+     * @test
+     */
+    public function it_should_remove_calendarSummary_if_set(): void
+    {
+        $this
+            ->given(['calendarSummary' => 'Foo bar bla bla'])
+            ->assertReturnedDocumentDoesNotContainKey('calendarSummary');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_complain_if_calendarSummary_property_is_not_found(): void
+    {
+        $this
+            ->given(['@type' => 'Event'])
+            ->assertReturnedDocumentContains(['@type' => 'Event']);
+    }
+
     private function given(array $given): self
     {
         $this->repository->save(


### PR DESCRIPTION
### Removed

- Removed `calendarSummary` from new event projections/replays from XML imports
- Removed `calendarSummary` from existing projections (on the fly), until we do a full replay again

---
Ticket: https://jira.uitdatabank.be/browse/III-3864
