### PR TITLE
III-3661 Filter out irrelevant Sentry messages

### DIFF
--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -4,11 +4,52 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
+use Broadway\Repository\AggregateNotFoundException;
+use CultuurNet\CalendarSummaryV3\FormatterException;
+use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
+use CultuurNet\UDB3\Deserializer\DataValidationException;
+use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\Deserializer\NotWellFormedException;
+use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
+use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
+use CultuurNet\UDB3\Jwt\JwtParserException;
+use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\Security\CommandAuthorizationException;
+use CultuurNet\UDB3\UiTPAS\Event\CommandHandling\Validation\EventHasTicketSalesException;
 use Psr\Log\LoggerInterface;
+use Respect\Validation\Exceptions\GroupedValidationException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Throwable;
 
 final class ErrorLogger
 {
+    private const BAD_REQUESTS = [
+        EntityNotFoundException::class,
+        CommandAuthorizationException::class,
+        NotFoundHttpException::class,
+        MethodNotAllowedException::class,
+        DataValidationException::class,
+        GroupedValidationException::class,
+        RequestAuthenticationException::class,
+        MissingValueException::class,
+        AggregateNotFoundException::class,
+        MethodNotAllowedHttpException::class,
+        EventHasTicketSalesException::class,
+        MediaObjectNotFoundException::class,
+        JwtParserException::class,
+        DocumentDoesNotExist::class,
+        NotWellFormedException::class,
+        BadRequestHttpException::class,
+        FormatterException::class,
+        EventCannotBeAddedToProduction::class,
+        EventCannotBeRemovedFromProduction::class,
+    ];
+
     /**
      * @var LoggerInterface
      */
@@ -21,7 +62,22 @@ final class ErrorLogger
 
     public function log(Throwable $throwable): void
     {
+        if (self::isBadRequestException($throwable)) {
+            return;
+        }
+
         // Include the original throwable as "exception" so that the Sentry monolog handler can process it correctly.
         $this->logger->error($throwable->getMessage(), ['exception' => $throwable]);
+    }
+
+    public static function isBadRequestException(Throwable $e): bool
+    {
+        // Use an instanceof check instead of in_array to also allow filtering on parent class or interface.
+        foreach (self::BAD_REQUESTS as $badRequestExceptionClass) {
+            if ($e instanceof $badRequestExceptionClass) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/Error/WebErrorHandlerProvider.php
+++ b/app/Error/WebErrorHandlerProvider.php
@@ -4,20 +4,31 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
+use Broadway\Repository\AggregateNotFoundException;
 use Crell\ApiProblem\ApiProblem;
 use CultureFeed_Exception;
 use CultureFeed_HttpException;
+use CultuurNet\CalendarSummaryV3\FormatterException;
 use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
+use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
 use CultuurNet\UDB3\HttpFoundation\Response\ApiProblemJsonResponse;
+use CultuurNet\UDB3\Jwt\JwtParserException;
+use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\Security\CommandAuthorizationException;
+use CultuurNet\UDB3\UiTPAS\Event\CommandHandling\Validation\EventHasTicketSalesException;
 use Error;
 use Exception;
 use Respect\Validation\Exceptions\GroupedValidationException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Throwable;
@@ -35,6 +46,17 @@ class WebErrorHandlerProvider implements ServiceProviderInterface
         GroupedValidationException::class,
         RequestAuthenticationException::class,
         MissingValueException::class,
+        AggregateNotFoundException::class,
+        MethodNotAllowedHttpException::class,
+        EventHasTicketSalesException::class,
+        MediaObjectNotFoundException::class,
+        JwtParserException::class,
+        DocumentDoesNotExist::class,
+        NotWellFormedException::class,
+        BadRequestHttpException::class,
+        FormatterException::class,
+        EventCannotBeAddedToProduction::class,
+        EventCannotBeRemovedFromProduction::class,
     ];
 
     public function register(Application $app): void

--- a/app/Error/WebErrorHandlerProvider.php
+++ b/app/Error/WebErrorHandlerProvider.php
@@ -4,60 +4,21 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
-use Broadway\Repository\AggregateNotFoundException;
 use Crell\ApiProblem\ApiProblem;
 use CultureFeed_Exception;
 use CultureFeed_HttpException;
-use CultuurNet\CalendarSummaryV3\FormatterException;
-use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
-use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Deserializer\NotWellFormedException;
-use CultuurNet\UDB3\EntityNotFoundException;
-use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
-use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
 use CultuurNet\UDB3\HttpFoundation\Response\ApiProblemJsonResponse;
-use CultuurNet\UDB3\Jwt\JwtParserException;
-use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
-use CultuurNet\UDB3\Security\CommandAuthorizationException;
-use CultuurNet\UDB3\UiTPAS\Event\CommandHandling\Validation\EventHasTicketSalesException;
 use Error;
 use Exception;
 use Respect\Validation\Exceptions\GroupedValidationException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Throwable;
 
 class WebErrorHandlerProvider implements ServiceProviderInterface
 {
     private static $debug = false;
-
-    private const BAD_REQUESTS = [
-        EntityNotFoundException::class,
-        CommandAuthorizationException::class,
-        NotFoundHttpException::class,
-        MethodNotAllowedException::class,
-        DataValidationException::class,
-        GroupedValidationException::class,
-        RequestAuthenticationException::class,
-        MissingValueException::class,
-        AggregateNotFoundException::class,
-        MethodNotAllowedHttpException::class,
-        EventHasTicketSalesException::class,
-        MediaObjectNotFoundException::class,
-        JwtParserException::class,
-        DocumentDoesNotExist::class,
-        NotWellFormedException::class,
-        BadRequestHttpException::class,
-        FormatterException::class,
-        EventCannotBeAddedToProduction::class,
-        EventCannotBeRemovedFromProduction::class,
-    ];
 
     public function register(Application $app): void
     {
@@ -73,21 +34,11 @@ class WebErrorHandlerProvider implements ServiceProviderInterface
 
         $app->error(
             function (Exception $e) use ($app) {
-                $defaultStatus = ApiProblemJsonResponse::HTTP_BAD_REQUEST;
+                $app[ErrorLogger::class]->log($e);
 
-                $badRequest = false;
-                // Don't log exceptions that are caused by user errors.
-                // Use an instanceof check instead of in_array to also allow filtering on parent class or interface.
-                foreach (self::BAD_REQUESTS as $badRequestExceptionClass) {
-                    if ($e instanceof $badRequestExceptionClass) {
-                        $badRequest = true;
-                        break;
-                    }
-                }
-
-                if (!$badRequest) {
-                    $app[ErrorLogger::class]->log($e);
-                    $defaultStatus = ApiProblemJsonResponse::HTTP_INTERNAL_SERVER_ERROR;
+                $defaultStatus = ApiProblemJsonResponse::HTTP_INTERNAL_SERVER_ERROR;
+                if (ErrorLogger::isBadRequestException($e)) {
+                    $defaultStatus = ApiProblemJsonResponse::HTTP_BAD_REQUEST;
                 }
 
                 $problem = $this::createNewApiProblem($e, $defaultStatus);


### PR DESCRIPTION
### Added

- Added more bad request exceptions to filter out of logs/Sentry

### Changed

- Bad request filtering now happens on the logger level, so if they occur async through supervisor/resque workers they do not get logged/sent to Sentry anymore either

---
Ticket: https://jira.uitdatabank.be/browse/III-3661
