### PR TITLE
III-3819 - Revert unnecessary cleanup

### DIFF
--- a/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
@@ -63,7 +63,12 @@ class OfferMetadataProjector implements EventListener
 
     private function projectMetadataForOffer(string $offerId, Metadata $metadata): void
     {
-        $offerMetadata = OfferMetadata::default($offerId);
+        try {
+            $offerMetadata = $this->offerMetadataRepository->get($offerId);
+        } catch (EntityNotFoundException $e) {
+            $offerMetadata = OfferMetadata::default($offerId);
+        }
+
         $createdByApiConsumer = $this->getCreatedByApiConsumerFromMetadata($metadata);
         $offerMetadata = $offerMetadata->withCreatedByApiConsumer($createdByApiConsumer);
 

--- a/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventHandling\EventListener;
+use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Events\EventCopied;
 use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;

--- a/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
@@ -39,13 +39,46 @@ class OfferMetadataRepository extends AbstractDBALRepository
         );
     }
 
+    private function exists(string $offerId): bool
+    {
+        try {
+            $this->get($offerId);
+            return true;
+        } catch (EntityNotFoundException $e) {
+            return false;
+        }
+    }
+
+
     public function save(OfferMetadata $offerMetadata): void
+    {
+        if (!$this->exists($offerMetadata->getOfferId())) {
+            $this->insert($offerMetadata);
+        } else {
+            $this->update($offerMetadata);
+        }
+    }
+
+    private function insert(OfferMetadata $offerMetadata): void
     {
         $this->getConnection()->insert(
             self::TABLE,
             [
                 'id' => $offerMetadata->getOfferId(),
                 'created_by_api_consumer' => $offerMetadata->getCreatedByApiConsumer(),
+            ]
+        );
+    }
+
+    private function update(OfferMetadata $offerMetadata): void
+    {
+        $this->getConnection()->update(
+            self::TABLE,
+            [
+                'created_by_api_consumer' => $offerMetadata->getCreatedByApiConsumer(),
+            ],
+            [
+                'id' => $offerMetadata->getOfferId(),
             ]
         );
     }

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
@@ -61,6 +61,11 @@ class OfferMetadataProjectorTest extends TestCase
     ): void {
         $this->repository
             ->expects($this->once())
+            ->method('get')
+            ->willReturn(OfferMetadata::default(self::OFFER_ID));
+
+        $this->repository
+            ->expects($this->once())
             ->method('save')
             ->with($expected);
 
@@ -74,6 +79,11 @@ class OfferMetadataProjectorTest extends TestCase
         Metadata $metadata,
         OfferMetadata $expected
     ): void {
+        $this->repository
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(OfferMetadata::default(self::OFFER_ID));
+
         $this->repository
             ->expects($this->once())
             ->method('save')
@@ -91,6 +101,11 @@ class OfferMetadataProjectorTest extends TestCase
     ): void {
         $this->repository
             ->expects($this->once())
+            ->method('get')
+            ->willReturn(OfferMetadata::default(self::OFFER_ID));
+
+        $this->repository
+            ->expects($this->once())
             ->method('save')
             ->with($expected);
 
@@ -106,6 +121,11 @@ class OfferMetadataProjectorTest extends TestCase
     ): void {
         $this->repository
             ->expects($this->once())
+            ->method('get')
+            ->willReturn(OfferMetadata::default(self::OFFER_ID));
+
+        $this->repository
+            ->expects($this->once())
             ->method('save')
             ->with($expected);
 
@@ -119,6 +139,11 @@ class OfferMetadataProjectorTest extends TestCase
         Metadata $metadata,
         OfferMetadata $expected
     ): void {
+        $this->repository
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(OfferMetadata::default(self::OFFER_ID));
+
         $this->repository
             ->expects($this->once())
             ->method('save')

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataRepositoryTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataRepositoryTest.php
@@ -52,4 +52,24 @@ class OfferMetadataRepositoryTest extends TestCase
         $this->expectException(EntityNotFoundException::class);
         $this->repository->get('offer_id');
     }
+
+    /**
+     * @test
+     */
+    public function it_can_update_existing_offer_metadata(): void
+    {
+        $offerId = 'offer_id';
+        $createdByApiConsumer = 'uitdatabank-ui';
+        $updatedCreatedByApiConsumer = 'other-api-consumer';
+
+        $offerMetadata = new OfferMetadata($offerId, $createdByApiConsumer);
+        $this->repository->save($offerMetadata);
+
+        $updatedOfferMetadata = $offerMetadata->withCreatedByApiConsumer($updatedCreatedByApiConsumer);
+        $this->repository->save($updatedOfferMetadata);
+
+        $persistedOfferMetadata = $this->repository->get($offerId);
+        $this->assertEquals($updatedCreatedByApiConsumer, $persistedOfferMetadata->getCreatedByApiConsumer());
+        $this->assertEquals($offerId, $persistedOfferMetadata->getOfferId());
+    }
 }


### PR DESCRIPTION
### Changed
- This reverts the changes introduced by an unnecessary cleanup in https://github.com/cultuurnet/udb3-silex/pull/635#issuecomment-809337347, making the read model projection idempotent again

---
Ticket: https://jira.uitdatabank.be/browse/III-3819
