### PR TITLE
III-4103 Extend the production create endpoint with a production id

### DIFF
--- a/src/Http/Productions/ProductionsWriteController.php
+++ b/src/Http/Productions/ProductionsWriteController.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Event\Productions\ProductionId;
 use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use CultuurNet\UDB3\Event\Productions\RejectSuggestedEventPair;
 use CultuurNet\UDB3\Event\Productions\SimilarEventPair;
+use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -55,7 +56,7 @@ class ProductionsWriteController
 
         $this->commandBus->dispatch($command);
 
-        return new Response('', 201);
+        return new JsonLdResponse(['productionId' => $command->getItemId()], 201);
     }
 
     public function addEventToProduction(

--- a/tests/Http/Productions/ProductionsWriteControllerTest.php
+++ b/tests/Http/Productions/ProductionsWriteControllerTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Event\Productions\MergeProductions;
 use CultuurNet\UDB3\Event\Productions\ProductionId;
 use CultuurNet\UDB3\Event\Productions\RemoveEventFromProduction;
 use CultuurNet\UDB3\Event\Productions\RejectSuggestedEventPair;
+use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
@@ -70,13 +71,17 @@ class ProductionsWriteControllerTest extends TestCase
         );
 
         $this->commandBus->record();
-        $this->controller->create($request);
+        $response = $this->controller->create($request);
 
         $this->assertCount(1, $this->commandBus->getRecordedCommands());
+
+        /** @var GroupEventsAsProduction $recordedCommand */
         $recordedCommand = $this->commandBus->getRecordedCommands()[0];
         $this->assertInstanceOf(GroupEventsAsProduction::class, $recordedCommand);
         $this->assertEquals($name, $recordedCommand->getName());
         $this->assertEquals([$eventId1, $eventId2], $recordedCommand->getEventIds());
+
+        $this->assertEquals(new JsonLdResponse(['productionId' => $recordedCommand->getItemId()], 201), $response);
     }
 
     /**


### PR DESCRIPTION
### Changed
- Extend the response of the production create endpoint with a production id
---
Ticket: https://jira.uitdatabank.be/browse/III-4103
