### PR TITLE
Fix serialising a JWT inside the metadata context for queued command

### DIFF
--- a/app/CommandHandling/ContextFactory.php
+++ b/app/CommandHandling/ContextFactory.php
@@ -29,7 +29,7 @@ final class ContextFactory
         }
 
         if ($jwt) {
-            $contextValues['auth_jwt'] = $jwt;
+            $contextValues['auth_jwt'] = (string) $jwt;
         }
 
         if ($jwt && $jwt->getClientId()) {

--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -124,10 +124,6 @@ class JsonWebToken extends AbstractToken
 
     public function getClientId(): ?string
     {
-        if ($this->token === null) {
-            return null;
-        }
-
         // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to
         // null and the claim is missing).
         if ($this->token->hasClaim('azp')) {

--- a/tests/CultuurNet/UDB3/Silex/CommandHandling/ContextFactoryTest.php
+++ b/tests/CultuurNet/UDB3/Silex/CommandHandling/ContextFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\CommandHandling;
+
+use CultuurNet\UDB3\Jwt\Symfony\Authentication\JsonWebTokenFactory;
+use PHPUnit\Framework\TestCase;
+
+class ContextFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_serialize_a_jwt_context_value(): void
+    {
+        $jsonWebToken = JsonWebTokenFactory::createWithClaims([]);
+        $context = ContextFactory::createContext(null, $jsonWebToken);
+
+        $encodedContext = base64_encode(serialize($context));
+        $decodedContext = unserialize(base64_decode($encodedContext));
+
+        $this->assertEquals($context, $decodedContext);
+    }
+}


### PR DESCRIPTION
### Fixed
- Fix serialising a JWT inside the metadata context for queued command

### Removed
- Remove validation for possible null value of token which should no longer happen

Note: I noticed to late there was already an open PR https://github.com/cultuurnet/udb3-silex/pull/689 but that PR had no reference to the ticket so I missed it.

---
Ticket: https://jira.uitdatabank.be/browse/III-4134
