### PR TITLE
III-4010 Term label decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 phpunit.xml
 external_id_mapping_organizer.yml
 external_id_mapping_place.yml
+term_mapping_*.yml
 .php_cs.cache

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -20,10 +20,12 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\TermLabelOfferRepositoryDecorator;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\Term\TermRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -58,6 +60,8 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                 );
 
                 $repository = new NewPropertyPolyfillOfferRepository($repository);
+
+                $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\TermLabelOfferRepositoryDecorator;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\Place\DummyPlaceProjectionEnricher;
@@ -22,6 +23,7 @@ use CultuurNet\UDB3\Place\ReadModel\JSONLD\PlaceLDProjector;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\RelatedPlaceLDProjector;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\Term\TermRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -97,6 +99,8 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                 );
 
                 $repository = new NewPropertyPolyfillOfferRepository($repository);
+
+                $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/app/Term/TermServiceProvider.php
+++ b/app/Term/TermServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Term;
+
+use CultuurNet\UDB3\Term\TermRepository;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\Yaml\Yaml;
+
+final class TermServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app[TermRepository::class] = $app::share(
+            function () {
+                $mapping = [];
+
+                $files = [
+                    __DIR__ . '/../../term_mapping_facilities.yml',
+                    __DIR__ . '/../../term_mapping_themes.yml',
+                    __DIR__ . '/../../term_mapping_types.yml',
+                ];
+
+                foreach ($files as $file) {
+                    if (file_exists($file)) {
+                        $yaml = file_get_contents($file);
+                        $yaml = Yaml::parse($yaml);
+
+                        if (is_array($yaml)) {
+                            $mapping = array_merge($mapping, $yaml);
+                        }
+                    }
+                }
+
+                return new TermRepository($mapping);
+            }
+        );
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -53,6 +53,7 @@ use CultuurNet\UDB3\Silex\Search\Sapi3SearchServiceProvider;
 use CultuurNet\UDB3\Silex\Security\GeneralSecurityServiceProvider;
 use CultuurNet\UDB3\Silex\Security\OrganizerSecurityServiceProvider;
 use CultuurNet\UDB3\Silex\Error\SentryServiceProvider;
+use CultuurNet\UDB3\Silex\Term\TermServiceProvider;
 use CultuurNet\UDB3\Silex\Yaml\YamlConfigServiceProvider;
 use CultuurNet\UDB3\User\Auth0UserIdentityResolver;
 use CultuurNet\UDB3\User\UserIdentityDetails;
@@ -1100,6 +1101,8 @@ $app->register(new CuratorsServiceProvider());
 
 $app->register(new Auth0ServiceProvider());
 $app->register(new Psr7ServiceProvider());
+
+$app->register(new TermServiceProvider());
 
 if (isset($app['config']['bookable_event']['dummy_place_ids'])) {
     LocationId::setDummyPlaceForEducationIds($app['config']['bookable_event']['dummy_place_ids']);

--- a/src/Category.php
+++ b/src/Category.php
@@ -31,10 +31,6 @@ class Category implements Serializable, JsonLdSerializableInterface
             throw new InvalidArgumentException('Category ID can not be empty.');
         }
 
-        if (!is_string($domain)) {
-            throw new InvalidArgumentException('Domain should be a string.');
-        }
-
         $this->id = $id;
         $this->label = $label;
         $this->domain = $domain;

--- a/src/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecorator.php
+++ b/src/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecorator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Term\TermNotFoundException;
+use CultuurNet\UDB3\Term\TermRepository;
+
+final class TermLabelOfferRepositoryDecorator extends DocumentRepositoryDecorator
+{
+    /**
+     * @var TermRepository
+     */
+    private $termRepository;
+
+    public function __construct(DocumentRepository $repository, TermRepository $termRepository)
+    {
+        parent::__construct($repository);
+        $this->termRepository = $termRepository;
+    }
+
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        $document = parent::fetch($id, $includeMetadata);
+        $document = $document->applyAssoc(
+            function (array $json) {
+                if (!isset($json['terms']) || !is_array($json['terms'])) {
+                    // JSON is not formatted as expected, continue without trying to fix it.
+                    return $json;
+                }
+
+                $json['terms'] = array_map(
+                    function ($term) {
+                        if (!is_array($term) || !isset($term['id']) || !is_string($term['id'])) {
+                            // The term is not formatted as expected, continue on to the next one without trying to fix
+                            // this one.
+                            return $term;
+                        }
+
+                        $id = $term['id'];
+
+                        try {
+                            $termConfig = $this->termRepository->getById($id);
+                        } catch (TermNotFoundException $e) {
+                            // The term id is not found in the config files with term labels. Continue on to the next
+                            // term without trying to fix this one.
+                            return $term;
+                        }
+
+                        $label = $termConfig->getLabel();
+                        if (!is_null($label)) {
+                            $term['label'] = $label->toString();
+                        }
+                        return $term;
+                    },
+                    $json['terms']
+                );
+
+                return $json;
+            }
+        );
+        return $document;
+    }
+}

--- a/src/Term/TermNotFoundException.php
+++ b/src/Term/TermNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Term;
+
+use RuntimeException;
+
+final class TermNotFoundException extends RuntimeException
+{
+    public static function forId(string $id): TermNotFoundException
+    {
+        return new self("No term found with id " . $id);
+    }
+}

--- a/src/Term/TermNotFoundException.php
+++ b/src/Term/TermNotFoundException.php
@@ -10,6 +10,6 @@ final class TermNotFoundException extends RuntimeException
 {
     public static function forId(string $id): TermNotFoundException
     {
-        return new self("No term found with id " . $id);
+        return new self('No term found with id ' . $id);
     }
 }

--- a/src/Term/TermRepository.php
+++ b/src/Term/TermRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Term;
+
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
+
+final class TermRepository
+{
+    /**
+     * @var array
+     */
+    private $mapping;
+
+    public function __construct(array $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    public function getById(string $id): Category
+    {
+        if (!isset($this->mapping[$id])) {
+            throw new TermNotFoundException($id);
+        }
+
+        $label = $this->mapping[$id]['name']['nl'] ?? null;
+        $label = $label ? new CategoryLabel($label) : null;
+
+        return new Category(new CategoryID($id), $label);
+    }
+}

--- a/tests/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecoratorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/TermLabelOfferRepositoryDecoratorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\Term\TermRepository;
+use PHPUnit\Framework\TestCase;
+
+class TermLabelOfferRepositoryDecoratorTest extends TestCase
+{
+    private const MAPPING = [
+        '0.41.0.0.0' => [
+            'name' => [
+                'nl' => 'Thema of pretpark',
+                'fr' => 'Parc à thème ou parc d\'attractions',
+                'de' => 'Unterhaltungspark',
+                'en' => 'Theme park',
+            ],
+        ],
+        '3CuHvenJ+EGkcvhXLg9Ykg' => [
+            'name' => [
+                'nl' => 'Archeologische Site',
+            ],
+        ],
+        'no_name' => [],
+        'no_name_nl' => [
+            'name' => [
+                'fr' => '...',
+            ],
+        ],
+    ];
+
+    /**
+     * @var TermLabelOfferRepositoryDecorator
+     */
+    private $termLabelDecorator;
+
+    protected function setUp(): void
+    {
+        $this->termLabelDecorator = new TermLabelOfferRepositoryDecorator(
+            new InMemoryDocumentRepository(),
+            new TermRepository(self::MAPPING)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_replace_known_term_labels(): void
+    {
+        $id = '5624b810-c340-40a4-8f38-0393eca59bfe';
+
+        $givenJson = [
+            'terms' => [
+                [
+                    'id' => '0.41.0.0.0',
+                    'label' => 'Should be changed',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => '3CuHvenJ+EGkcvhXLg9Ykg',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'no_name',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'no_name_nl',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'does_not_exist',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+            ],
+        ];
+
+        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+
+        $expectedJson = [
+            'terms' => [
+                [
+                    'id' => '0.41.0.0.0',
+                    'label' => 'Thema of pretpark',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => '3CuHvenJ+EGkcvhXLg9Ykg',
+                    'label' => 'Archeologische Site',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'no_name',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'no_name_nl',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+                [
+                    'id' => 'does_not_exist',
+                    'label' => 'Should remain unchanged',
+                    'domain' => 'mock',
+                ],
+            ],
+        ];
+
+        $this->termLabelDecorator->save($givenDocument);
+        $actualDocument = $this->termLabelDecorator->fetch($id);
+        $actualJson = $actualDocument->getAssocBody();
+
+        $this->assertEquals($expectedJson, $actualJson);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_offers_without_terms_property(): void
+    {
+        $id = 'b8fa0fcb-4062-42a7-9e39-d3a515421ec9';
+
+        $givenJson = ['foo' => 'bar'];
+        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+
+        $expectedJson = ['foo' => 'bar'];
+
+        $this->termLabelDecorator->save($givenDocument);
+        $actualDocument = $this->termLabelDecorator->fetch($id);
+        $actualJson = $actualDocument->getAssocBody();
+
+        $this->assertEquals($expectedJson, $actualJson);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_offers_with_terms_property_that_is_not_an_array(): void
+    {
+        $id = 'b220e450-0cec-4607-84a2-0026dfda77ff';
+
+        $givenJson = ['terms' => 'foo'];
+        $givenDocument = new JsonDocument($id, json_encode($givenJson));
+
+        $expectedJson = ['terms' => 'foo'];
+
+        $this->termLabelDecorator->save($givenDocument);
+        $actualDocument = $this->termLabelDecorator->fetch($id);
+        $actualJson = $actualDocument->getAssocBody();
+
+        $this->assertEquals($expectedJson, $actualJson);
+    }
+}

--- a/tests/Term/TermRepositoryTest.php
+++ b/tests/Term/TermRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace CultuurNet\UDB3\Term;
+
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
+use PHPUnit\Framework\TestCase;
+
+final class TermRepositoryTest extends TestCase
+{
+    private const MAPPING = [
+        '0.41.0.0.0' => [
+            'name' => [
+                'nl' => 'Thema of pretpark',
+                'fr' => 'Parc à thème ou parc d\'attractions',
+                'de' => 'Unterhaltungspark',
+                'en' => 'Theme park',
+            ],
+        ],
+        '0.59.0.0.0' => [
+            'name' => [
+                'nl' => 'Sportactiviteit',
+                'fr' => 'Activité sportive',
+                'de' => 'Geben Wettbewerb',
+                'en' => 'Sports activity',
+            ],
+        ],
+        '3CuHvenJ+EGkcvhXLg9Ykg' => [
+            'name' => [
+                'nl' => 'Archeologische Site',
+            ],
+        ],
+        'rJRFUqmd6EiqTD4c7HS90w' => [
+            'name' => [
+                'nl' => 'School of onderwijscentrum',
+            ],
+        ],
+        'no_name' => [],
+        'no_name_nl' => [
+            'name' => [
+                'fr' => '...',
+            ],
+        ],
+    ];
+
+    /**
+     * @var TermRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = new TermRepository(self::MAPPING);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_an_existing_term_with_label_by_id(): void
+    {
+        $givenId = '0.41.0.0.0';
+        $expectedTerm = new Category(
+            new CategoryID('0.41.0.0.0'),
+            new CategoryLabel('Thema of pretpark')
+        );
+        $actualTerm = $this->repository->getById($givenId);
+        $this->assertEquals($expectedTerm, $actualTerm);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_an_existing_term_without_label(): void
+    {
+        $givenId = 'no_name';
+        $expectedTerm = new Category(
+            new CategoryID('no_name')
+        );
+        $actualTerm = $this->repository->getById($givenId);
+        $this->assertEquals($expectedTerm, $actualTerm);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_an_existing_term_without_dutch_label(): void
+    {
+        $givenId = 'no_name_nl';
+        $expectedTerm = new Category(
+            new CategoryID('no_name_nl')
+        );
+        $actualTerm = $this->repository->getById($givenId);
+        $this->assertEquals($expectedTerm, $actualTerm);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_an_exception_for_an_id_that_does_not_exist(): void
+    {
+        $givenId = 'does_not_exist';
+        $this->expectException(TermNotFoundException::class);
+        $this->repository->getById($givenId);
+    }
+}

--- a/tests/Term/TermRepositoryTest.php
+++ b/tests/Term/TermRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CultuurNet\UDB3\Term;
 
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;


### PR DESCRIPTION
### Added

- Added decorator around event/place JSON-LD repositories to update/add term labels on-the-fly from config

---
Ticket: https://jira.uitdatabank.be/browse/III-4010

Related config PRs:
- https://github.com/cultuurnet/appconfig/pull/70
- https://github.com/cultuurnet/udb3-vagrant/pull/63

Note that this config still needs to be double checked to make sure the label names are correct
