### PR TITLE
Introduce RetryingCommandBus for optimistic locking

### DIFF
--- a/app/CommandHandling/CommandBusServiceProvider.php
+++ b/app/CommandHandling/CommandBusServiceProvider.php
@@ -99,7 +99,9 @@ class CommandBusServiceProvider implements ServiceProviderInterface
                 return new LazyLoadingCommandBus(
                     new ValidatingCommandBusDecorator(
                         new ContextDecoratedCommandBus(
-                            $app['authorized_command_bus'],
+                            new RetryingCommandBus(
+                                $app['authorized_command_bus']
+                            ),
                             $app
                         ),
                         $app['event_command_validator']

--- a/app/CommandHandling/RetryingCommandBus.php
+++ b/app/CommandHandling/RetryingCommandBus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\CommandHandling;
+
+use CultuurNet\UDB3\CommandHandling\CommandBusDecoratorBase;
+
+class RetryingCommandBus extends CommandBusDecoratorBase
+{
+    public function dispatch($command)
+    {
+        return $this->decoratee->dispatch($command);
+    }
+}

--- a/app/CommandHandling/RetryingCommandBus.php
+++ b/app/CommandHandling/RetryingCommandBus.php
@@ -8,6 +8,8 @@ use CultuurNet\UDB3\CommandHandling\CommandBusDecoratorBase;
 
 class RetryingCommandBus extends CommandBusDecoratorBase
 {
+    public const MAX_RETRIES = 3;
+
     public function dispatch($command)
     {
         return $this->decoratee->dispatch($command);

--- a/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
+++ b/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Broadway\CommandHandling;
+
+use Broadway\CommandHandling\CommandBus;
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Silex\CommandHandling\RetryingCommandBus;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RetryingCommandBusTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $decoratee;
+
+    /**
+     * @var RetryingCommandBus
+     */
+    private $commandBus;
+
+    protected function setUp()
+    {
+        $this->decoratee = $this->createMock(CommandBus::class);
+        $this->commandBus = new RetryingCommandBus($this->decoratee);
+    }
+
+    /**
+     * @test
+     */
+    public function it_decorates_command_dispatching(): void
+    {
+        $command = (object) ['do' => 'something'];
+
+        $this->decoratee->expects($this->once())
+            ->method('dispatch')
+            ->with($command);
+
+        $this->commandBus->dispatch($command);
+    }
+
+    /**
+     * @test
+     */
+    public function it_decorates_handler_subscriptions()
+    {
+        /* @var CommandHandler $handler */
+        $handler = $this->createMock(CommandHandler::class);
+
+        $this->decoratee->expects($this->once())
+            ->method('subscribe')
+            ->with($handler);
+
+        $this->commandBus->subscribe($handler);
+    }
+}


### PR DESCRIPTION
### Fixed
- Introduced a retrying command bus as a form of optimistic locking for race conditions in an aggregate that was loaded through concurrent requests.

---
Ticket: https://jira.uitdatabank.be/browse/III-3919
