### PR TITLE
Hotfix to prevent crash when token was not parsed

### DIFF
--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -89,6 +89,10 @@ class JsonWebToken extends AbstractToken
 
     public function getClientId(): ?string
     {
+        if ($this->token === null) {
+            return null;
+        }
+
         // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to
         // null and the claim is missing).
         if ($this->token->hasClaim('azp')) {


### PR DESCRIPTION
### Fixed
- Hotfix to prevent crash when token was not parsed
