### PR TITLE
III-3526

### DIFF
--- a/src/Model/Import/Offer/LegacyOffer.php
+++ b/src/Model/Import/Offer/LegacyOffer.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
+use DateTimeImmutable;
 
 interface LegacyOffer
 {
@@ -77,10 +78,7 @@ interface LegacyOffer
      */
     public function getContactPoint();
 
-    /**
-     * @return \DateTimeImmutable|null
-     */
-    public function getAvailableFrom(\DateTimeImmutable $default);
+    public function getAvailableFrom(\DateTimeImmutable $default): DateTimeImmutable;
 
     /**
      * @return Title[]

--- a/src/Model/Import/Offer/LegacyOffer.php
+++ b/src/Model/Import/Offer/LegacyOffer.php
@@ -80,7 +80,7 @@ interface LegacyOffer
     /**
      * @return \DateTimeImmutable|null
      */
-    public function getAvailableFrom(\DateTimeImmutable $default = null);
+    public function getAvailableFrom(\DateTimeImmutable $default);
 
     /**
      * @return Title[]

--- a/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
+++ b/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
@@ -181,10 +181,7 @@ class Udb3ModelToLegacyOfferAdapter implements LegacyOffer
         return ContactPoint::fromUdb3ModelContactPoint($contactPoint);
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getAvailableFrom(DateTimeImmutable $default)
+    public function getAvailableFrom(DateTimeImmutable $default): DateTimeImmutable
     {
         $availableFrom = $this->offer->getAvailableFrom();
         if (!$availableFrom || $availableFrom < $default) {

--- a/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
+++ b/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
@@ -187,7 +187,7 @@ class Udb3ModelToLegacyOfferAdapter implements LegacyOffer
     public function getAvailableFrom(DateTimeImmutable $default)
     {
         $availableFrom = $this->offer->getAvailableFrom();
-        if (!$availableFrom) {
+        if (!$availableFrom || $availableFrom < $default) {
             $availableFrom = $default;
         }
         return $availableFrom;

--- a/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
+++ b/src/Model/Import/Offer/Udb3ModelToLegacyOfferAdapter.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
+use DateTimeImmutable;
 
 class Udb3ModelToLegacyOfferAdapter implements LegacyOffer
 {
@@ -183,7 +184,7 @@ class Udb3ModelToLegacyOfferAdapter implements LegacyOffer
     /**
      * @inheritdoc
      */
-    public function getAvailableFrom(\DateTimeImmutable $default = null)
+    public function getAvailableFrom(DateTimeImmutable $default)
     {
         $availableFrom = $this->offer->getAvailableFrom();
         if (!$availableFrom) {

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -403,7 +403,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_default_available_form_if_there_is_none()
+    public function it_should_return_default_available_form_if_there_is_none(): void
     {
         $now = new DateTimeImmutable();
         $actual = $this->adapter->getAvailableFrom($now);
@@ -413,7 +413,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_available_from_if_there_is_one()
+    public function it_should_return_available_from_if_there_is_one(): void
     {
         $expected = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2040-01-01T10:00:00+01:00');
         $actual = $this->completeAdapter->getAvailableFrom(new DateTimeImmutable());
@@ -423,7 +423,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_default_if_available_from_is_in_the_past()
+    public function it_should_return_default_if_available_from_is_in_the_past(): void
     {
         $now = new DateTimeImmutable();
         $dateInThePast = new DateTimeImmutable('2019-02-14');

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -403,7 +403,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_default_available_form_if_there_is_none(): void
+    public function it_should_return_default_available_from_if_there_is_none(): void
     {
         $now = new DateTimeImmutable();
         $actual = $this->adapter->getAvailableFrom($now);

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -403,10 +403,11 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_no_available_from_by_default()
+    public function it_should_return_default_available_form_if_there_is_none()
     {
-        $actual = $this->adapter->getAvailableFrom(new DateTimeImmutable());
-        $this->assertNull($actual);
+        $now = new DateTimeImmutable();
+        $actual = $this->adapter->getAvailableFrom($now);
+        $this->assertEquals($now, $actual);
     }
 
     /**

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -47,6 +47,7 @@ use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use DateTimeImmutable;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -145,8 +146,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                     new TelephoneNumber('044/444444'),
                     new EmailAddress('info@publiq.be'),
                     new BookingAvailability(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T10:00:00+01:00')
+                        DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00'),
+                        DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T10:00:00+01:00')
                     )
                 )
             )
@@ -167,7 +168,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                 )
             )
             ->withAvailableFrom(
-                \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00')
+                DateTimeImmutable::createFromFormat(\DATE_ATOM, '2040-01-01T10:00:00+01:00')
             );
 
         $this->adapter = new Udb3ModelToLegacyOfferAdapter($this->offer);
@@ -368,8 +369,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
             ),
             '044/444444',
             'info@publiq.be',
-            new \DateTimeImmutable('2018-01-01T10:00:00+01:00'),
-            new \DateTimeImmutable('2018-01-10T10:00:00+01:00')
+            new DateTimeImmutable('2018-01-01T10:00:00+01:00'),
+            new DateTimeImmutable('2018-01-10T10:00:00+01:00')
         );
         $actual = $this->completeAdapter->getBookingInfo();
         $this->assertEquals($expected, $actual);
@@ -404,7 +405,7 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
      */
     public function it_should_return_no_available_from_by_default()
     {
-        $actual = $this->adapter->getAvailableFrom();
+        $actual = $this->adapter->getAvailableFrom(new DateTimeImmutable());
         $this->assertNull($actual);
     }
 
@@ -413,8 +414,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
      */
     public function it_should_return_available_from_if_there_is_one()
     {
-        $expected = \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T10:00:00+01:00');
-        $actual = $this->completeAdapter->getAvailableFrom();
+        $expected = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2040-01-01T10:00:00+01:00');
+        $actual = $this->completeAdapter->getAvailableFrom(new DateTimeImmutable());
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -422,6 +422,18 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
     /**
      * @test
      */
+    public function it_should_return_default_if_available_from_is_in_the_past()
+    {
+        $now = new DateTimeImmutable();
+        $dateInThePast = new DateTimeImmutable('2019-02-14');
+        $offer = $this->completeOffer->withAvailableFrom($dateInThePast);
+        $adapter = new Udb3ModelToLegacyOfferAdapter($offer);
+        $this->assertEquals($now, $adapter->getAvailableFrom($now));
+    }
+
+    /**
+     * @test
+     */
     public function it_should_return_the_title_translations()
     {
         $expected = [


### PR DESCRIPTION
### Changed
- When importing places or events with an availableFrom date in the past, we will use the current date instead

---
Ticket: https://jira.uitdatabank.be/browse/III-3526

---
Note that I changed the interface's signature to better match how it was used in reality. It now always expects a default and never returns `null` (as it already did in production).