### PR TITLE
III-3890 Fix for empty search result for labels

### DIFF
--- a/src/Http/Label/ReadRestController.php
+++ b/src/Http/Label/ReadRestController.php
@@ -74,20 +74,13 @@ class ReadRestController
 
         $totalEntities = $this->readService->searchTotalLabels($query);
 
-        if ($totalEntities->toNative() > 0) {
-            $entities = $this->readService->search($query);
+        $entities = $totalEntities->toNative() > 0 ? $this->readService->search($query) : [];
 
-            return $this->createPagedCollectionResponse(
-                $query,
-                $entities !== null ? $entities : [],
-                $totalEntities
-            );
-        } else {
-            $apiProblem = new ApiProblem('No label found for search query.');
-            $apiProblem->setStatus(Response::HTTP_NOT_FOUND);
-
-            return new ApiProblemJsonResponse($apiProblem);
-        }
+        return $this->createPagedCollectionResponse(
+            $query,
+            $entities,
+            $totalEntities
+        );
     }
 
     /**

--- a/tests/Http/Label/ReadRestControllerTest.php
+++ b/tests/Http/Label/ReadRestControllerTest.php
@@ -155,6 +155,40 @@ class ReadRestControllerTest extends TestCase
         $this->assertEquals($expectedJson, json_decode($jsonResponse->getContent(), true));
     }
 
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_collection_when_no_labels_are_found(): void
+    {
+        $readService = $this->createMock(ReadServiceInterface::class);
+
+        $readService->method('searchTotalLabels')
+            ->with($this->query)
+            ->willReturn(new Natural(0));
+
+        $readService->method('search')
+            ->with($this->query)
+            ->willReturn([]);
+
+        $readRestController = new ReadRestController(
+            $readService,
+            $this->queryFactory
+        );
+
+        $jsonResponse = $readRestController->search($this->request);
+
+        $expectedJson = [
+            '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+            '@type' => 'PagedCollection',
+            'itemsPerPage' => 2,
+            'totalItems' => 0,
+            'member' => [],
+        ];
+
+        $this->assertEquals(200, $jsonResponse->getStatusCode());
+        $this->assertEquals($expectedJson, json_decode($jsonResponse->getContent(), true));
+    }
+
     private function mockGetByUuid()
     {
         $this->readService->method('getByUuid')


### PR DESCRIPTION
### Changed
- Return empty collection and HTTP status code 200 when no labels are found
---
Ticket: https://jira.uitdatabank.be/browse/III-3890
