### PR TITLE
III-3991 Return early when type is not object

### DIFF
--- a/src/ReadModel/ConfigurableJsonDocumentLanguageAnalyzer.php
+++ b/src/ReadModel/ConfigurableJsonDocumentLanguageAnalyzer.php
@@ -98,6 +98,10 @@ class ConfigurableJsonDocumentLanguageAnalyzer implements JsonDocumentLanguageAn
             return [];
         }
 
+        if (!is_object($json->{$propertyName})) {
+            return [];
+        }
+
         return array_keys(
             get_object_vars($json->{$propertyName})
         );


### PR DESCRIPTION
### Fixed
- Return early when type is not object inside language analyzer
---
Ticket: https://jira.uitdatabank.be/browse/III-3991
