### PR TITLE
III-4052 Remove unused claims from required claims

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -78,15 +78,12 @@ $app['security.firewalls'] = array(
                 'validation' => $app['config']['jwt']['uitid']['validation'],
                 'required_claims' => [
                     'uid',
-                    'nick',
-                    'email',
                 ],
                 'public_key' => 'file://' . __DIR__ . '/../' . $app['config']['jwt']['uitid']['keys']['public']['file']
             ],
             'auth0' => [
                 'validation' => $app['config']['jwt']['auth0']['validation'],
                 'required_claims' => [
-                    'email',
                     'sub',
                 ],
                 'public_key' => 'file://' . __DIR__ . '/../' . $app['config']['jwt']['auth0']['keys']['public']['file']


### PR DESCRIPTION
### Removed

- Removed `email` from required claims in Auth0 tokens
- Removed `nick` and `email` from required claims in old UDB3 self-signed tokens (long-lived or integrations using the old JWT provider)

---
Ticket: https://jira.uitdatabank.be/browse/III-4052

Note: This just removes the requirement for these claims from the token validation. It shouldn't break existing tokens that have these claims, they will just be ignored.
