### PR TITLE
III-3928 Fix console app exiting with incorrect status on error

### DIFF
--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -137,5 +137,7 @@ try {
     exit(1);
 } catch (\Error $error) {
     $app[ErrorLogger::class]->log($error);
+    // The version of Symfony Console that we are on does not support rendering of Errors yet, so after logging it we
+    // should re-throw it so PHP itself prints a message and then exits with a non-zero status code.
     throw $error;
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -132,6 +132,9 @@ try {
 } catch (\Exception $exception) {
     $app[ErrorLogger::class]->log($exception);
     $consoleApp->renderException($exception, new ConsoleOutput());
+    // Exit with a non-zero status code so a script executing this command gets feedback on whether it was successful or
+    // not. This is also how Symfony Console normally does it when it catches exceptions. (Which we disabled)
+    exit(1);
 } catch (\Error $error) {
     $app[ErrorLogger::class]->log($error);
     throw $error;


### PR DESCRIPTION
### Fixed

- Fixed the console app returning status 0 when it crashed, for example during a replay.

---
Ticket: https://jira.uitdatabank.be/browse/III-3928
