### PR TITLE
III-4061 Remove api key requirement for access tokens

### DIFF
--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -120,6 +120,7 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                 }
 
                 $app['consumer'] = $consumer;
+                return null;
             },
             Application::LATE_EVENT
         );

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -98,7 +98,7 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                 $token = $app['jwt'];
                 $clientId = $token->getClientId();
                 if ($clientId) {
-                    // return null;
+                    return null;
                 }
 
                 try {

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -94,10 +94,8 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                     return null;
                 }
 
-                /** @var Udb3Token $token */
-                $token = $app['jwt'];
-                $clientId = $token->getClientId();
-                if ($clientId) {
+                // Don't do an API key check if an access token with Auth0 client id is used.
+                if (!is_null($app['api_client_id'])) {
                     return null;
                 }
 

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedApiKeyAuthenticator;
 use CultuurNet\UDB3\ApiGuard\Request\ApiKeyRequestAuthenticator;
 use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
+use CultuurNet\UDB3\Jwt\Udb3Token;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
@@ -87,6 +88,13 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                     }
                 } catch (AuthenticationCredentialsNotFoundException $exception) {
                     // The request is for a public URL so we can skip any checks.
+                    return;
+                }
+
+                /** @var Udb3Token $token */
+                $token = $app['jwt'];
+                $clientId = $token->getClientId();
+                if ($clientId) {
                     return;
                 }
 

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -16,7 +16,6 @@ use CultuurNet\UDB3\ApiGuard\Request\ApiKeyRequestAuthenticator;
 use CultuurNet\UDB3\ApiGuard\Request\RequestAuthenticationException;
 use CultuurNet\UDB3\HttpFoundation\Response\ForbiddenResponse;
 use CultuurNet\UDB3\HttpFoundation\Response\UnauthorizedResponse;
-use CultuurNet\UDB3\Jwt\Udb3Token;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -73,6 +73,11 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                     return null;
                 }
 
+                // Don't do an API key check if an access token with Auth0 client id is used.
+                if (!is_null($app['api_client_id'])) {
+                    return null;
+                }
+
                 /** @var AuthorizationChecker $security */
                 $security = $app['security.authorization_checker'];
                 /** @var ApiKeyRequestAuthenticator $apiKeyAuthenticator */
@@ -91,11 +96,6 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                     }
                 } catch (AuthenticationCredentialsNotFoundException $exception) {
                     // The request is for a public URL so we can skip any checks.
-                    return null;
-                }
-
-                // Don't do an API key check if an access token with Auth0 client id is used.
-                if (!is_null($app['api_client_id'])) {
                     return null;
                 }
 

--- a/app/CommandHandling/ContextFactory.php
+++ b/app/CommandHandling/ContextFactory.php
@@ -32,6 +32,10 @@ final class ContextFactory
             $contextValues['auth_jwt'] = $jwt;
         }
 
+        if ($jwt && $jwt->getClientId()) {
+            $contextValues['auth_api_client_id'] = $jwt->getClientId();
+        }
+
         if ($apiKey) {
             $contextValues['auth_api_key'] = $apiKey;
         }

--- a/app/Error/SentryHandlerScopeDecorator.php
+++ b/app/Error/SentryHandlerScopeDecorator.php
@@ -64,7 +64,9 @@ final class SentryHandlerScopeDecorator implements HandlerInterface
 
     private function createApiTags(): array
     {
+        $clientId = $this->udb3Token ? $this->udb3Token->getClientId() : null;
         return [
+            'api_client_id' => $clientId ?? 'null',
             'api_key' => $this->apiKey ? $this->apiKey->toString() : 'null',
             'api_name' => $this->apiName ?? 'null',
         ];

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Clock\SystemClock;
 use CultuurNet\UDB3\Event\EventOrganizerRelationService;
 use CultuurNet\UDB3\Event\Productions\ProductionCommandHandler;
 use CultuurNet\UDB3\Jwt\Symfony\Authentication\JwtUserToken;
+use CultuurNet\UDB3\Jwt\Udb3Token;
 use CultuurNet\UDB3\Log\SocketIOEmitterHandler;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Event\ExternalEventService;
@@ -282,6 +283,16 @@ $app['api_key'] = $app->share(
         // It is possible to work without api key then null is returned
         // and will be handled with a pass through authorizer.
         return isset($app['auth.api_key']) ? $app['auth.api_key'] : null;
+    }
+);
+
+$app['api_client_id'] = $app::share(
+    function (Application $app) {
+        $token = $app['jwt'];
+        if ($token instanceof Udb3Token) {
+            return $token->getClientId();
+        }
+        return null;
     }
 );
 

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -123,6 +123,7 @@ jwt:
     domain: publiq-acc.eu.auth0.com
     client_id:
     client_secret:
+    jwt_provider_client_id:
 
 api_key:
   group_id: ***

--- a/src/HttpFoundation/Response/ForbiddenResponse.php
+++ b/src/HttpFoundation/Response/ForbiddenResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\HttpFoundation\Response;
+
+use Crell\ApiProblem\ApiProblem;
+
+final class ForbiddenResponse extends ApiProblemJsonResponse
+{
+    public function __construct(string $detail)
+    {
+        $problem = new ApiProblem('Forbidden', 'https://api.publiq.be/probs/auth/forbidden');
+        $problem->setStatus(403);
+        $problem->setDetail($detail);
+
+        parent::__construct($problem);
+    }
+}

--- a/src/HttpFoundation/Response/UnauthorizedResponse.php
+++ b/src/HttpFoundation/Response/UnauthorizedResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\HttpFoundation\Response;
+
+use Crell\ApiProblem\ApiProblem;
+
+final class UnauthorizedResponse extends ApiProblemJsonResponse
+{
+    public function __construct(string $detail)
+    {
+        $problem = new ApiProblem('Unauthorized', 'https://api.publiq.be/probs/auth/unauthorized');
+        $problem->setStatus(401);
+        $problem->setDetail($detail);
+
+        parent::__construct($problem);
+    }
+}

--- a/src/Jwt/JwtParserException.php
+++ b/src/Jwt/JwtParserException.php
@@ -11,6 +11,6 @@ class JwtParserException extends \InvalidArgumentException
 {
     public function __construct($e)
     {
-        parent::__construct($e->getMessage(), 403);
+        parent::__construct($e->getMessage(), 401);
     }
 }

--- a/src/Jwt/Silex/JwtServiceProvider.php
+++ b/src/Jwt/Silex/JwtServiceProvider.php
@@ -69,7 +69,8 @@ class JwtServiceProvider implements ServiceProviderInterface
                 $app['security.authentication_provider.' . $name . '.jwt'] = $app->share(
                     function () use ($app, $name) {
                         return new JwtAuthenticationProvider(
-                            $app['security.token_decoder.' . $name . '.jwt']
+                            $app['security.token_decoder.' . $name . '.jwt'],
+                            $app['config']['jwt']['auth0']['jwt_provider_client_id']
                         );
                     }
                 );

--- a/src/Jwt/Symfony/Authentication/JwtAuthenticationEntryPoint.php
+++ b/src/Jwt/Symfony/Authentication/JwtAuthenticationEntryPoint.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Jwt\Symfony\Authentication;
 
-use Symfony\Component\HttpFoundation\JsonResponse;
+use CultuurNet\UDB3\HttpFoundation\Response\UnauthorizedResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -23,12 +23,6 @@ class JwtAuthenticationEntryPoint implements AuthenticationEntryPointInterface
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        $responseData = ['error' => 'Unauthorized'];
-
-        if (!is_null($authException)) {
-            $responseData['details'] = $authException->getMessage();
-        }
-
-        return JsonResponse::create($responseData, 401);
+        return new UnauthorizedResponse('This endpoint requires a token but none found in the request.');
     }
 }

--- a/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
+++ b/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
@@ -70,11 +70,22 @@ class JwtAuthenticationProvider implements AuthenticationProviderInterface
             );
         }
 
-        if (!$jwt->isAccessToken()) {
+        if ($jwt->isAccessToken()) {
+            $this->validateAccessToken($jwt);
+        } else {
             $this->validateIdToken($jwt);
         }
 
         return new JwtUserToken($jwt, true);
+    }
+
+    private function validateAccessToken(Udb3Token $jwt): void
+    {
+        if (!$jwt->canUseEntryAPI()) {
+            throw new AuthenticationException(
+                'The given token and its related client are not allowed to access EntryAPI.'
+            );
+        }
     }
 
     private function validateIdToken(Udb3Token $jwt): void

--- a/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
+++ b/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
@@ -16,11 +16,17 @@ class JwtAuthenticationProvider implements AuthenticationProviderInterface
      */
     private $decoderService;
 
+    /**
+     * @var string
+     */
+    private $jwtProviderClientId;
 
     public function __construct(
-        JwtDecoderServiceInterface $decoderService
+        JwtDecoderServiceInterface $decoderService,
+        string $jwtProviderClientId
     ) {
         $this->decoderService = $decoderService;
+        $this->jwtProviderClientId = $jwtProviderClientId;
     }
 
     /**
@@ -60,6 +66,12 @@ class JwtAuthenticationProvider implements AuthenticationProviderInterface
         if (!$this->decoderService->validateRequiredClaims($jwt)) {
             throw new AuthenticationException(
                 'Token is missing one of its required claims.'
+            );
+        }
+
+        if (!$jwt->getClientId() && !$jwt->audienceContains($this->jwtProviderClientId)) {
+            throw new AuthenticationException(
+                'Token has no azp claim. Did you accidentally use an id token instead of an access token?'
             );
         }
 

--- a/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
+++ b/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Jwt\Symfony\Authentication;
 
 use CultuurNet\UDB3\Jwt\JwtDecoderServiceInterface;
+use CultuurNet\UDB3\Jwt\Udb3Token;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -69,12 +70,19 @@ class JwtAuthenticationProvider implements AuthenticationProviderInterface
             );
         }
 
-        if (!$jwt->getClientId() && !$jwt->audienceContains($this->jwtProviderClientId)) {
-            throw new AuthenticationException(
-                'Token has no azp claim. Did you accidentally use an id token instead of an access token?'
-            );
+        if (!$jwt->isAccessToken()) {
+            $this->validateIdToken($jwt);
         }
 
         return new JwtUserToken($jwt, true);
+    }
+
+    private function validateIdToken(Udb3Token $jwt): void
+    {
+        if (!$jwt->audienceContains($this->jwtProviderClientId)) {
+            throw new AuthenticationException(
+                'Only legacy id tokens are supported. Please use an access token instead.'
+            );
+        }
     }
 }

--- a/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
+++ b/src/Jwt/Symfony/Authentication/JwtAuthenticationProvider.php
@@ -83,7 +83,8 @@ class JwtAuthenticationProvider implements AuthenticationProviderInterface
     {
         if (!$jwt->canUseEntryAPI()) {
             throw new AuthenticationException(
-                'The given token and its related client are not allowed to access EntryAPI.'
+                'The given token and its related client are not allowed to access EntryAPI.',
+                403
             );
         }
     }

--- a/src/Jwt/Symfony/Firewall/JwtListener.php
+++ b/src/Jwt/Symfony/Firewall/JwtListener.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Jwt\Symfony\Firewall;
 
+use CultuurNet\UDB3\HttpFoundation\Response\ForbiddenResponse;
+use CultuurNet\UDB3\HttpFoundation\Response\UnauthorizedResponse;
+use CultuurNet\UDB3\Jwt\JwtParserException;
 use CultuurNet\UDB3\Jwt\Symfony\Authentication\JwtUserToken;
 use CultuurNet\UDB3\Jwt\JwtDecoderServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -53,16 +55,25 @@ class JwtListener implements ListenerInterface
             return;
         }
 
-        $jwt = $this->decoderService->parse(new StringLiteral($jwtString));
+        try {
+            $jwt = $this->decoderService->parse(new StringLiteral($jwtString));
+        } catch (JwtParserException $e) {
+            $response = new UnauthorizedResponse('Could not parse the given JWT.');
+            $event->setResponse($response);
+            return;
+        }
+
         $token = new JwtUserToken($jwt);
 
         try {
             $authenticatedToken = $this->authenticationManager->authenticate($token);
             $this->tokenStorage->setToken($authenticatedToken);
         } catch (AuthenticationException $e) {
-            $event->setResponse(
-                new Response($e->getMessage(), 401)
-            );
+            $response = new UnauthorizedResponse($e->getMessage());
+            if ($e->getCode() === 403) {
+                $response = new ForbiddenResponse($e->getMessage());
+            }
+            $event->setResponse($response);
         }
     }
 

--- a/src/Jwt/Udb3Token.php
+++ b/src/Jwt/Udb3Token.php
@@ -49,4 +49,19 @@ final class Udb3Token
         }
         return null;
     }
+
+    public function audienceContains(string $audience): bool
+    {
+        if (!$this->token->hasClaim('aud')) {
+            return false;
+        }
+
+        // The aud claim can be a string or an array. Convert string to array with one value for consistency.
+        $aud = $this->token->getClaim('aud');
+        if (is_string($aud)) {
+            $aud = [$aud];
+        }
+
+        return in_array($audience, $aud, true);
+    }
 }

--- a/src/Jwt/Udb3Token.php
+++ b/src/Jwt/Udb3Token.php
@@ -39,4 +39,14 @@ final class Udb3Token
     {
         return $this->token;
     }
+
+    public function getClientId(): ?string
+    {
+        // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to
+        // null and the claim is missing).
+        if ($this->token->hasClaim('azp')) {
+            return (string) $this->token->getClaim('azp');
+        }
+        return null;
+    }
 }

--- a/src/Jwt/Udb3Token.php
+++ b/src/Jwt/Udb3Token.php
@@ -40,6 +40,14 @@ final class Udb3Token
         return $this->token;
     }
 
+    public function isAccessToken(): bool
+    {
+        // This does not 100% guarantee that the token is an access token, because an access token does not have an azp
+        // if it has no specific aud. However we require our integrators to always include the "https://api.publiq.be"
+        // aud, so access tokens should always have an azp in our case.
+        return !is_null($this->getClientId());
+    }
+
     public function getClientId(): ?string
     {
         // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to

--- a/src/Jwt/Udb3Token.php
+++ b/src/Jwt/Udb3Token.php
@@ -64,4 +64,16 @@ final class Udb3Token
 
         return in_array($audience, $aud, true);
     }
+
+    public function canUseEntryAPI(): bool
+    {
+        $apis = $this->token->getClaim('https://publiq.be/publiq-apis', '');
+
+        if (!is_string($apis)) {
+            return false;
+        }
+
+        $apis = explode(' ', $apis);
+        return in_array('entry', $apis, true);
+    }
 }

--- a/tests/Jwt/Symfony/Authentication/JwtAuthenticationEntryPointTest.php
+++ b/tests/Jwt/Symfony/Authentication/JwtAuthenticationEntryPointTest.php
@@ -26,12 +26,14 @@ class JwtAuthenticationEntryPointTest extends TestCase
     public function it_returns_a_response_with_status_401_and_a_json_body()
     {
         $request = new Request();
-        $exception = new AuthenticationException('JWT is expired.');
+        $exception = new AuthenticationException('No token found in TokenStorage');
 
         $expectedBody = json_encode(
             [
-                'error' => 'Unauthorized',
-                'details' => 'JWT is expired.',
+                'title' => 'Unauthorized',
+                'type' => 'https://api.publiq.be/probs/auth/unauthorized',
+                'status' => 401,
+                'detail' => 'This endpoint requires a token but none found in the request.',
             ]
         );
 

--- a/tests/Jwt/Symfony/Authentication/JwtAuthenticationProviderTest.php
+++ b/tests/Jwt/Symfony/Authentication/JwtAuthenticationProviderTest.php
@@ -180,7 +180,7 @@ class JwtAuthenticationProviderTest extends TestCase
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage(
-            'Token has no azp claim. Did you accidentally use an id token instead of an access token?'
+            'Only legacy id tokens are supported. Please use an access token instead.'
         );
 
         $this->authenticationProvider->authenticate($token);

--- a/tests/Jwt/Symfony/Firewall/JwtListenerTest.php
+++ b/tests/Jwt/Symfony/Firewall/JwtListenerTest.php
@@ -203,7 +203,6 @@ class JwtListenerTest extends TestCase
             ->method('setResponse')
             ->willReturnCallback(
                 function (Response $response) {
-                    $this->assertEquals('Authentication failed', $response->getContent());
                     $this->assertEquals(401, $response->getStatusCode());
                 }
             );

--- a/tests/Jwt/Udb3TokenTest.php
+++ b/tests/Jwt/Udb3TokenTest.php
@@ -154,4 +154,34 @@ final class Udb3TokenTest extends TestCase
         $this->assertTrue($token->audienceContains('vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'));
         $this->assertFalse($token->audienceContains('bla'));
     }
+
+    /**
+     * @test
+     */
+    public function it_can_check_if_a_token_can_be_used_on_entry_api(): void
+    {
+        $tokenWithoutApis = new Udb3Token(new Token());
+        $tokenWithOnlyEntry = $this->createTokenForPubliqApis('entry');
+        $tokenWithMultipleIncludingEntry = $this->createTokenForPubliqApis('ups entry sapi');
+        $tokenWithMultipleExcludingEntry = $this->createTokenForPubliqApis('ups sapi');
+        $tokenWithMultipleAndTooManySpaces = $this->createTokenForPubliqApis(' ups  entry  sapi ');
+
+        $this->assertFalse($tokenWithoutApis->canUseEntryAPI());
+        $this->assertTrue($tokenWithOnlyEntry->canUseEntryAPI());
+        $this->assertTrue($tokenWithMultipleIncludingEntry->canUseEntryAPI());
+        $this->assertFalse($tokenWithMultipleExcludingEntry->canUseEntryAPI());
+        $this->assertTrue($tokenWithMultipleAndTooManySpaces->canUseEntryAPI());
+    }
+
+    private function createTokenForPubliqApis(string $publiqApis): Udb3Token
+    {
+        return new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                [
+                    'https://publiq.be/publiq-apis' => new Basic('https://publiq.be/publiq-apis', $publiqApis),
+                ]
+            )
+        );
+    }
 }

--- a/tests/Jwt/Udb3TokenTest.php
+++ b/tests/Jwt/Udb3TokenTest.php
@@ -85,6 +85,7 @@ final class Udb3TokenTest extends TestCase
         );
 
         $this->assertEquals('jndYaQY9BSa9W7FQqDEGI0WEi4KlU6vJ', $token->getClientId());
+        $this->assertTrue($token->isAccessToken());
     }
 
     /**
@@ -102,6 +103,7 @@ final class Udb3TokenTest extends TestCase
         );
 
         $this->assertNull($token->getClientId());
+        $this->assertFalse($token->isAccessToken());
     }
 
     /**

--- a/tests/Jwt/Udb3TokenTest.php
+++ b/tests/Jwt/Udb3TokenTest.php
@@ -103,4 +103,55 @@ final class Udb3TokenTest extends TestCase
 
         $this->assertNull($token->getClientId());
     }
+
+    /**
+     * @test
+     */
+    public function it_can_check_if_the_aud_claim_contains_a_specific_value(): void
+    {
+        $token = new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                [
+                    'aud' => new Basic('aud', ['vsCe0hXlLaR255wOrW56Fau7vYO5qvqD']),
+                ]
+            )
+        );
+
+        $this->assertTrue($token->audienceContains('vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'));
+        $this->assertFalse($token->audienceContains('bla'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_if_the_aud_claim_is_missing(): void
+    {
+        $token = new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                []
+            )
+        );
+
+        $this->assertFalse($token->audienceContains('vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_string_as_aud_claim(): void
+    {
+        $token = new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                [
+                    'aud' => new Basic('aud', 'vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'),
+                ]
+            )
+        );
+
+        $this->assertTrue($token->audienceContains('vsCe0hXlLaR255wOrW56Fau7vYO5qvqD'));
+        $this->assertFalse($token->audienceContains('bla'));
+    }
 }

--- a/tests/Jwt/Udb3TokenTest.php
+++ b/tests/Jwt/Udb3TokenTest.php
@@ -69,4 +69,38 @@ final class Udb3TokenTest extends TestCase
 
         $this->assertEquals('auth0|ce6abd8f-b1e2-4bce-9dde-08af64438e87', $token->id());
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_client_id_from_azp_claim_if_present(): void
+    {
+        $token = new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                [
+                    'azp' => new Basic('azp', 'jndYaQY9BSa9W7FQqDEGI0WEi4KlU6vJ'),
+                ]
+            )
+        );
+
+        $this->assertEquals('jndYaQY9BSa9W7FQqDEGI0WEi4KlU6vJ', $token->getClientId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_as_client_id_if_azp_claim_is_missing(): void
+    {
+        $token = new Udb3Token(
+            new Token(
+                ['alg' => 'none'],
+                [
+                    'sub' => new Basic('sub', 'auth0|ce6abd8f-b1e2-4bce-9dde-08af64438e87'),
+                ]
+            )
+        );
+
+        $this->assertNull($token->getClientId());
+    }
 }


### PR DESCRIPTION
### Added

- Added check that id tokens can only be used if they are provided by the JWT provider (for backward compatibility)
- Client id from access tokens in Sentry errors
- Client id from access tokens in event store metadata

### Removed

- Removed API key requirement for access tokens (that have an `azp` claim)

---
Ticket: https://jira.uitdatabank.be/browse/III-4061

![Screen Shot 2021-06-23 at 16 26 10](https://user-images.githubusercontent.com/959026/123120124-5bec2780-d444-11eb-92f4-701ceb040e8f.png)
