### PR TITLE
III-4133 Fix /user and /saved-searches for v1 tokens

### DIFF
--- a/app/SavedSearches/SavedSearchesServiceProvider.php
+++ b/app/SavedSearches/SavedSearchesServiceProvider.php
@@ -36,7 +36,7 @@ class SavedSearchesServiceProvider implements ServiceProviderInterface
             function (Application $app) {
                 return new CombinedSavedSearchRepository(
                     new Sapi3FixedSavedSearchRepository(
-                        $app['current_user_id'],
+                        $app['jwt'],
                         $app[Auth0UserIdentityResolver::class],
                         $this->getCreatedByQueryMode($app)
                     ),

--- a/src/Http/User/UserIdentityController.php
+++ b/src/Http/User/UserIdentityController.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use Psr\Http\Message\ServerRequestInterface;
 use ValueObjects\Exception\InvalidNativeArgumentException;
-use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\EmailAddress;
 use Zend\Diactoros\Response\JsonResponse;
 

--- a/src/Http/User/UserIdentityController.php
+++ b/src/Http/User/UserIdentityController.php
@@ -66,15 +66,10 @@ class UserIdentityController
             );
         }
 
-        if ($this->jwt->containsUserIdentityDetails()) {
-            return $this->createCurrentUserResponse($this->jwt->getUserIdentityDetails());
-        }
-
-        $userIdentity = $this->userIdentityResolver->getUserById(new StringLiteral($this->jwt->getUserId()));
-
+        $userIdentity = $this->jwt->getUserIdentityDetails($this->userIdentityResolver);
         if (!($userIdentity instanceof UserIdentityDetails)) {
             return new ApiProblemJsonResponse(
-                ApiProblems::tokenNotSupported('No user found for the user id in the given token.')
+                ApiProblems::tokenNotSupported('No user found for the given token.')
             );
         }
 

--- a/src/Http/User/UserIdentityController.php
+++ b/src/Http/User/UserIdentityController.php
@@ -66,6 +66,10 @@ class UserIdentityController
             );
         }
 
+        if ($this->jwt->containsUserIdentityDetails()) {
+            return $this->createCurrentUserResponse($this->jwt->getUserIdentityDetails());
+        }
+
         $userIdentity = $this->userIdentityResolver->getUserById(new StringLiteral($this->jwt->getUserId()));
 
         if (!($userIdentity instanceof UserIdentityDetails)) {

--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Jwt\Symfony\Authentication;
 
 use CultuurNet\UDB3\User\UserIdentityDetails;
+use CultuurNet\UDB3\User\UserIdentityResolver;
+use Exception;
 use InvalidArgumentException;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Key;
@@ -97,8 +99,12 @@ class JsonWebToken extends AbstractToken
         return $this->hasClaims(['nick', 'email']) || $this->hasClaims(['nickname', 'email']);
     }
 
-    public function getUserIdentityDetails(): ?UserIdentityDetails
+    public function getUserIdentityDetails(UserIdentityResolver $userIdentityResolver): ?UserIdentityDetails
     {
+        if ($this->getType() === self::V2_CLIENT_ACCESS_TOKEN) {
+            return null;
+        }
+
         // Tokens from V1 JWT provider (= custom)
         if ($this->hasClaims(['nick', 'email'])) {
             return new UserIdentityDetails(
@@ -107,6 +113,7 @@ class JsonWebToken extends AbstractToken
                 new EmailAddress($this->token->getClaim('email'))
             );
         }
+
         // Tokens from V2 JWT provider (= Auth0 ID tokens)
         if ($this->hasClaims(['nickname', 'email'])) {
             return new UserIdentityDetails(
@@ -115,7 +122,12 @@ class JsonWebToken extends AbstractToken
                 new EmailAddress($this->token->getClaim('email'))
             );
         }
-        return null;
+
+        try {
+            return $userIdentityResolver->getUserById(new StringLiteral($this->getUserId()));
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
     public function getClientId(): ?string

--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -92,13 +92,6 @@ class JsonWebToken extends AbstractToken
         return $this->token->getClaim('sub');
     }
 
-    public function containsUserIdentityDetails(): bool
-    {
-        // Tokens from the V1 JWT provider (= custom) and V2 JWT provider (= Auth0 ID tokens) contain the username and
-        // email. Auth0 access tokens do not.
-        return $this->hasClaims(['nick', 'email']) || $this->hasClaims(['nickname', 'email']);
-    }
-
     public function getUserIdentityDetails(UserIdentityResolver $userIdentityResolver): ?UserIdentityDetails
     {
         if ($this->getType() === self::V2_CLIENT_ACCESS_TOKEN) {

--- a/tests/CultuurNet/UDB3/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
+++ b/tests/CultuurNet/UDB3/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
@@ -8,11 +8,9 @@ use CultuurNet\UDB3\Jwt\Symfony\Authentication\JsonWebTokenFactory;
 use CultuurNet\UDB3\SavedSearches\Properties\CreatorQueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
-use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
-use ValueObjects\Web\EmailAddress;
 
 class Sapi3FixedSavedSearchRepositoryTest extends TestCase
 {

--- a/tests/CultuurNet/UDB3/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
+++ b/tests/CultuurNet/UDB3/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches;
 
+use CultuurNet\UDB3\Jwt\Symfony\Authentication\JsonWebTokenFactory;
 use CultuurNet\UDB3\SavedSearches\Properties\CreatorQueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
@@ -20,12 +21,20 @@ class Sapi3FixedSavedSearchRepositoryTest extends TestCase
      */
     public function it_handles_query_mode_uuid(): void
     {
+        $token = JsonWebTokenFactory::createWithClaims(
+            [
+                'uid' => 'my_user_id',
+                'nick' => 'my_name',
+                'email' => 'jane.doe@anonymous.com',
+            ]
+        );
+
         $userIdentityResolver = $this->createMock(UserIdentityResolver::class);
         $userIdentityResolver->expects($this->never())
             ->method('getUserById');
 
         $sapi3FixedSavedSearchRepository = new Sapi3FixedSavedSearchRepository(
-            'my_user_id',
+            $token,
             $userIdentityResolver,
             CreatedByQueryMode::UUID()
         );
@@ -48,6 +57,13 @@ class Sapi3FixedSavedSearchRepositoryTest extends TestCase
      */
     public function it_handles_user_not_found(): void
     {
+        $token = JsonWebTokenFactory::createWithClaims(
+            [
+                'sub' => 'my_user_id',
+                'azp' => 'mock-client-id',
+            ]
+        );
+
         $userIdentityResolver = $this->createMock(UserIdentityResolver::class);
         $userIdentityResolver->expects($this->once())
             ->method('getUserById')
@@ -55,7 +71,7 @@ class Sapi3FixedSavedSearchRepositoryTest extends TestCase
             ->willReturn(null);
 
         $sapi3FixedSavedSearchRepository = new Sapi3FixedSavedSearchRepository(
-            'my_user_id',
+            $token,
             $userIdentityResolver,
             CreatedByQueryMode::MIXED()
         );
@@ -78,20 +94,20 @@ class Sapi3FixedSavedSearchRepositoryTest extends TestCase
      */
     public function it_handles_mixed_mode(): void
     {
-        $user = new UserIdentityDetails(
-            new StringLiteral('my_user_id'),
-            new StringLiteral('my_name'),
-            new EmailAddress('jane.doe@anonymous.com')
+        $token = JsonWebTokenFactory::createWithClaims(
+            [
+                'uid' => 'my_user_id',
+                'nick' => 'my_name',
+                'email' => 'jane.doe@anonymous.com',
+            ]
         );
 
         $userIdentityResolver = $this->createMock(UserIdentityResolver::class);
-        $userIdentityResolver->expects($this->once())
-            ->method('getUserById')
-            ->with(new StringLiteral('my_user_id'))
-            ->willReturn($user);
+        $userIdentityResolver->expects($this->never())
+            ->method('getUserById');
 
         $sapi3FixedSavedSearchRepository = new Sapi3FixedSavedSearchRepository(
-            'my_user_id',
+            $token,
             $userIdentityResolver,
             CreatedByQueryMode::MIXED()
         );
@@ -114,20 +130,20 @@ class Sapi3FixedSavedSearchRepositoryTest extends TestCase
      */
     public function it_handles_email_mode(): void
     {
-        $user = new UserIdentityDetails(
-            new StringLiteral('my_user_id'),
-            new StringLiteral('my_name'),
-            new EmailAddress('jane.doe@anonymous.com')
+        $token = JsonWebTokenFactory::createWithClaims(
+            [
+                'uid' => 'my_user_id',
+                'nick' => 'my_name',
+                'email' => 'jane.doe@anonymous.com',
+            ]
         );
 
         $userIdentityResolver = $this->createMock(UserIdentityResolver::class);
-        $userIdentityResolver->expects($this->once())
-            ->method('getUserById')
-            ->with(new StringLiteral('my_user_id'))
-            ->willReturn($user);
+        $userIdentityResolver->expects($this->never())
+            ->method('getUserById');
 
         $sapi3FixedSavedSearchRepository = new Sapi3FixedSavedSearchRepository(
-            'my_user_id',
+            $token,
             $userIdentityResolver,
             CreatedByQueryMode::EMAIL()
         );

--- a/tests/Http/User/UserIdentityControllerTest.php
+++ b/tests/Http/User/UserIdentityControllerTest.php
@@ -52,11 +52,17 @@ class UserIdentityControllerTest extends TestCase
             ->method('getUserByEmail')
             ->willReturn($userIdentity);
 
+        $expected = [
+            'uuid' => 'user_id',
+            'email' => 'jane.doe@anonymous.com',
+            'username' => 'jane_doe',
+        ];
+
         $response = $this->userIdentityController->getByEmailAddress(
             (new ServerRequest())->withAttribute('emailAddress', 'jane.doe@anonymous.com')
         );
 
-        $this->assertJsonResponse(new JsonLdResponse($this->userIdentityToArray($userIdentity)), $response);
+        $this->assertJsonResponse(new JsonLdResponse($expected), $response);
     }
 
     /**
@@ -139,12 +145,16 @@ class UserIdentityControllerTest extends TestCase
 
         $response = $this->userIdentityController->getCurrentUser();
 
-        $userIdentityAsArray = $this->userIdentityToArray($userIdentity);
-        $userIdentityAsArray['id'] = $userIdentity->getUserId()->toNative();
-        $userIdentityAsArray['nick'] = $userIdentity->getUserName()->toNative();
+        $expected = [
+            'uuid' => 'current_user_id',
+            'email' => 'jane.doe@anonymous.com',
+            'username' => 'jane_doe',
+            'id' => 'current_user_id',
+            'nick' => 'jane_doe',
+        ];
 
         $this->assertJsonResponse(
-            new JsonLdResponse($userIdentityAsArray, 200, ['Cache-Control' => 'private']),
+            new JsonLdResponse($expected, 200, ['Cache-Control' => 'private']),
             $response
         );
     }
@@ -222,14 +232,5 @@ class UserIdentityControllerTest extends TestCase
         $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
         $this->assertEquals($expectedResponse->getHeaders(), $actualResponse->getHeaders());
         $this->assertEquals($expectedResponse->getBody()->getContents(), $actualResponse->getBody()->getContents());
-    }
-
-    private function userIdentityToArray(UserIdentityDetails $userIdentityDetails): array
-    {
-        return [
-            'uuid' => $userIdentityDetails->getUserId()->toNative(),
-            'email' => $userIdentityDetails->getEmailAddress()->toNative(),
-            'username' => $userIdentityDetails->getUserName()->toNative(),
-        ];
     }
 }

--- a/tests/Http/User/UserIdentityControllerTest.php
+++ b/tests/Http/User/UserIdentityControllerTest.php
@@ -130,7 +130,43 @@ class UserIdentityControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_can_get_user_identity_of_current_user(): void
+    public function it_can_get_user_identity_of_current_user_from_token_that_contains_it(): void
+    {
+        $jwt = JsonWebTokenFactory::createWithClaims(
+            [
+                'uid' => 'current_user_id',
+                'nick' => 'jane_doe',
+                'email' => 'jane.doe@anonymous.com',
+            ]
+        );
+
+        $this->userIdentityResolver->expects($this->never())
+            ->method('getUserById');
+
+        $controller = new UserIdentityController(
+            $this->userIdentityResolver,
+            $jwt
+        );
+        $response = $controller->getCurrentUser();
+
+        $expected = [
+            'uuid' => 'current_user_id',
+            'email' => 'jane.doe@anonymous.com',
+            'username' => 'jane_doe',
+            'id' => 'current_user_id',
+            'nick' => 'jane_doe',
+        ];
+
+        $this->assertJsonResponse(
+            new JsonLdResponse($expected, 200, ['Cache-Control' => 'private']),
+            $response
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_user_identity_of_current_user_from_auth0_if_not_in_token(): void
     {
         $userIdentity = new UserIdentityDetails(
             new StringLiteral('current_user_id'),

--- a/tests/Http/User/UserIdentityControllerTest.php
+++ b/tests/Http/User/UserIdentityControllerTest.php
@@ -250,7 +250,7 @@ class UserIdentityControllerTest extends TestCase
                     'title' => 'Token not supported',
                     'type' => 'https://api.publiq.be/probs/auth/token-not-supported',
                     'status' => 400,
-                    'detail' => 'No user found for the user id in the given token.',
+                    'detail' => 'No user found for the given token.',
                 ],
                 400,
                 [


### PR DESCRIPTION
### Fixed

- Fixed 400 response on `/user` for v1 tokens
- Fixed email not being included in "door mij ingevoerd" saved search on `/saved-searches` for v1 tokens

---
Ticket: https://jira.uitdatabank.be/browse/III-4133