### PR TITLE
III-3819

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -76,7 +76,8 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                         new EventJsonDocumentLanguageAnalyzer()
                     ),
                     new EventTypeResolver(),
-                    $app['config']['base_price_translations']
+                    $app['config']['base_price_translations'],
+                    $app['config']['udb_api_key']
                 );
 
                 return $projector;

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -117,7 +117,7 @@ jwt:
       iss: http://culudb-jwt-provider.dev
   auth0:
     keys:
-      public:
+    dummy_place_ids      public:
         file: public-auth0.pem
     validation:
       iss: https://publiq-acc.eu.auth0.com/
@@ -173,4 +173,4 @@ sentry:
   dsn: ***
   environment: development
 
-udb_api_key: ***
+api_key_consumers: []

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -172,3 +172,5 @@ bypass_api_key_check: false
 sentry:
   dsn: ***
   environment: development
+
+udb_api_key: ***

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -117,7 +117,7 @@ jwt:
       iss: http://culudb-jwt-provider.dev
   auth0:
     keys:
-    dummy_place_ids      public:
+      public:
         file: public-auth0.pem
     validation:
       iss: https://publiq-acc.eu.auth0.com/
@@ -173,4 +173,5 @@ sentry:
   dsn: ***
   environment: development
 
-api_key_consumers: []
+api_key_consumers:
+  - 'deb306a6-6f46-4c98-89ce-b03ec4fd11e2': 'uitdatabank-ui'

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -302,7 +302,7 @@ class EventLDProjector extends OfferLDProjector implements
         $jsonLD->audience = $defaultAudience->serialize();
 
         $jsonLD->metadata = (object)[
-            'createdByApiConsumer' => $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata())
+            'createdByApiConsumer' => $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata()),
         ];
 
         return $document->withBody($jsonLD);

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -121,7 +121,7 @@ class EventLDProjector extends OfferLDProjector implements
         JsonDocumentMetaDataEnricherInterface $jsonDocumentMetaDataEnricher,
         EventTypeResolver $eventTypeResolver,
         array $basePriceTranslations,
-        string $udbApiKey = ''
+        string $udbApiKey
     ) {
         parent::__construct(
             $repository,

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -103,9 +103,9 @@ class EventLDProjector extends OfferLDProjector implements
     private $eventTypeResolver;
 
     /**
-     * @var string
+     * @var array<string,string>
      */
-    private $udbApiKey;
+    private $apiKeyConsumerMapping;
 
     /**
      * @param string[] $basePriceTranslations
@@ -121,7 +121,7 @@ class EventLDProjector extends OfferLDProjector implements
         JsonDocumentMetaDataEnricherInterface $jsonDocumentMetaDataEnricher,
         EventTypeResolver $eventTypeResolver,
         array $basePriceTranslations,
-        string $udbApiKey
+        array $apiKeyConsumerMapping
     ) {
         parent::__construct(
             $repository,
@@ -137,7 +137,7 @@ class EventLDProjector extends OfferLDProjector implements
 
         $this->iriOfferIdentifierFactory = $iriOfferIdentifierFactory;
         $this->eventTypeResolver = $eventTypeResolver;
-        $this->udbApiKey = $udbApiKey;
+        $this->apiKeyConsumerMapping = $apiKeyConsumerMapping;
     }
 
     /**
@@ -528,7 +528,7 @@ class EventLDProjector extends OfferLDProjector implements
         return null;
     }
 
-    private function getCreatedByApiConsumerFromMetadata(Metadata $metadata): ?string
+    private function getCreatedByApiConsumerFromMetadata(Metadata $metadata): string
     {
         $properties = $metadata->serialize();
 
@@ -537,11 +537,11 @@ class EventLDProjector extends OfferLDProjector implements
         }
 
         $apiKey = $properties['auth_api_key'];
-        if ($apiKey === $this->udbApiKey) {
-            return 'uitdatabank-ui';
+        if (!array_key_exists($apiKey, $this->apiKeyConsumerMapping)) {
+            return 'other';
         }
 
-        return 'other';
+        return $this->apiKeyConsumerMapping[$apiKey];
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -170,7 +170,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'de' => 'Basisrate',
             ],
             [
-                self::UDB_API_KEY => 'uitdatabank-ui'
+                self::UDB_API_KEY => 'uitdatabank-ui',
             ]
         );
     }
@@ -378,7 +378,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
         $jsonLD->metadata = (object)[
-            'createdByApiConsumer' => $expected
+            'createdByApiConsumer' => $expected,
         ];
 
         $this->mockPlaceService();

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -169,7 +169,9 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'en' => 'Base tariff',
                 'de' => 'Basisrate',
             ],
-            self::UDB_API_KEY
+            [
+                self::UDB_API_KEY => 'uitdatabank-ui'
+            ]
         );
     }
 
@@ -195,6 +197,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'label' => 'concert',
                 'domain' => 'eventtype',
             ],
+        ];
+
+        $jsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
         ];
 
         $this->mockPlaceService();
@@ -236,6 +242,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'label' => 'theme label',
                 'domain' => 'theme',
             ],
+        ];
+
+        $jsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
         ];
 
         $this->mockPlaceService();
@@ -285,6 +295,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ],
         ];
         $jsonLD->creator = $expectedCreator;
+
+        $jsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
+        ];
 
         $this->mockPlaceService();
 
@@ -495,6 +509,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = '20a72430-7e3e-4b75-ab59-043156b3169c';
 
+        $expectedJsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
+        ];
+
         $this->assertEquals($expectedJsonLD, $body);
     }
 
@@ -530,6 +548,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $expectedJsonLD->created = $recordedOn;
         $expectedJsonLD->modified = $recordedOn;
         $expectedJsonLD->creator = $userId;
+
+        $expectedJsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
+        ];
 
         $this->assertEquals($expectedJsonLD, $body);
     }
@@ -670,6 +692,10 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'label' => 'theme label',
                 'domain' => 'theme',
             ],
+        ];
+
+        $jsonLD->metadata = (object)[
+            'createdByApiConsumer' => 'unknown',
         ];
 
         $this->mockPlaceService();


### PR DESCRIPTION
### Added
- `EventCreated` events now also project the `createdByApiConsumer` property

---
Ticket: https://jira.uitdatabank.be/browse/III-3819

---
### Todo
- [ ] PlaceCreated
- [ ] EventCopied
- [ ] Add temporary projector to fix existing projections without having to replay everything
- [x] Add configuration mapping to appconfig and vagrant box repos
- [ ] Add polyfill that sets this property to 'unknown' for all (old) events without a known API consumer
