### PR TITLE
III-3494 Cleanup the type hinting of commands

### DIFF
--- a/src/Event/Productions/AddEventToProduction.php
+++ b/src/Event/Productions/AddEventToProduction.php
@@ -37,12 +37,12 @@ final class AddEventToProduction implements AuthorizableCommandInterface
         return $this->productionId;
     }
 
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getProductionId()->toNative();
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::PRODUCTIES_AANMAKEN();
     }

--- a/src/Event/Productions/GroupEventsAsProduction.php
+++ b/src/Event/Productions/GroupEventsAsProduction.php
@@ -40,12 +40,12 @@ class GroupEventsAsProduction implements AuthorizableCommandInterface
         );
     }
 
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getProductionId()->toNative();
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::PRODUCTIES_AANMAKEN();
     }

--- a/src/Event/Productions/MergeProductions.php
+++ b/src/Event/Productions/MergeProductions.php
@@ -37,12 +37,12 @@ final class MergeProductions implements AuthorizableCommandInterface
         return $this->to;
     }
 
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getFrom()->toNative();
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::PRODUCTIES_AANMAKEN();
     }

--- a/src/Event/Productions/RejectSuggestedEventPair.php
+++ b/src/Event/Productions/RejectSuggestedEventPair.php
@@ -27,7 +27,7 @@ final class RejectSuggestedEventPair implements AuthorizableCommandInterface
         ];
     }
 
-    public function getItemId()
+    public function getItemId(): string
     {
         return  $this->eventPair->getEventOne();
     }
@@ -37,7 +37,7 @@ final class RejectSuggestedEventPair implements AuthorizableCommandInterface
         return $this->eventPair;
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::PRODUCTIES_AANMAKEN();
     }

--- a/src/Event/Productions/RemoveEventFromProduction.php
+++ b/src/Event/Productions/RemoveEventFromProduction.php
@@ -37,12 +37,12 @@ final class RemoveEventFromProduction implements AuthorizableCommandInterface
         return $this->productionId;
     }
 
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getProductionId()->toNative();
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::PRODUCTIES_AANMAKEN();
     }

--- a/src/Label/Commands/AbstractCommand.php
+++ b/src/Label/Commands/AbstractCommand.php
@@ -31,18 +31,12 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
         return $this->uuid;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->uuid->toNative();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::LABELS_BEHEREN();
     }

--- a/src/Label/Commands/AbstractCommand.php
+++ b/src/Label/Commands/AbstractCommand.php
@@ -23,10 +23,7 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
         $this->uuid = $uuid;
     }
 
-    /**
-     * @return UUID
-     */
-    public function getUuid()
+    public function getUuid(): UUID
     {
         return $this->uuid;
     }

--- a/src/Label/Commands/AbstractCommand.php
+++ b/src/Label/Commands/AbstractCommand.php
@@ -15,9 +15,6 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
      */
     private $uuid;
 
-    /**
-     * AbstractCommand constructor.
-     */
     public function __construct(UUID $uuid)
     {
         $this->uuid = $uuid;

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -105,18 +105,12 @@ class UploadImage implements AuthorizableCommandInterface
         return $this->filePath;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return (string) $this->getFileId();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::MEDIA_UPLOADEN();
     }

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -60,26 +60,17 @@ class UploadImage implements AuthorizableCommandInterface
         $this->language = $language;
     }
 
-    /**
-     * @return Language
-     */
-    public function getLanguage()
+    public function getLanguage(): Language
     {
         return $this->language;
     }
 
-    /**
-     * @return UUID
-     */
-    public function getFileId()
+    public function getFileId(): UUID
     {
         return $this->fileId;
     }
 
-    /**
-     * @return StringLiteral
-     */
-    public function getDescription()
+    public function getDescription(): StringLiteral
     {
         return $this->description;
     }
@@ -89,18 +80,12 @@ class UploadImage implements AuthorizableCommandInterface
         return $this->copyrightHolder;
     }
 
-    /**
-     * @return MIMEType
-     */
-    public function getMimeType()
+    public function getMimeType(): MIMEType
     {
         return $this->mimeType;
     }
 
-    /**
-     * @return StringLiteral
-     */
-    public function getFilePath()
+    public function getFilePath(): StringLiteral
     {
         return $this->filePath;
     }

--- a/src/Offer/Commands/AbstractCommand.php
+++ b/src/Offer/Commands/AbstractCommand.php
@@ -13,11 +13,7 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
      */
     protected $itemId;
 
-    /**
-     * AbstractCommand constructor.
-     * @param string $itemId
-     */
-    public function __construct($itemId)
+    public function __construct(string $itemId)
     {
         if (!is_string($itemId)) {
             throw new \InvalidArgumentException(

--- a/src/Offer/Commands/AbstractCommand.php
+++ b/src/Offer/Commands/AbstractCommand.php
@@ -28,18 +28,12 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
         $this->itemId = $itemId;
     }
 
-    /**
-     * @return string
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->itemId;
     }
 
-    /**
-     * @return Permission
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::AANBOD_BEWERKEN();
     }

--- a/src/Offer/Commands/AbstractUpdateFacilities.php
+++ b/src/Offer/Commands/AbstractUpdateFacilities.php
@@ -14,10 +14,7 @@ abstract class AbstractUpdateFacilities extends AbstractCommand
      */
     protected $facilities;
 
-    /**
-     * @param string $itemId
-     */
-    public function __construct($itemId, array $facilities)
+    public function __construct(string $itemId, array $facilities)
     {
         parent::__construct($itemId);
         $this->facilities = $facilities;

--- a/src/Offer/Commands/AbstractUpdateFacilities.php
+++ b/src/Offer/Commands/AbstractUpdateFacilities.php
@@ -23,10 +23,7 @@ abstract class AbstractUpdateFacilities extends AbstractCommand
         $this->facilities = $facilities;
     }
 
-    /**
-     * @return array
-     */
-    public function getFacilities()
+    public function getFacilities(): array
     {
         return $this->facilities;
     }

--- a/src/Offer/Commands/AbstractUpdateFacilities.php
+++ b/src/Offer/Commands/AbstractUpdateFacilities.php
@@ -31,10 +31,7 @@ abstract class AbstractUpdateFacilities extends AbstractCommand
         return $this->facilities;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::VOORZIENINGEN_BEWERKEN();
     }

--- a/src/Offer/Commands/AuthorizableCommandInterface.php
+++ b/src/Offer/Commands/AuthorizableCommandInterface.php
@@ -8,13 +8,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 interface AuthorizableCommandInterface
 {
-    /**
-     * @return string
-     */
-    public function getItemId();
+    public function getItemId(): string;
 
-    /**
-     * @return Permission
-     */
-    public function getPermission();
+    public function getPermission(): Permission;
 }

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -61,10 +61,7 @@ final class ImportLabels extends AbstractCommand implements LabelSecurityInterfa
         return $this->labelsToRemoveWhenOnOffer;
     }
 
-    /**
-     * @return Labels
-     */
-    public function getLabelsToImport()
+    public function getLabelsToImport(): Labels
     {
         $labelNamesToKeep = array_map(
             function (Label $label) {

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -26,10 +26,7 @@ final class ImportLabels extends AbstractCommand implements LabelSecurityInterfa
      */
     private $labelsToRemoveWhenOnOffer;
 
-    /**
-     * @param string $itemId
-     */
-    public function __construct($itemId, Labels $labels)
+    public function __construct(string $itemId, Labels $labels)
     {
         parent::__construct($itemId);
         $this->labels = $labels;

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -80,10 +80,7 @@ final class ImportLabels extends AbstractCommand implements LabelSecurityInterfa
         );
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getNames()
+    public function getNames(): array
     {
         return array_map(
             function (Label $label) {

--- a/src/Offer/Commands/Moderation/AbstractModerationCommand.php
+++ b/src/Offer/Commands/Moderation/AbstractModerationCommand.php
@@ -9,10 +9,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 abstract class AbstractModerationCommand extends AbstractCommand
 {
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::AANBOD_MODEREREN();
     }

--- a/src/Offer/Commands/PreflightCommand.php
+++ b/src/Offer/Commands/PreflightCommand.php
@@ -13,11 +13,7 @@ class PreflightCommand extends AbstractCommand
      */
     private $permission;
 
-    /**
-     * @param string $itemId
-     * @param Permission $permission
-     */
-    public function __construct($itemId, $permission)
+    public function __construct(string $itemId, Permission $permission)
     {
         parent::__construct($itemId);
         $this->permission = $permission;

--- a/src/Offer/Commands/PreflightCommand.php
+++ b/src/Offer/Commands/PreflightCommand.php
@@ -23,10 +23,7 @@ class PreflightCommand extends AbstractCommand
         $this->permission = $permission;
     }
 
-    /**
-     * @return Permission
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return $this->permission;
     }

--- a/src/Organizer/Commands/AbstractLabelCommand.php
+++ b/src/Organizer/Commands/AbstractLabelCommand.php
@@ -17,11 +17,8 @@ abstract class AbstractLabelCommand extends AbstractOrganizerCommand implements 
      */
     private $label;
 
-    /**
-     * @param string $organizerId
-     */
     public function __construct(
-        $organizerId,
+        string $organizerId,
         Label $label
     ) {
         parent::__construct($organizerId);

--- a/src/Organizer/Commands/AbstractLabelCommand.php
+++ b/src/Organizer/Commands/AbstractLabelCommand.php
@@ -41,10 +41,7 @@ abstract class AbstractLabelCommand extends AbstractOrganizerCommand implements 
         return $this->getOrganizerId();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getNames()
+    public function getNames(): array
     {
         return [
             new StringLiteral((string) $this->label),

--- a/src/Organizer/Commands/AbstractLabelCommand.php
+++ b/src/Organizer/Commands/AbstractLabelCommand.php
@@ -36,10 +36,7 @@ abstract class AbstractLabelCommand extends AbstractOrganizerCommand implements 
         return $this->label;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getOrganizerId();
     }
@@ -54,7 +51,7 @@ abstract class AbstractLabelCommand extends AbstractOrganizerCommand implements 
         ];
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::ORGANISATIES_BEWERKEN();
     }

--- a/src/Organizer/Commands/AbstractLabelCommand.php
+++ b/src/Organizer/Commands/AbstractLabelCommand.php
@@ -28,10 +28,7 @@ abstract class AbstractLabelCommand extends AbstractOrganizerCommand implements 
         $this->label = $label;
     }
 
-    /**
-     * @return Label
-     */
-    public function getLabel()
+    public function getLabel(): Label
     {
         return $this->label;
     }

--- a/src/Organizer/Commands/AbstractOrganizerCommand.php
+++ b/src/Organizer/Commands/AbstractOrganizerCommand.php
@@ -11,10 +11,7 @@ abstract class AbstractOrganizerCommand
      */
     private $organizerId;
 
-    /**
-     * @param string $organizerId
-     */
-    public function __construct($organizerId)
+    public function __construct(string $organizerId)
     {
         $this->organizerId = $organizerId;
     }

--- a/src/Organizer/Commands/AbstractOrganizerCommand.php
+++ b/src/Organizer/Commands/AbstractOrganizerCommand.php
@@ -19,10 +19,7 @@ abstract class AbstractOrganizerCommand
         $this->organizerId = $organizerId;
     }
 
-    /**
-     * @return string
-     */
-    public function getOrganizerId()
+    public function getOrganizerId(): string
     {
         return $this->organizerId;
     }

--- a/src/Organizer/Commands/AbstractUpdateOrganizerCommand.php
+++ b/src/Organizer/Commands/AbstractUpdateOrganizerCommand.php
@@ -9,18 +9,12 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 abstract class AbstractUpdateOrganizerCommand extends AbstractOrganizerCommand implements AuthorizableCommandInterface
 {
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getOrganizerId();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::ORGANISATIES_BEWERKEN();
     }

--- a/src/Organizer/Commands/DeleteOrganizer.php
+++ b/src/Organizer/Commands/DeleteOrganizer.php
@@ -9,18 +9,12 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 class DeleteOrganizer extends AbstractOrganizerCommand implements AuthorizableCommandInterface
 {
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getOrganizerId();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::ORGANISATIES_BEHEREN();
     }

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -23,11 +23,8 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
      */
     private $labelsToKeepIfAlreadyOnOrganizer;
 
-    /**
-     * @param string $organizerId
-     */
     public function __construct(
-        $organizerId,
+        string $organizerId,
         Labels $label
     ) {
         parent::__construct($organizerId);

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -76,10 +76,7 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
         return Permission::AANBOD_BEWERKEN();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getNames()
+    public function getNames(): array
     {
         return array_map(
             function (Label $label) {

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -47,10 +47,7 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
         return $this->labelsToKeepIfAlreadyOnOrganizer;
     }
 
-    /**
-     * @return Labels
-     */
-    public function getLabels()
+    public function getLabels(): Labels
     {
         $labelNamesToKeep = array_map(
             function (Label $label) {

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -66,18 +66,12 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
         );
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->getOrganizerId();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::AANBOD_BEWERKEN();
     }

--- a/src/Place/Commands/MarkAsDuplicate.php
+++ b/src/Place/Commands/MarkAsDuplicate.php
@@ -35,18 +35,12 @@ final class MarkAsDuplicate implements AuthorizableCommandInterface
         return $this->canonicalPlaceId;
     }
 
-    /**
-     * @return string
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return $this->duplicatePlaceId;
     }
 
-    /**
-     * @return Permission
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::GEBRUIKERS_BEHEREN();
     }

--- a/src/Role/Commands/AbstractCommand.php
+++ b/src/Role/Commands/AbstractCommand.php
@@ -15,34 +15,22 @@ abstract class AbstractCommand implements AuthorizableCommandInterface
      */
     private $uuid;
 
-    /**
-     * AbstractCommand constructor.
-     */
     public function __construct(UUID $uuid)
     {
         $this->uuid = $uuid;
     }
 
-    /**
-     * @return UUID
-     */
-    public function getUuid()
+    public function getUuid(): UUID
     {
         return $this->uuid;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getItemId()
+    public function getItemId(): string
     {
         return (string) $this->getUuid();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::GEBRUIKERS_BEHEREN();
     }

--- a/src/Role/Commands/AbstractLabelCommand.php
+++ b/src/Role/Commands/AbstractLabelCommand.php
@@ -22,10 +22,7 @@ abstract class AbstractLabelCommand extends AbstractCommand
         $this->labelId = $labelId;
     }
 
-    /**
-     * @return UUID
-     */
-    public function getLabelId()
+    public function getLabelId(): UUID
     {
         return $this->labelId;
     }

--- a/src/Role/Commands/AbstractLabelCommand.php
+++ b/src/Role/Commands/AbstractLabelCommand.php
@@ -13,7 +13,6 @@ abstract class AbstractLabelCommand extends AbstractCommand
      */
     private $labelId;
 
-
     public function __construct(
         UUID $uuid,
         UUID $labelId

--- a/src/Role/Commands/AbstractPermissionCommand.php
+++ b/src/Role/Commands/AbstractPermissionCommand.php
@@ -14,7 +14,6 @@ abstract class AbstractPermissionCommand extends AbstractCommand
      */
     private $rolePermission;
 
-
     public function __construct(
         UUID $uuid,
         Permission $rolePermission
@@ -26,10 +25,7 @@ abstract class AbstractPermissionCommand extends AbstractCommand
         $this->rolePermission = $rolePermission->toNative();
     }
 
-    /**
-     * @return Permission
-     */
-    public function getRolePermission()
+    public function getRolePermission(): Permission
     {
         return Permission::fromNative($this->rolePermission);
     }

--- a/src/Role/Commands/AbstractUserCommand.php
+++ b/src/Role/Commands/AbstractUserCommand.php
@@ -14,7 +14,6 @@ abstract class AbstractUserCommand extends AbstractCommand
      */
     private $userId;
 
-
     public function __construct(
         UUID $uuid,
         StringLiteral $userId
@@ -23,10 +22,7 @@ abstract class AbstractUserCommand extends AbstractCommand
         $this->userId = $userId;
     }
 
-    /**
-     * @return StringLiteral
-     */
-    public function getUserId()
+    public function getUserId(): StringLiteral
     {
         return $this->userId;
     }

--- a/src/Role/Commands/AddConstraint.php
+++ b/src/Role/Commands/AddConstraint.php
@@ -20,9 +20,6 @@ class AddConstraint extends AbstractCommand
      */
     private $query;
 
-    /**
-     * CreateConstraint constructor.
-     */
     public function __construct(
         UUID $uuid,
         SapiVersion $sapiVersion,

--- a/src/Role/Commands/AddConstraint.php
+++ b/src/Role/Commands/AddConstraint.php
@@ -30,12 +30,10 @@ class AddConstraint extends AbstractCommand
         $this->query = $query;
     }
 
-
     public function getSapiVersion(): SapiVersion
     {
         return SapiVersion::fromNative($this->sapiVersion);
     }
-
 
     public function getQuery(): Query
     {

--- a/src/Role/Commands/CreateRole.php
+++ b/src/Role/Commands/CreateRole.php
@@ -23,10 +23,7 @@ class CreateRole extends AbstractCommand
         $this->name = $name;
     }
 
-    /**
-     * @return StringLiteral
-     */
-    public function getName()
+    public function getName(): StringLiteral
     {
         return $this->name;
     }

--- a/src/Role/Commands/RemoveConstraint.php
+++ b/src/Role/Commands/RemoveConstraint.php
@@ -14,7 +14,6 @@ class RemoveConstraint extends AbstractCommand
      */
     private $sapiVersion;
 
-
     public function __construct(
         UUID $uuid,
         SapiVersion $sapiVersion
@@ -22,7 +21,6 @@ class RemoveConstraint extends AbstractCommand
         parent::__construct($uuid);
         $this->sapiVersion = $sapiVersion->toNative();
     }
-
 
     public function getSapiVersion(): SapiVersion
     {

--- a/src/Security/LabelSecurityInterface.php
+++ b/src/Security/LabelSecurityInterface.php
@@ -11,5 +11,5 @@ interface LabelSecurityInterface
     /**
      * @return StringLiteral[]
      */
-    public function getNames();
+    public function getNames(): array;
 }

--- a/tests/Security/DummyCommand.php
+++ b/tests/Security/DummyCommand.php
@@ -9,12 +9,12 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 class DummyCommand implements AuthorizableCommandInterface
 {
-    public function getItemId()
+    public function getItemId(): string
     {
         return '';
     }
 
-    public function getPermission()
+    public function getPermission(): Permission
     {
         return Permission::AANBOD_BEWERKEN();
     }


### PR DESCRIPTION
### Changed
- Cleanup the type hinting of commands

Note: not essential for III-3494 but always better to create new code with return types

---
Ticket: https://jira.uitdatabank.be/browse/III-3494
