### PR TITLE
III-3819 - Add decoration layer that embeds the offer metadata

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -20,6 +20,8 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use Silex\Application;
@@ -39,12 +41,15 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     new NewPropertyPolyfillOfferRepository(
                         new PopularityEnrichedOfferRepository(
                             $app[PopularityRepository::class],
-                            new ProductionEnrichedEventRepository(
-                                new CacheDocumentRepository(
-                                    $app['event_jsonld_cache']
-                                ),
-                                $app[ProductionRepository::class],
-                                $app['event_iri_generator']
+                            new OfferMetadataEnrichedOfferRepository(
+                                $app[OfferMetadataRepository::class],
+                                new ProductionEnrichedEventRepository(
+                                    new CacheDocumentRepository(
+                                        $app['event_jsonld_cache']
+                                    ),
+                                    $app[ProductionRepository::class],
+                                    $app['event_iri_generator']
+                                )
                             )
                         )
                     ),

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -12,6 +12,8 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\Place\DummyPlaceProjectionEnricher;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\CdbXMLImporter;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\EventFactory;
@@ -82,6 +84,11 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                         $app['place_jsonld_cache']
                     ),
                     $dummyPlaceIds
+                );
+
+                $repository = new OfferMetadataEnrichedOfferRepository(
+                    $app[OfferMetadataRepository::class],
+                    $repository
                 );
 
                 $repository = new PopularityEnrichedOfferRepository(

--- a/src/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepository.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
+
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+
+class OfferMetadataEnrichedOfferRepository extends DocumentRepositoryDecorator
+{
+    /**
+     * @var OfferMetadataRepository
+     */
+    private $offerMetadataRepository;
+
+    public function __construct(OfferMetadataRepository $offerMetadataRepository, DocumentRepository $documentRepository)
+    {
+        parent::__construct($documentRepository);
+        $this->offerMetadataRepository = $offerMetadataRepository;
+    }
+
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        $jsonDocument = parent::fetch($id, $includeMetadata);
+
+        if ($includeMetadata) {
+            $jsonDocument = $this->enrich($jsonDocument);
+        }
+
+        return $jsonDocument;
+    }
+
+    public function get(string $id, bool $includeMetadata = false): ?JsonDocument
+    {
+        $jsonDocument = parent::get($id, $includeMetadata);
+
+        if ($includeMetadata && $jsonDocument instanceof JsonDocument) {
+            $jsonDocument = $this->enrich($jsonDocument);
+        }
+
+        return $jsonDocument;
+    }
+
+    private function enrich(JsonDocument $jsonDocument): JsonDocument
+    {
+        try {
+            $offerMetadata = $this->offerMetadataRepository->get($jsonDocument->getId());
+        } catch (EntityNotFoundException $e) {
+            $offerMetadata = OfferMetadata::default($jsonDocument->getId());
+        }
+
+        return $jsonDocument->applyAssoc(
+            function (array $body) use ($offerMetadata) {
+                $body['metadata']['createdByApiConsumer'] = $offerMetadata->getCreatedByApiConsumer();
+                return $body;
+            }
+        );
+    }
+}

--- a/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
@@ -39,69 +39,38 @@ class OfferMetadataProjector implements EventListener
 
     public function applyEventCreated(EventCreated $eventCreated, DomainMessage $domainMessage)
     {
-        try {
-            $offerMetadata = $this->repository->get($eventCreated->getEventId());
-        } catch (EntityNotFoundException $e) {
-            $offerMetadata = OfferMetadata::default($eventCreated->getEventId());
-        }
-
-        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata());
-        $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
-
-        $this->repository->save($offerMetadata);
+        $this->projectMetadataForOffer($eventCreated->getEventId(), $domainMessage->getMetadata());
     }
 
     public function applyPlaceCreated(PlaceCreated $placeCreated, DomainMessage $domainMessage)
     {
-        try {
-            $offerMetadata = $this->repository->get($placeCreated->getPlaceId());
-        } catch (EntityNotFoundException $e) {
-            $offerMetadata = OfferMetadata::default($placeCreated->getPlaceId());
-        }
-
-        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata());
-        $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
-
-        $this->repository->save($offerMetadata);
+        $this->projectMetadataForOffer($placeCreated->getPlaceId(), $domainMessage->getMetadata());
     }
 
     public function applyEventCopied(EventCopied $eventCopied, DomainMessage $domainMessage)
     {
-        try {
-            $offerMetadata = $this->repository->get($eventCopied->getItemId());
-        } catch (EntityNotFoundException $e) {
-            $offerMetadata = OfferMetadata::default($eventCopied->getItemId());
-        }
-
-        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata());
-        $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
-
-        $this->repository->save($offerMetadata);
+        $this->projectMetadataForOffer($eventCopied->getItemId(), $domainMessage->getMetadata());
     }
 
     public function applyEventImportedFromUDB2(EventImportedFromUDB2 $eventImportedFromUDB2, DomainMessage $domainMessage)
     {
-        try {
-            $offerMetadata = $this->repository->get($eventImportedFromUDB2->getEventId());
-        } catch (EntityNotFoundException $e) {
-            $offerMetadata = OfferMetadata::default($eventImportedFromUDB2->getEventId());
-        }
-
-        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata());
-        $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
-
-        $this->repository->save($offerMetadata);
+        $this->projectMetadataForOffer($eventImportedFromUDB2->getEventId(), $domainMessage->getMetadata());
     }
 
     public function applyPlaceImportedFromUDB2(PlaceImportedFromUDB2 $placeImportedFromUDB2, DomainMessage $domainMessage)
     {
+        $this->projectMetadataForOffer($placeImportedFromUDB2->getActorId(), $domainMessage->getMetadata());
+    }
+
+    private function projectMetadataForOffer(string $offerId, Metadata $metadata): void
+    {
         try {
-            $offerMetadata = $this->repository->get($placeImportedFromUDB2->getActorId());
+            $offerMetadata = $this->repository->get($offerId);
         } catch (EntityNotFoundException $e) {
-            $offerMetadata = OfferMetadata::default($placeImportedFromUDB2->getActorId());
+            $offerMetadata = OfferMetadata::default($offerId);
         }
 
-        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($domainMessage->getMetadata());
+        $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($metadata);
         $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
 
         $this->repository->save($offerMetadata);

--- a/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
@@ -22,7 +22,7 @@ class OfferMetadataProjector implements EventListener
     /**
      * @var OfferMetadataRepository
      */
-    private $repository;
+    private $offerMetadataRepository;
 
     /**
      * @var array<string,string>
@@ -33,7 +33,7 @@ class OfferMetadataProjector implements EventListener
         OfferMetadataRepository $repository,
         array $apiKeyConsumerMapping
     ) {
-        $this->repository = $repository;
+        $this->offerMetadataRepository = $repository;
         $this->apiKeyConsumerMapping = $apiKeyConsumerMapping;
     }
 
@@ -65,7 +65,7 @@ class OfferMetadataProjector implements EventListener
     private function projectMetadataForOffer(string $offerId, Metadata $metadata): void
     {
         try {
-            $offerMetadata = $this->repository->get($offerId);
+            $offerMetadata = $this->offerMetadataRepository->get($offerId);
         } catch (EntityNotFoundException $e) {
             $offerMetadata = OfferMetadata::default($offerId);
         }
@@ -73,7 +73,7 @@ class OfferMetadataProjector implements EventListener
         $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($metadata);
         $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
 
-        $this->repository->save($offerMetadata);
+        $this->offerMetadataRepository->save($offerMetadata);
     }
 
     private function getCreatedByApiConsumerFromMetadata(Metadata $metadata): string

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataEnrichedOfferRepositoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
+
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class OfferMetadataEnrichedOfferRepositoryTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $offerMetadataRepository;
+
+    /**
+     * @var InMemoryDocumentRepository
+     */
+    private $decoratedRepository;
+
+    /**
+     * @var OfferMetadataEnrichedOfferRepository
+     */
+    private $offerMetadataEnrichedOfferRepository;
+
+    protected function setUp()
+    {
+        $this->offerMetadataRepository = $this->createMock(OfferMetadataRepository::class);
+        $this->decoratedRepository = new InMemoryDocumentRepository();
+
+        $this->offerMetadataEnrichedOfferRepository = new OfferMetadataEnrichedOfferRepository(
+            $this->offerMetadataRepository,
+            $this->decoratedRepository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_offer_metadata_if_include_metadata_is_false(): void
+    {
+        $offerId = '4ff559bd-9543-4ae2-900f-fe6d32fd019b';
+
+        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $this->decoratedRepository->save($jsonLd);
+
+        $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, false);
+        $getJsonLd = $this->offerMetadataEnrichedOfferRepository->get($offerId, false);
+
+        $this->assertEquals($jsonLd, $fetchJsonLd);
+        $this->assertEquals($jsonLd, $getJsonLd);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_offer_metadata(): void
+    {
+        $offerId = '4ff559bd-9543-4ae2-900f-fe6d32fd019b';
+
+        $this->offerMetadataRepository->method('get')->willReturn(
+            new OfferMetadata($offerId, 'uitdatabank-ui')
+        );
+
+        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $this->decoratedRepository->save($jsonLd);
+
+        $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, true);
+        $getJsonLd = $this->offerMetadataEnrichedOfferRepository->get($offerId, true);
+
+        $expectedJsonLd = new JsonDocument(
+            $offerId,
+            json_encode(
+                [
+                    '@type' => 'Event',
+                    'metadata' => [
+                        'createdByApiConsumer' => 'uitdatabank-ui',
+                    ],
+                ]
+            )
+        );
+
+        $this->assertEquals($expectedJsonLd, $fetchJsonLd);
+        $this->assertEquals($expectedJsonLd, $getJsonLd);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_default_metadata_when_not_found(): void
+    {
+        $offerId = '4ff559bd-9543-4ae2-900f-fe6d32fd019b';
+
+        $this->offerMetadataRepository->method('get')->willThrowException(
+            new EntityNotFoundException()
+        );
+
+        $jsonLd = new JsonDocument($offerId, json_encode(['@type' => 'Event']));
+        $this->decoratedRepository->save($jsonLd);
+
+        $fetchJsonLd = $this->offerMetadataEnrichedOfferRepository->fetch($offerId, true);
+        $getJsonLd = $this->offerMetadataEnrichedOfferRepository->get($offerId, true);
+
+        $expectedJsonLd = new JsonDocument(
+            $offerId,
+            json_encode(
+                [
+                    '@type' => 'Event',
+                    'metadata' => [
+                        'createdByApiConsumer' => 'unknown',
+                    ],
+                ]
+            )
+        );
+
+        $this->assertEquals($expectedJsonLd, $fetchJsonLd);
+        $this->assertEquals($expectedJsonLd, $getJsonLd);
+    }
+}


### PR DESCRIPTION
### Added
- When requesting places or events with metadata, the `createdByApiConsumer` property will now be embedded. If that information is not available (due to a not yet available read model or the offer being a very old event), we will default to `unknown`.

---
Ticket: https://jira.uitdatabank.be/browse/III-3819
