### PR TITLE
III-4067 Support auth_api_client_id metadata for consumer

### DIFF
--- a/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataProjector.php
@@ -80,11 +80,11 @@ class OfferMetadataProjector implements EventListener
     {
         $properties = $metadata->serialize();
 
-        if (!isset($properties['auth_api_key'])) {
+        if (!isset($properties['auth_api_key']) && !isset($properties['auth_api_client_id'])) {
             return 'unknown';
         }
 
-        $apiKey = $properties['auth_api_key'];
+        $apiKey = $properties['auth_api_key'] ?? $properties['auth_api_client_id'];
         if (!array_key_exists($apiKey, $this->apiKeyConsumerMapping)) {
             return 'other';
         }

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
@@ -31,6 +31,7 @@ class OfferMetadataProjectorTest extends TestCase
     private const OFFER_ID = 'OFFER_ID';
     private const TEST_MAPPING = [
         'udb_api_key' => 'uitdatabank-ui',
+        'auth0_client_id' => 'uitdatabank-ui-auth0'
     ];
 
     /**
@@ -170,10 +171,26 @@ class OfferMetadataProjectorTest extends TestCase
                 ),
                 new OfferMetadata(self::OFFER_ID, 'uitdatabank-ui'),
             ],
+            'with auth0 client id' => [
+                new Metadata(
+                    [
+                        'auth_api_client_id' => 'auth0_client_id',
+                    ]
+                ),
+                new OfferMetadata(self::OFFER_ID, 'uitdatabank-ui-auth0'),
+            ],
             'with other api key' => [
                 new Metadata(
                     [
                         'auth_api_key' => 'other-api-key',
+                    ]
+                ),
+                new OfferMetadata(self::OFFER_ID, 'other'),
+            ],
+            'with other auth0 client id' => [
+                new Metadata(
+                    [
+                        'auth_api_client_id' => 'other_auth0_client_id-api-key',
                     ]
                 ),
                 new OfferMetadata(self::OFFER_ID, 'other'),

--- a/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
+++ b/tests/Offer/ReadModel/Metadata/OfferMetadataProjectorTest.php
@@ -31,7 +31,7 @@ class OfferMetadataProjectorTest extends TestCase
     private const OFFER_ID = 'OFFER_ID';
     private const TEST_MAPPING = [
         'udb_api_key' => 'uitdatabank-ui',
-        'auth0_client_id' => 'uitdatabank-ui-auth0'
+        'auth0_client_id' => 'uitdatabank-ui-auth0',
     ];
 
     /**


### PR DESCRIPTION
### Added
- Support auth_api_client_id metadata for consumer
---
Ticket: https://jira.uitdatabank.be/browse/III-4067

Note: the mapping config still needs to be updated in the appconfig repo and the udb3-vagrant repo and needs to represent the new id for the user interface
