### PR TITLE
III-4150 Import booking availability

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -23,40 +23,19 @@ use InvalidArgumentException;
 
 final class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serializable
 {
-    /**
-     * @var CalendarType
-     */
-    private $type;
+    private CalendarType $type;
 
-    /**
-     * @var DateTimeInterface
-     */
-    private $startDate;
+    private ?DateTimeInterface $startDate;
 
-    /**
-     * @var DateTimeInterface
-     */
-    private $endDate;
+    private ?DateTimeInterface $endDate;
 
-    /**
-     * @var Timestamp[]
-     */
-    private $timestamps = [];
+    private array $timestamps ;
 
-    /**
-     * @var OpeningHour[]
-     */
-    private $openingHours = [];
+    private array $openingHours ;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
 
-    /**
-     * @var BookingAvailability
-     */
-    private $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     /**
      * @param Timestamp[] $timestamps

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -396,6 +396,9 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
 
         $calendar = new self($type, $startDate, $endDate, $timestamps, $openingHours);
         $calendar->status = Status::fromUdb3ModelStatus($udb3Calendar->getStatus());
+        $calendar->bookingAvailability = BookingAvailability::fromUdb3ModelBookingAvailability(
+            $udb3Calendar->getBookingAvailability()
+        );
         return $calendar;
     }
 

--- a/src/Event/Events/EventCreated.php
+++ b/src/Event/Events/EventCreated.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 
 final class EventCreated extends EventEvent
 {
@@ -114,7 +115,7 @@ final class EventCreated extends EventEvent
         }
         $publicationDate = null;
         if (!is_null($this->getPublicationDate())) {
-            $publicationDate = $this->getPublicationDate()->format(\DateTime::ATOM);
+            $publicationDate = $this->getPublicationDate()->format(DateTimeInterface::ATOM);
         }
         return parent::serialize() + [
             'main_language' => $this->mainLanguage->getCode(),
@@ -136,7 +137,7 @@ final class EventCreated extends EventEvent
         $publicationDate = null;
         if (!empty($data['publication_date'])) {
             $publicationDate = DateTimeImmutable::createFromFormat(
-                \DateTime::ATOM,
+                DateTimeInterface::ATOM,
                 $data['publication_date']
             );
         }

--- a/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
+++ b/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
@@ -20,6 +20,7 @@ use CultuurNet\UDB3\EventExport\Media\Url;
 use CultuurNet\UDB3\EventExport\PriceFormatter;
 use CultuurNet\UDB3\EventExport\UitpasInfoFormatter;
 use CultuurNet\UDB3\StringFilter\StripHtmlStringFilter;
+use DateTimeInterface;
 use stdClass;
 
 class TabularDataEventFormatter
@@ -130,7 +131,7 @@ class TabularDataEventFormatter
         // Try to create from various formats to maintain backwards
         // compatibility with external systems with older json-ld
         // projections (eg. OMD).
-        $formats = [\DateTime::ATOM, \DateTime::ISO8601, 'Y-m-d\TH:i:s'];
+        $formats = [DateTimeInterface::ATOM, DateTimeInterface::ISO8601, 'Y-m-d\TH:i:s'];
 
         do {
             $datetime = \DateTime::createFromFormat(current($formats), $date, $timezoneUtc);
@@ -151,7 +152,7 @@ class TabularDataEventFormatter
     protected function formatDateWithoutTime($date)
     {
         $timezone = new \DateTimeZone('Europe/Brussels');
-        $datetime = \DateTime::createFromFormat(\DateTime::ATOM, $date, $timezone);
+        $datetime = \DateTime::createFromFormat(DateTimeInterface::ATOM, $date, $timezone);
         return $datetime->format('Y-m-d');
     }
 

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar;
 
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
@@ -53,7 +53,7 @@ class CalendarDenormalizer implements DenormalizerInterface
 
         $topLevelStatus = isset($data['status']) ? $this->denormalizeStatus($data['status']) : null;
         $topLevelBookingAvailability = isset($data['bookingAvailability']['type'])
-            ? new BookingAvailability($data['bookingAvailability']['type']) : null;
+            ? new BookingAvailabilityType($data['bookingAvailability']['type']) : null;
 
         switch ($data['calendarType']) {
             case 'single':
@@ -164,11 +164,11 @@ class CalendarDenormalizer implements DenormalizerInterface
     private function denormalizeSubEvent(
         array $subEventData,
         ?Status $topLevelStatus,
-        ?BookingAvailability $topLevelBookingAvailability
+        ?BookingAvailabilityType $topLevelBookingAvailability
     ): SubEvent {
         $statusType = $topLevelStatus ? $topLevelStatus->getType() : StatusType::Available();
         $statusReason = $topLevelStatus ? $topLevelStatus->getReason() : null;
-        $bookingAvailability = $topLevelBookingAvailability ?: BookingAvailability::Available();
+        $bookingAvailability = $topLevelBookingAvailability ?: BookingAvailabilityType::Available();
 
         if (isset($subEventData['status']['type'])) {
             $statusType = new StatusType($subEventData['status']['type']);
@@ -183,7 +183,7 @@ class CalendarDenormalizer implements DenormalizerInterface
         }
 
         if (isset($subEventData['bookingAvailability']['type'])) {
-            $bookingAvailability = new BookingAvailability($subEventData['bookingAvailability']['type']);
+            $bookingAvailability = new BookingAvailabilityType($subEventData['bookingAvailability']['type']);
         }
 
         $status = new Status($statusType, $statusReason);

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -183,7 +183,7 @@ class CalendarDenormalizer implements DenormalizerInterface
         }
 
         if (isset($subEventData['bookingAvailability']['type'])) {
-            $bookingAvailability = new BookingAvailability($subEventData['status']['type']);
+            $bookingAvailability = new BookingAvailability($subEventData['bookingAvailability']['type']);
         }
 
         $status = new Status($statusType, $statusReason);

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar;
 
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -53,7 +54,7 @@ class CalendarDenormalizer implements DenormalizerInterface
 
         $topLevelStatus = isset($data['status']) ? $this->denormalizeStatus($data['status']) : null;
         $topLevelBookingAvailability = isset($data['bookingAvailability']['type'])
-            ? new BookingAvailabilityType($data['bookingAvailability']['type']) : null;
+            ? new BookingAvailability(new BookingAvailabilityType($data['bookingAvailability']['type'])) : null;
 
         switch ($data['calendarType']) {
             case 'single':
@@ -164,11 +165,12 @@ class CalendarDenormalizer implements DenormalizerInterface
     private function denormalizeSubEvent(
         array $subEventData,
         ?Status $topLevelStatus,
-        ?BookingAvailabilityType $topLevelBookingAvailability
+        ?BookingAvailability $topLevelBookingAvailability
     ): SubEvent {
         $statusType = $topLevelStatus ? $topLevelStatus->getType() : StatusType::Available();
         $statusReason = $topLevelStatus ? $topLevelStatus->getReason() : null;
-        $bookingAvailability = $topLevelBookingAvailability ?: BookingAvailabilityType::Available();
+        $bookingAvailability = $topLevelBookingAvailability
+            ?: new BookingAvailability(BookingAvailabilityType::Available());
 
         if (isset($subEventData['status']['type'])) {
             $statusType = new StatusType($subEventData['status']['type']);
@@ -183,7 +185,9 @@ class CalendarDenormalizer implements DenormalizerInterface
         }
 
         if (isset($subEventData['bookingAvailability']['type'])) {
-            $bookingAvailability = new BookingAvailabilityType($subEventData['bookingAvailability']['type']);
+            $bookingAvailability = new BookingAvailability(
+                new BookingAvailabilityType($subEventData['bookingAvailability']['type'])
+            );
         }
 
         $status = new Status($statusType, $statusReason);

--- a/src/Model/Validation/Offer/OfferValidator.php
+++ b/src/Model/Validation/Offer/OfferValidator.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\Validation\Offer;
 
 use CultuurNet\UDB3\Model\Validation\Organizer\OrganizerReferenceValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Audience\AgeRangeValidator;
+use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\BookingAvailabilityValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\MultipleSubEventsCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PeriodicCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PermanentCalendarValidator;
@@ -44,6 +45,7 @@ abstract class OfferValidator extends Validator
             new Key('description', new TranslatedStringValidator('description'), false),
             new HasMainLanguageRule('description'),
             new Key('status', new StatusValidator(), false),
+            new Key('bookingAvailability', new BookingAvailabilityValidator(), false),
             new Key('labels', new LabelsValidator(), false),
             new Key('hiddenLabels', new LabelsValidator(), false),
             new Key('organizer', new OrganizerReferenceValidator(), false),

--- a/src/Model/Validation/ValueObject/Calendar/BookingAvailabilityTypeValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/BookingAvailabilityTypeValidator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
+
+use CultuurNet\UDB3\Model\Validation\ValueObject\EnumValidator;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
+
+class BookingAvailabilityTypeValidator extends EnumValidator
+{
+    protected function getAllowedValues(): array
+    {
+        return BookingAvailabilityType::getAllowedValues();
+    }
+}

--- a/src/Model/Validation/ValueObject/Calendar/BookingAvailabilityValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/BookingAvailabilityValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
+
+use Respect\Validation\Rules\ArrayType;
+use Respect\Validation\Rules\Key;
+use Respect\Validation\Validator;
+
+class BookingAvailabilityValidator extends Validator
+{
+    public function __construct()
+    {
+        $rules = [
+            new ArrayType(),
+            new Key('type', new BookingAvailabilityTypeValidator(), false),
+        ];
+
+        parent::__construct($rules);
+    }
+}

--- a/src/Model/Validation/ValueObject/Calendar/MultipleSubEventsCalendarValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/MultipleSubEventsCalendarValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
 
+use DateTimeInterface;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\AlwaysValid;
 use Respect\Validation\Rules\Date;
@@ -21,12 +22,12 @@ class MultipleSubEventsCalendarValidator extends Validator
             new When(
                 new Key('calendarType', new Equals('multiple'), true),
                 (new AllOf(
-                    new Key('startDate', new Date(\DateTime::ATOM), true),
-                    new Key('endDate', new Date(\DateTime::ATOM), true),
+                    new Key('startDate', new Date(DateTimeInterface::ATOM), true),
+                    new Key('endDate', new Date(DateTimeInterface::ATOM), true),
                     new When(
                         new AllOf(
-                            new Key('startDate', new Date(\DateTime::ATOM)),
-                            new Key('endDate', new Date(\DateTime::ATOM))
+                            new Key('startDate', new Date(DateTimeInterface::ATOM)),
+                            new Key('endDate', new Date(DateTimeInterface::ATOM))
                         ),
                         new KeyValue('endDate', 'min', 'startDate'),
                         new AlwaysValid()

--- a/src/Model/Validation/ValueObject/Calendar/PeriodicCalendarValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/PeriodicCalendarValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
 
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\OpeningHours\OpeningHoursValidator;
+use DateTimeInterface;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\AlwaysValid;
 use Respect\Validation\Rules\Date;
@@ -22,12 +23,12 @@ class PeriodicCalendarValidator extends Validator
             new When(
                 new Key('calendarType', new Equals('periodic'), true),
                 (new AllOf(
-                    new Key('startDate', new Date(\DateTime::ATOM), true),
-                    new Key('endDate', new Date(\DateTime::ATOM), true),
+                    new Key('startDate', new Date(DateTimeInterface::ATOM), true),
+                    new Key('endDate', new Date(DateTimeInterface::ATOM), true),
                     new When(
                         new AllOf(
-                            new Key('startDate', new Date(\DateTime::ATOM)),
-                            new Key('endDate', new Date(\DateTime::ATOM))
+                            new Key('startDate', new Date(DateTimeInterface::ATOM)),
+                            new Key('endDate', new Date(DateTimeInterface::ATOM))
                         ),
                         new KeyValue('endDate', 'min', 'startDate'),
                         new AlwaysValid()

--- a/src/Model/Validation/ValueObject/Calendar/SingleSubEventCalendarValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/SingleSubEventCalendarValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
 
+use DateTimeInterface;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\AlwaysValid;
 use Respect\Validation\Rules\Date;
@@ -23,12 +24,12 @@ class SingleSubEventCalendarValidator extends Validator
             new When(
                 new Key('calendarType', new Equals('single'), true),
                 (new AllOf(
-                    new Key('startDate', new Date(\DateTime::ATOM), true),
-                    new Key('endDate', new Date(\DateTime::ATOM), true),
+                    new Key('startDate', new Date(DateTimeInterface::ATOM), true),
+                    new Key('endDate', new Date(DateTimeInterface::ATOM), true),
                     new When(
                         new AllOf(
-                            new Key('startDate', new Date(\DateTime::ATOM)),
-                            new Key('endDate', new Date(\DateTime::ATOM))
+                            new Key('startDate', new Date(DateTimeInterface::ATOM)),
+                            new Key('endDate', new Date(DateTimeInterface::ATOM))
                         ),
                         new KeyValue('endDate', 'min', 'startDate'),
                         new AlwaysValid()

--- a/src/Model/Validation/ValueObject/Calendar/SubEventValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/SubEventValidator.php
@@ -29,6 +29,7 @@ class SubEventValidator extends Validator
                 new AlwaysValid()
             ),
             new Key('status', new StatusValidator(), false),
+            new Key('bookingAvailability', new BookingAvailabilityValidator(), false),
         ];
 
         parent::__construct($rules);

--- a/src/Model/Validation/ValueObject/Calendar/SubEventValidator.php
+++ b/src/Model/Validation/ValueObject/Calendar/SubEventValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Validation\ValueObject\Calendar;
 
+use DateTimeInterface;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\AlwaysValid;
 use Respect\Validation\Rules\Date;
@@ -17,12 +18,12 @@ class SubEventValidator extends Validator
     public function __construct()
     {
         $rules = [
-            new Key('startDate', new Date(\DateTime::ATOM), true),
-            new Key('endDate', new Date(\DateTime::ATOM), true),
+            new Key('startDate', new Date(DateTimeInterface::ATOM), true),
+            new Key('endDate', new Date(DateTimeInterface::ATOM), true),
             new When(
                 new AllOf(
-                    new Key('startDate', new Date(\DateTime::ATOM)),
-                    new Key('endDate', new Date(\DateTime::ATOM))
+                    new Key('startDate', new Date(DateTimeInterface::ATOM)),
+                    new Key('endDate', new Date(DateTimeInterface::ATOM))
                 ),
                 new KeyValue('endDate', 'min', 'startDate'),
                 new AlwaysValid()

--- a/src/Model/ValueObject/Calendar/BookingAvailability.php
+++ b/src/Model/ValueObject/Calendar/BookingAvailability.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
+
+use CultuurNet\UDB3\Model\ValueObject\String\Enum;
+
+/**
+ * @method static BookingAvailability Available()
+ * @method static BookingAvailability Unavailable()
+ */
+final class BookingAvailability extends Enum
+{
+    public static function getAllowedValues(): array
+    {
+        return [
+            'Available',
+            'Unavailable',
+        ];
+    }
+}

--- a/src/Model/ValueObject/Calendar/BookingAvailability.php
+++ b/src/Model/ValueObject/Calendar/BookingAvailability.php
@@ -6,14 +6,14 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 final class BookingAvailability
 {
-    private BookingAvailability $type;
+    private BookingAvailabilityType $type;
 
-    public function __construct(BookingAvailability $type)
+    public function __construct(BookingAvailabilityType $type)
     {
         $this->type = $type;
     }
 
-    public function getType(): BookingAvailability
+    public function getType(): BookingAvailabilityType
     {
         return $this->type;
     }

--- a/src/Model/ValueObject/Calendar/BookingAvailability.php
+++ b/src/Model/ValueObject/Calendar/BookingAvailability.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
+
+final class BookingAvailability
+{
+    private BookingAvailability $type;
+
+    public function __construct(BookingAvailability $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): BookingAvailability
+    {
+        return $this->type;
+    }
+}

--- a/src/Model/ValueObject/Calendar/BookingAvailabilityType.php
+++ b/src/Model/ValueObject/Calendar/BookingAvailabilityType.php
@@ -7,10 +7,10 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\String\Enum;
 
 /**
- * @method static BookingAvailability Available()
- * @method static BookingAvailability Unavailable()
+ * @method static BookingAvailabilityType Available()
+ * @method static BookingAvailabilityType Unavailable()
  */
-final class BookingAvailability extends Enum
+final class BookingAvailabilityType extends Enum
 {
     public static function getAllowedValues(): array
     {

--- a/src/Model/ValueObject/Calendar/Calendar.php
+++ b/src/Model/ValueObject/Calendar/Calendar.php
@@ -12,7 +12,7 @@ interface Calendar
 
     public function withStatus(Status $status): Calendar;
 
-    public function getBookingAvailability(): BookingAvailabilityType;
+    public function getBookingAvailability(): BookingAvailability;
 
-    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar;
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar;
 }

--- a/src/Model/ValueObject/Calendar/Calendar.php
+++ b/src/Model/ValueObject/Calendar/Calendar.php
@@ -12,7 +12,7 @@ interface Calendar
 
     public function withStatus(Status $status): Calendar;
 
-    public function getBookingAvailability(): BookingAvailability;
+    public function getBookingAvailability(): BookingAvailabilityType;
 
-    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar;
+    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar;
 }

--- a/src/Model/ValueObject/Calendar/Calendar.php
+++ b/src/Model/ValueObject/Calendar/Calendar.php
@@ -11,4 +11,8 @@ interface Calendar
     public function getStatus(): Status;
 
     public function withStatus(Status $status): Calendar;
+
+    public function getBookingAvailability(): BookingAvailability;
+
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar;
 }

--- a/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
+++ b/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
@@ -10,7 +10,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
 
     private Status $status;
 
-    private BookingAvailabilityType $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(SubEvents $dateRanges)
     {
@@ -20,7 +20,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
 
         $this->dateRanges = $dateRanges;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailabilityType::Available();
+        $this->bookingAvailability = new BookingAvailability(BookingAvailabilityType::Available());
     }
 
     public function withStatus(Status $status): Calendar
@@ -30,7 +30,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -47,7 +47,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailabilityType
+    public function getBookingAvailability(): BookingAvailability
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
+++ b/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
@@ -6,15 +6,11 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
-    /**
-     * @var SubEvents
-     */
-    private $dateRanges;
+    private SubEvents $dateRanges;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
+
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(SubEvents $dateRanges)
     {
@@ -24,12 +20,20 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
 
         $this->dateRanges = $dateRanges;
         $this->status = new Status(StatusType::Available());
+        $this->bookingAvailability = BookingAvailability::Available();
     }
 
     public function withStatus(Status $status): Calendar
     {
         $clone = clone $this;
         $clone->status = $status;
+        return $clone;
+    }
+
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    {
+        $clone = clone $this;
+        $clone->bookingAvailability = $bookingAvailability;
         return $clone;
     }
 
@@ -41,6 +45,11 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
     public function getStatus(): Status
     {
         return $this->status;
+    }
+
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
     }
 
     public function getStartDate(): \DateTimeImmutable

--- a/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
+++ b/src/Model/ValueObject/Calendar/MultipleSubEventsCalendar.php
@@ -10,7 +10,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
 
     private Status $status;
 
-    private BookingAvailability $bookingAvailability;
+    private BookingAvailabilityType $bookingAvailability;
 
     public function __construct(SubEvents $dateRanges)
     {
@@ -20,7 +20,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
 
         $this->dateRanges = $dateRanges;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailability::Available();
+        $this->bookingAvailability = BookingAvailabilityType::Available();
     }
 
     public function withStatus(Status $status): Calendar
@@ -30,7 +30,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -47,7 +47,7 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailability
+    public function getBookingAvailability(): BookingAvailabilityType
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/PeriodicCalendar.php
+++ b/src/Model/ValueObject/Calendar/PeriodicCalendar.php
@@ -14,7 +14,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
 
     private Status $status;
 
-    private BookingAvailability $bookingAvailability;
+    private BookingAvailabilityType $bookingAvailability;
 
     public function __construct(
         DateRange $dateRange,
@@ -23,7 +23,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         $this->dateRange = $dateRange;
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailability::Available();
+        $this->bookingAvailability = BookingAvailabilityType::Available();
     }
 
     public function withStatus(Status $status): Calendar
@@ -33,7 +33,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -50,7 +50,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailability
+    public function getBookingAvailability(): BookingAvailabilityType
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/PeriodicCalendar.php
+++ b/src/Model/ValueObject/Calendar/PeriodicCalendar.php
@@ -14,7 +14,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
 
     private Status $status;
 
-    private BookingAvailabilityType $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(
         DateRange $dateRange,
@@ -23,7 +23,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         $this->dateRange = $dateRange;
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailabilityType::Available();
+        $this->bookingAvailability = new BookingAvailability(BookingAvailabilityType::Available());
     }
 
     public function withStatus(Status $status): Calendar
@@ -33,7 +33,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -50,7 +50,7 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailabilityType
+    public function getBookingAvailability(): BookingAvailability
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/PeriodicCalendar.php
+++ b/src/Model/ValueObject/Calendar/PeriodicCalendar.php
@@ -8,20 +8,13 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 
 class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHours
 {
-    /**
-     * @var DateRange
-     */
-    private $dateRange;
+    private DateRange $dateRange;
 
-    /**
-     * @var OpeningHours
-     */
-    private $openingHours;
+    private OpeningHours $openingHours;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
+
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(
         DateRange $dateRange,
@@ -30,12 +23,20 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         $this->dateRange = $dateRange;
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
+        $this->bookingAvailability = BookingAvailability::Available();
     }
 
     public function withStatus(Status $status): Calendar
     {
         $clone = clone $this;
         $clone->status = $status;
+        return $clone;
+    }
+
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    {
+        $clone = clone $this;
+        $clone->bookingAvailability = $bookingAvailability;
         return $clone;
     }
 
@@ -47,6 +48,11 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
     public function getStatus(): Status
     {
         return $this->status;
+    }
+
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
     }
 
     public function getStartDate(): \DateTimeImmutable

--- a/src/Model/ValueObject/Calendar/PermanentCalendar.php
+++ b/src/Model/ValueObject/Calendar/PermanentCalendar.php
@@ -12,13 +12,13 @@ class PermanentCalendar implements CalendarWithOpeningHours
 
     private Status $status;
 
-    private BookingAvailabilityType $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(OpeningHours $openingHours)
     {
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailabilityType::Available();
+        $this->bookingAvailability = new BookingAvailability(BookingAvailabilityType::Available());
     }
 
     public function withStatus(Status $status): Calendar
@@ -28,7 +28,7 @@ class PermanentCalendar implements CalendarWithOpeningHours
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -45,7 +45,7 @@ class PermanentCalendar implements CalendarWithOpeningHours
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailabilityType
+    public function getBookingAvailability(): BookingAvailability
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/PermanentCalendar.php
+++ b/src/Model/ValueObject/Calendar/PermanentCalendar.php
@@ -12,13 +12,13 @@ class PermanentCalendar implements CalendarWithOpeningHours
 
     private Status $status;
 
-    private BookingAvailability $bookingAvailability;
+    private BookingAvailabilityType $bookingAvailability;
 
     public function __construct(OpeningHours $openingHours)
     {
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailability::Available();
+        $this->bookingAvailability = BookingAvailabilityType::Available();
     }
 
     public function withStatus(Status $status): Calendar
@@ -28,7 +28,7 @@ class PermanentCalendar implements CalendarWithOpeningHours
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -45,7 +45,7 @@ class PermanentCalendar implements CalendarWithOpeningHours
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailability
+    public function getBookingAvailability(): BookingAvailabilityType
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/PermanentCalendar.php
+++ b/src/Model/ValueObject/Calendar/PermanentCalendar.php
@@ -8,26 +8,30 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 
 class PermanentCalendar implements CalendarWithOpeningHours
 {
-    /**
-     * @var OpeningHours
-     */
-    private $openingHours;
+    private OpeningHours $openingHours;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
+
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(OpeningHours $openingHours)
     {
         $this->openingHours = $openingHours;
         $this->status = new Status(StatusType::Available());
+        $this->bookingAvailability = BookingAvailability::Available();
     }
 
     public function withStatus(Status $status): Calendar
     {
         $clone = clone $this;
         $clone->status = $status;
+        return $clone;
+    }
+
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    {
+        $clone = clone $this;
+        $clone->bookingAvailability = $bookingAvailability;
         return $clone;
     }
 
@@ -39,6 +43,11 @@ class PermanentCalendar implements CalendarWithOpeningHours
     public function getStatus(): Status
     {
         return $this->status;
+    }
+
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
     }
 
     public function getOpeningHours(): OpeningHours

--- a/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
+++ b/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
@@ -10,13 +10,13 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
 
     private Status $status;
 
-    private BookingAvailabilityType $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(SubEvent $subEvent)
     {
         $this->subEvent = $subEvent;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailabilityType::Available();
+        $this->bookingAvailability = new BookingAvailability(BookingAvailabilityType::Available());
     }
 
     public function withStatus(Status $status): Calendar
@@ -26,7 +26,7 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -43,7 +43,7 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailabilityType
+    public function getBookingAvailability(): BookingAvailability
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
+++ b/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
@@ -10,13 +10,13 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
 
     private Status $status;
 
-    private BookingAvailability $bookingAvailability;
+    private BookingAvailabilityType $bookingAvailability;
 
     public function __construct(SubEvent $subEvent)
     {
         $this->subEvent = $subEvent;
         $this->status = new Status(StatusType::Available());
-        $this->bookingAvailability = BookingAvailability::Available();
+        $this->bookingAvailability = BookingAvailabilityType::Available();
     }
 
     public function withStatus(Status $status): Calendar
@@ -26,7 +26,7 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
         return $clone;
     }
 
-    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    public function withBookingAvailability(BookingAvailabilityType $bookingAvailability): Calendar
     {
         $clone = clone $this;
         $clone->bookingAvailability = $bookingAvailability;
@@ -43,7 +43,7 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailability
+    public function getBookingAvailability(): BookingAvailabilityType
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
+++ b/src/Model/ValueObject/Calendar/SingleSubEventCalendar.php
@@ -6,26 +6,30 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
-    /**
-     * @var SubEvent
-     */
-    private $subEvent;
+    private SubEvent $subEvent;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
+
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(SubEvent $subEvent)
     {
         $this->subEvent = $subEvent;
         $this->status = new Status(StatusType::Available());
+        $this->bookingAvailability = BookingAvailability::Available();
     }
 
     public function withStatus(Status $status): Calendar
     {
         $clone = clone $this;
         $clone->status = $status;
+        return $clone;
+    }
+
+    public function withBookingAvailability(BookingAvailability $bookingAvailability): Calendar
+    {
+        $clone = clone $this;
+        $clone->bookingAvailability = $bookingAvailability;
         return $clone;
     }
 
@@ -37,6 +41,11 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
     public function getStatus(): Status
     {
         return $this->status;
+    }
+
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
     }
 
     public function getStartDate(): \DateTimeImmutable

--- a/src/Model/ValueObject/Calendar/SubEvent.php
+++ b/src/Model/ValueObject/Calendar/SubEvent.php
@@ -10,9 +10,9 @@ final class SubEvent
 
     private Status $status;
 
-    private BookingAvailability $bookingAvailability;
+    private BookingAvailabilityType $bookingAvailability;
 
-    public function __construct(DateRange $dateRange, Status $status, BookingAvailability $bookingAvailability)
+    public function __construct(DateRange $dateRange, Status $status, BookingAvailabilityType $bookingAvailability)
     {
         $this->dateRange = $dateRange;
         $this->status = $status;
@@ -29,7 +29,7 @@ final class SubEvent
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailability
+    public function getBookingAvailability(): BookingAvailabilityType
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Calendar/SubEvent.php
+++ b/src/Model/ValueObject/Calendar/SubEvent.php
@@ -6,20 +6,17 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 final class SubEvent
 {
-    /**
-     * @var DateRange
-     */
-    private $dateRange;
+    private DateRange $dateRange;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
 
-    public function __construct(DateRange $dateRange, Status $status)
+    private BookingAvailability $bookingAvailability;
+
+    public function __construct(DateRange $dateRange, Status $status, BookingAvailability $bookingAvailability)
     {
         $this->dateRange = $dateRange;
         $this->status = $status;
+        $this->bookingAvailability = $bookingAvailability;
     }
 
     public function getDateRange(): DateRange
@@ -30,5 +27,10 @@ final class SubEvent
     public function getStatus(): Status
     {
         return $this->status;
+    }
+
+    public function getBookingAvailability(): BookingAvailability
+    {
+        return $this->bookingAvailability;
     }
 }

--- a/src/Model/ValueObject/Calendar/SubEvent.php
+++ b/src/Model/ValueObject/Calendar/SubEvent.php
@@ -10,9 +10,9 @@ final class SubEvent
 
     private Status $status;
 
-    private BookingAvailabilityType $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
-    public function __construct(DateRange $dateRange, Status $status, BookingAvailabilityType $bookingAvailability)
+    public function __construct(DateRange $dateRange, Status $status, BookingAvailability $bookingAvailability)
     {
         $this->dateRange = $dateRange;
         $this->status = $status;
@@ -29,7 +29,7 @@ final class SubEvent
         return $this->status;
     }
 
-    public function getBookingAvailability(): BookingAvailabilityType
+    public function getBookingAvailability(): BookingAvailability
     {
         return $this->bookingAvailability;
     }

--- a/src/Model/ValueObject/Moderation/AvailableTo.php
+++ b/src/Model/ValueObject/Moderation/AvailableTo.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithDateRange;
+use DateTimeInterface;
 
 class AvailableTo
 {
@@ -27,7 +28,7 @@ class AvailableTo
     public static function forever()
     {
         return \DateTimeImmutable::createFromFormat(
-            \DateTime::ATOM,
+            DateTimeInterface::ATOM,
             '2100-01-01T00:00:00+00:00'
         );
     }

--- a/src/Offer/AvailableTo.php
+++ b/src/Offer/AvailableTo.php
@@ -59,6 +59,6 @@ class AvailableTo
 
     public function __toString(): string
     {
-        return $this->availableTo->format(\DateTime::ATOM);
+        return $this->availableTo->format(DateTimeInterface::ATOM);
     }
 }

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Offer\Item\Events\Moderation\Published;
 use CultuurNet\UDB3\Offer\Item\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Offer\Item\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Offer\Item\Events\OrganizerUpdated;
+use DateTimeInterface;
 
 trait OfferHistoryProjectorTrait
 {
@@ -260,7 +261,7 @@ trait OfferHistoryProjectorTrait
     {
         /* @var Published $event */
         $event = $domainMessage->getPayload();
-        $date = $event->getPublicationDate()->format(\DateTime::ATOM);
+        $date = $event->getPublicationDate()->format(DateTimeInterface::ATOM);
 
         $this->writeHistory(
             $domainMessage->getId(),

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -55,6 +55,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocumentMetaDataEnricherInterface;
 use CultuurNet\UDB3\ReadModel\MultilingualJsonLDProjectorTrait;
 use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\SluggerInterface;
+use DateTimeInterface;
 use ValueObjects\Identity\UUID;
 
 abstract class OfferLDProjector implements OrganizerServiceInterface
@@ -823,7 +824,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
         $offerLd->workflowStatus = WorkflowStatus::READY_FOR_VALIDATION()->getName();
 
         $publicationDate = $published->getPublicationDate();
-        $offerLd->availableFrom = $publicationDate->format(\DateTime::ATOM);
+        $offerLd->availableFrom = $publicationDate->format(DateTimeInterface::ATOM);
 
         return $document->withBody($offerLd);
     }

--- a/src/Offer/ValueObjects/BookingAvailability.php
+++ b/src/Offer/ValueObjects/BookingAvailability.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
 use Broadway\Serializer\Serializable;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
 use InvalidArgumentException;
 
 final class BookingAvailability implements Serializable
@@ -74,6 +74,6 @@ final class BookingAvailability implements Serializable
     public static function fromUdb3ModelBookingAvailability(
         Udb3ModelBookingAvailability $udb3ModelBookingAvailability
     ): self {
-        return self::fromNative($udb3ModelBookingAvailability->toString());
+        return self::fromNative($udb3ModelBookingAvailability->getType()->toString());
     }
 }

--- a/src/Offer/ValueObjects/BookingAvailability.php
+++ b/src/Offer/ValueObjects/BookingAvailability.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
 use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
 use InvalidArgumentException;
 
 final class BookingAvailability implements Serializable
@@ -68,5 +69,11 @@ final class BookingAvailability implements Serializable
         return [
             'type' => $this->value,
         ];
+    }
+
+    public static function fromUdb3ModelBookingAvailability(
+        Udb3ModelBookingAvailability $udb3ModelBookingAvailability
+    ): self {
+        return self::fromNative($udb3ModelBookingAvailability->toString());
     }
 }

--- a/src/Offer/ValueObjects/BookingAvailability.php
+++ b/src/Offer/ValueObjects/BookingAvailability.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
 use Broadway\Serializer\Serializable;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
 use InvalidArgumentException;
 
 final class BookingAvailability implements Serializable

--- a/src/Place/Events/PlaceCreated.php
+++ b/src/Place/Events/PlaceCreated.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Place\PlaceEvent;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 
 final class PlaceCreated extends PlaceEvent
 {
@@ -117,7 +118,7 @@ final class PlaceCreated extends PlaceEvent
         }
         $publicationDate = null;
         if (!is_null($this->getPublicationDate())) {
-            $publicationDate = $this->getPublicationDate()->format(\DateTime::ATOM);
+            $publicationDate = $this->getPublicationDate()->format(DateTimeInterface::ATOM);
         }
         return parent::serialize() + [
             'main_language' => $this->mainLanguage->getCode(),
@@ -139,7 +140,7 @@ final class PlaceCreated extends PlaceEvent
         $publicationDate = null;
         if (!empty($data['publication_date'])) {
             $publicationDate = DateTimeImmutable::createFromFormat(
-                \DateTime::ATOM,
+                DateTimeInterface::ATOM,
                 $data['publication_date']
             );
         }

--- a/src/Timestamp.php
+++ b/src/Timestamp.php
@@ -97,8 +97,8 @@ final class Timestamp implements Serializable
             $bookingAvailability = BookingAvailability::deserialize($data['bookingAvailability']);
         }
 
-        $startDate = DateTime::createFromFormat(DateTime::ATOM, $data['startDate']);
-        $endDate = DateTime::createFromFormat(DateTime::ATOM, $data['endDate']);
+        $startDate = DateTime::createFromFormat(DateTimeInterface::ATOM, $data['startDate']);
+        $endDate = DateTime::createFromFormat(DateTimeInterface::ATOM, $data['endDate']);
 
         if ($startDate > $endDate) {
             $endDate = $startDate;
@@ -110,8 +110,8 @@ final class Timestamp implements Serializable
     public function serialize(): array
     {
         return [
-            'startDate' => $this->startDate->format(DateTime::ATOM),
-            'endDate' => $this->endDate->format(DateTime::ATOM),
+            'startDate' => $this->startDate->format(DateTimeInterface::ATOM),
+            'endDate' => $this->endDate->format(DateTimeInterface::ATOM),
             'status' => $this->status->serialize(),
             'bookingAvailability' => $this->bookingAvailability->serialize(),
         ];

--- a/src/Timestamp.php
+++ b/src/Timestamp.php
@@ -15,25 +15,13 @@ use InvalidArgumentException;
 
 final class Timestamp implements Serializable
 {
-    /**
-     * @var DateTimeInterface
-     */
-    private $startDate;
+    private DateTimeInterface $startDate;
 
-    /**
-     * @var DateTimeInterface
-     */
-    private $endDate;
+    private DateTimeInterface $endDate;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private Status $status;
 
-    /**
-     * @var BookingAvailability
-     */
-    private $bookingAvailability;
+    private BookingAvailability $bookingAvailability;
 
     public function __construct(
         DateTimeInterface $startDate,
@@ -130,7 +118,8 @@ final class Timestamp implements Serializable
         return new Timestamp(
             $subEvent->getDateRange()->getFrom(),
             $subEvent->getDateRange()->getTo(),
-            Status::fromUdb3ModelStatus($subEvent->getStatus())
+            Status::fromUdb3ModelStatus($subEvent->getStatus()),
+            BookingAvailability::fromUdb3ModelBookingAvailability($subEvent->getBookingAvailability())
         );
     }
 }

--- a/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
+++ b/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
+use DateTimeInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
 trait HasAuthoringMetadataTrait
@@ -50,7 +51,7 @@ trait HasAuthoringMetadataTrait
     public function serialize()
     {
         return [
-            'time' => $this->getTime()->format(\DateTime::ISO8601),
+            'time' => $this->getTime()->format(DateTimeInterface::ISO8601),
             'author' => (string) $this->getAuthor(),
         ];
     }

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -46,7 +46,7 @@ class CalendarTest extends TestCase
     public const TIMESTAMP_2 = '1457859600';
     public const TIMESTAMP_2_START_DATE = '2016-03-13T10:00:00+01:00';
     public const TIMESTAMP_2_END_DATE = '2016-03-13T12:00:00+01:00';
-    
+
     private Calendar $calendar;
 
     public function setUp(): void

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -11,7 +11,8 @@ use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Day;
@@ -1483,12 +1484,12 @@ class CalendarTest extends TestCase
                 \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
             ),
             new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
-            Udb3ModelBookingAvailability::Unavailable()
+            new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
         );
 
         $udb3ModelCalendar = (new SingleSubEventCalendar($subEvent))
             ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
-            ->withBookingAvailability(Udb3ModelBookingAvailability::Unavailable());
+            ->withBookingAvailability(new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable()));
 
         $expected = (new Calendar(
             CalendarType::SINGLE(),
@@ -1523,7 +1524,7 @@ class CalendarTest extends TestCase
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
                 ),
                 new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
-                Udb3ModelBookingAvailability::Unavailable()
+                new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
             ),
             new SubEvent(
                 new DateRange(
@@ -1531,13 +1532,13 @@ class CalendarTest extends TestCase
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00')
                 ),
                 new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
-                Udb3ModelBookingAvailability::Unavailable()
+                new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
             )
         );
 
         $udb3ModelCalendar = (new MultipleSubEventsCalendar($subEvents))
             ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
-            ->withBookingAvailability(Udb3ModelBookingAvailability::Unavailable());
+            ->withBookingAvailability(new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable()));
 
         $expected = (new Calendar(
             CalendarType::MULTIPLE(),

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Day;
@@ -1484,23 +1485,29 @@ class CalendarTest extends TestCase
                 \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
                 \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
             ),
-            new Udb3ModelStatus(Udb3ModelStatusType::Available())
+            new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+            Udb3ModelBookingAvailability::Unavailable()
         );
 
-        $udb3ModelCalendar = new SingleSubEventCalendar($subEvent);
+        $udb3ModelCalendar = (new SingleSubEventCalendar($subEvent))
+            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
+            ->withBookingAvailability(Udb3ModelBookingAvailability::Unavailable());
 
-        $expected = new Calendar(
+        $expected = (new Calendar(
             CalendarType::SINGLE(),
             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
             [
                 new Timestamp(
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+                    new Status(StatusType::unavailable(), []),
+                    BookingAvailability::unavailable()
                 ),
             ],
             []
-        );
+        ))->withStatus(new Status(StatusType::unavailable(), []))
+            ->withBookingAvailability(BookingAvailability::unavailable());
 
         $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
 
@@ -1518,35 +1525,44 @@ class CalendarTest extends TestCase
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
                 ),
-                new Udb3ModelStatus(Udb3ModelStatusType::Available())
+                new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+                Udb3ModelBookingAvailability::Unavailable()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-09T10:00:00+01:00'),
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00')
                 ),
-                new Udb3ModelStatus(Udb3ModelStatusType::Available())
+                new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()),
+                Udb3ModelBookingAvailability::Unavailable()
             )
         );
 
-        $udb3ModelCalendar = new MultipleSubEventsCalendar($subEvents);
+        $udb3ModelCalendar = (new MultipleSubEventsCalendar($subEvents))
+            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::Unavailable()))
+            ->withBookingAvailability(Udb3ModelBookingAvailability::Unavailable());
 
-        $expected = new Calendar(
+        $expected = (new Calendar(
             CalendarType::MULTIPLE(),
             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00'),
             [
                 new Timestamp(
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-06T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00')
+                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-07T10:00:00+01:00'),
+                    new Status(StatusType::unavailable(), []),
+                    BookingAvailability::unavailable()
                 ),
                 new Timestamp(
                     \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-09T10:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00')
+                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2016-03-10T10:00:00+01:00'),
+                    new Status(StatusType::unavailable(), []),
+                    BookingAvailability::unavailable()
                 ),
             ],
             []
-        );
+        ))->withStatus(new Status(StatusType::unavailable(), []))
+            ->withBookingAvailability(BookingAvailability::unavailable());
 
         $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
 
@@ -1732,22 +1748,6 @@ class CalendarTest extends TestCase
                 ),
             ]
         );
-
-        $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * @test
-     */
-    public function it_takes_into_account_udb3_model_calendar_status(): void
-    {
-        $udb3ModelCalendar = (new PermanentCalendar(new OpeningHours()))
-            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::TemporarilyUnavailable()));
-
-        $expected = (new Calendar(CalendarType::PERMANENT()))
-            ->withStatus(new Status(StatusType::temporarilyUnavailable(), []));
 
         $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
 

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Calendar\OpeningTime;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Day;

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -46,11 +46,8 @@ class CalendarTest extends TestCase
     public const TIMESTAMP_2 = '1457859600';
     public const TIMESTAMP_2_START_DATE = '2016-03-13T10:00:00+01:00';
     public const TIMESTAMP_2_END_DATE = '2016-03-13T12:00:00+01:00';
-
-    /**
-     * @var Calendar
-     */
-    private $calendar;
+    
+    private Calendar $calendar;
 
     public function setUp(): void
     {

--- a/tests/Model/Event/ImmutableEventTest.php
+++ b/tests/Model/Event/ImmutableEventTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Event;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
 use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
@@ -145,7 +145,7 @@ class ImmutableEventTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
     }

--- a/tests/Model/Event/ImmutableEventTest.php
+++ b/tests/Model/Event/ImmutableEventTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Event;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
 use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -145,7 +146,7 @@ class ImmutableEventTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
     }

--- a/tests/Model/Event/ImmutableEventTest.php
+++ b/tests/Model/Event/ImmutableEventTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Event;
 use CultuurNet\UDB3\Model\Place\ImmutablePlace;
 use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
@@ -143,7 +144,8 @@ class ImmutableEventTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
     }

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Offer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -597,7 +598,8 @@ class ImmutableOfferTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
     }

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Offer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -599,7 +600,7 @@ class ImmutableOfferTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
     }

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Offer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -599,7 +599,7 @@ class ImmutableOfferTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
     }

--- a/tests/Model/Place/ImmutablePlaceTest.php
+++ b/tests/Model/Place/ImmutablePlaceTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Place;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithOpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -69,7 +70,7 @@ class ImmutablePlaceTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
 

--- a/tests/Model/Place/ImmutablePlaceTest.php
+++ b/tests/Model/Place/ImmutablePlaceTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Place;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithOpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -69,7 +69,7 @@ class ImmutablePlaceTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
 

--- a/tests/Model/Place/ImmutablePlaceTest.php
+++ b/tests/Model/Place/ImmutablePlaceTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Model\Place;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithOpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -67,7 +68,8 @@ class ImmutablePlaceTest extends TestCase
                     \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
@@ -342,7 +343,7 @@ class EventDenormalizerTest extends TestCase
                     new Status(
                         StatusType::Available()
                     ),
-                    BookingAvailabilityType::Available()
+                    new BookingAvailability(BookingAvailabilityType::Available())
                 ),
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -419,7 +420,7 @@ class EventDenormalizerTest extends TestCase
                         ))
                             ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                     ),
-                    BookingAvailabilityType::Available()
+                    new BookingAvailability(BookingAvailabilityType::Available())
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -477,7 +478,7 @@ class EventDenormalizerTest extends TestCase
                     new Status(
                         StatusType::Available()
                     ),
-                    BookingAvailabilityType::Available()
+                    new BookingAvailability(BookingAvailabilityType::Available())
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -553,7 +554,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -563,7 +564,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -573,7 +574,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     )
                 )
             ),
@@ -679,7 +680,7 @@ class EventDenormalizerTest extends TestCase
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -689,7 +690,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -699,7 +700,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::TemporarilyUnavailable()
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -717,7 +718,7 @@ class EventDenormalizerTest extends TestCase
                                     new StatusReason('Franse reden zonder status type')
                                 )
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     )
                 )
             ),
@@ -793,7 +794,7 @@ class EventDenormalizerTest extends TestCase
                             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
-                        BookingAvailabilityType::Unavailable()
+                        new BookingAvailability(BookingAvailabilityType::Unavailable())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -801,7 +802,7 @@ class EventDenormalizerTest extends TestCase
                             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
-                        BookingAvailabilityType::Unavailable()
+                        new BookingAvailability(BookingAvailabilityType::Unavailable())
                     )
                 )
             ),
@@ -871,7 +872,7 @@ class EventDenormalizerTest extends TestCase
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                     ),
-                    BookingAvailabilityType::Available()
+                    new BookingAvailability(BookingAvailabilityType::Available())
                 )
             ))->withStatus(
                 new Status(
@@ -955,7 +956,7 @@ class EventDenormalizerTest extends TestCase
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                     ),
-                    BookingAvailabilityType::Available()
+                    new BookingAvailability(BookingAvailabilityType::Available())
                 )
             ))->withStatus(
                 new Status(
@@ -1053,7 +1054,7 @@ class EventDenormalizerTest extends TestCase
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     ),
                     new SubEvent(
                         new DateRange(
@@ -1067,7 +1068,7 @@ class EventDenormalizerTest extends TestCase
                                 new StatusReason('Nederlands')
                             ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                         ),
-                        BookingAvailabilityType::Available()
+                        new BookingAvailability(BookingAvailabilityType::Available())
                     )
                 )
             ))->withStatus(

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -737,6 +737,90 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_can_denormalize_booking_availability(): void
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'calendarType' => 'multiple',
+            'startDate' => '2018-01-01T13:00:00+01:00',
+            'endDate' => '2018-01-10T17:00:00+01:00',
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-01-01T13:00:00+01:00',
+                    'endDate' => '2018-01-01T17:00:00+01:00',
+                    'bookingAvailability' => [
+                        'type' => 'Unavailable',
+                    ],
+                ],
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-01-03T13:00:00+01:00',
+                    'endDate' => '2018-01-03T17:00:00+01:00',
+                    'bookingAvailability' => [
+                        'type' => 'Unavailable',
+                    ],
+                ],
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ],
+            ],
+        ];
+
+        $expected = new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            new MultipleSubEventsCalendar(
+                new SubEvents(
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
+                        new Status(StatusType::Available()),
+                        BookingAvailability::Unavailable()
+                    ),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
+                        new Status(StatusType::Available()),
+                        BookingAvailability::Unavailable()
+                    )
+                )
+            ),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_denormalize_event_data_with_single_date_range_and_apply_status_to_sub_event_with_no_status()
     {
         $eventData = [

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
@@ -29,7 +30,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\PeriodicCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
-use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability as ContactBookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
@@ -340,8 +341,9 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new Status(
                         StatusType::Available()
-                    )
-                )
+                    ),
+                    BookingAvailability::Available()
+                ),
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
             new Categories(
@@ -416,7 +418,8 @@ class EventDenormalizerTest extends TestCase
                             new StatusReason('Nederlandse reden')
                         ))
                             ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
-                    )
+                    ),
+                    BookingAvailability::Available()
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -473,7 +476,8 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new Status(
                         StatusType::Available()
-                    )
+                    ),
+                    BookingAvailability::Available()
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -548,7 +552,8 @@ class EventDenormalizerTest extends TestCase
                         ),
                         new Status(
                             StatusType::Available()
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -557,7 +562,8 @@ class EventDenormalizerTest extends TestCase
                         ),
                         new Status(
                             StatusType::Available()
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -566,7 +572,8 @@ class EventDenormalizerTest extends TestCase
                         ),
                         new Status(
                             StatusType::Available()
-                        )
+                        ),
+                        BookingAvailability::Available()
                     )
                 )
             ),
@@ -671,7 +678,8 @@ class EventDenormalizerTest extends TestCase
                                 new StatusReason('Nederlandse reden')
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -680,7 +688,8 @@ class EventDenormalizerTest extends TestCase
                         ),
                         new Status(
                             StatusType::Available()
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -689,7 +698,8 @@ class EventDenormalizerTest extends TestCase
                         ),
                         new Status(
                             StatusType::TemporarilyUnavailable()
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -706,7 +716,8 @@ class EventDenormalizerTest extends TestCase
                                     new Language('fr'),
                                     new StatusReason('Franse reden zonder status type')
                                 )
-                        )
+                        ),
+                        BookingAvailability::Available()
                     )
                 )
             ),
@@ -775,7 +786,8 @@ class EventDenormalizerTest extends TestCase
                             new Language('nl'),
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
-                    )
+                    ),
+                    BookingAvailability::Available()
                 )
             ))->withStatus(
                 new Status(
@@ -858,7 +870,8 @@ class EventDenormalizerTest extends TestCase
                             new Language('nl'),
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
-                    )
+                    ),
+                    BookingAvailability::Available()
                 )
             ))->withStatus(
                 new Status(
@@ -955,7 +968,8 @@ class EventDenormalizerTest extends TestCase
                                 new StatusReason('Nederlandse reden')
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
-                        )
+                        ),
+                        BookingAvailability::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -968,7 +982,8 @@ class EventDenormalizerTest extends TestCase
                                 new Language('nl'),
                                 new StatusReason('Nederlands')
                             ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
-                        )
+                        ),
+                        BookingAvailability::Available()
                     )
                 )
             ))->withStatus(
@@ -1502,7 +1517,7 @@ class EventDenormalizerTest extends TestCase
                     ),
                     new TelephoneNumber('02 551 18 70'),
                     new EmailAddress('info@publiq.be'),
-                    new BookingAvailability(
+                    new ContactBookingAvailability(
                         \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T00:00:00+01:00'),
                         \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-10-01T00:00:00+01:00')
                     )

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
@@ -342,7 +342,7 @@ class EventDenormalizerTest extends TestCase
                     new Status(
                         StatusType::Available()
                     ),
-                    BookingAvailability::Available()
+                    BookingAvailabilityType::Available()
                 ),
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -419,7 +419,7 @@ class EventDenormalizerTest extends TestCase
                         ))
                             ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                     ),
-                    BookingAvailability::Available()
+                    BookingAvailabilityType::Available()
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -477,7 +477,7 @@ class EventDenormalizerTest extends TestCase
                     new Status(
                         StatusType::Available()
                     ),
-                    BookingAvailability::Available()
+                    BookingAvailabilityType::Available()
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -553,7 +553,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -563,7 +563,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -573,7 +573,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     )
                 )
             ),
@@ -679,7 +679,7 @@ class EventDenormalizerTest extends TestCase
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -689,7 +689,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -699,7 +699,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::TemporarilyUnavailable()
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -717,7 +717,7 @@ class EventDenormalizerTest extends TestCase
                                     new StatusReason('Franse reden zonder status type')
                                 )
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     )
                 )
             ),
@@ -793,7 +793,7 @@ class EventDenormalizerTest extends TestCase
                             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
-                        BookingAvailability::Unavailable()
+                        BookingAvailabilityType::Unavailable()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -801,7 +801,7 @@ class EventDenormalizerTest extends TestCase
                             \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
                         ),
                         new Status(StatusType::Available()),
-                        BookingAvailability::Unavailable()
+                        BookingAvailabilityType::Unavailable()
                     )
                 )
             ),
@@ -871,7 +871,7 @@ class EventDenormalizerTest extends TestCase
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                     ),
-                    BookingAvailability::Available()
+                    BookingAvailabilityType::Available()
                 )
             ))->withStatus(
                 new Status(
@@ -955,7 +955,7 @@ class EventDenormalizerTest extends TestCase
                             new StatusReason('Nederlands')
                         ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                     ),
-                    BookingAvailability::Available()
+                    BookingAvailabilityType::Available()
                 )
             ))->withStatus(
                 new Status(
@@ -1053,7 +1053,7 @@ class EventDenormalizerTest extends TestCase
                             ))
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     ),
                     new SubEvent(
                         new DateRange(
@@ -1067,7 +1067,7 @@ class EventDenormalizerTest extends TestCase
                                 new StatusReason('Nederlands')
                             ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
                         ),
-                        BookingAvailability::Available()
+                        BookingAvailabilityType::Available()
                     )
                 )
             ))->withStatus(

--- a/tests/Model/Validation/Event/EventValidatorTest.php
+++ b/tests/Model/Validation/Event/EventValidatorTest.php
@@ -2067,6 +2067,152 @@ class EventValidatorTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_on_invalid_top_level_booking_availability_structure(): void
+    {
+        $event = [
+            '@id' => 'https://io.uitdatabank.be/events/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Example name',
+            ],
+            'bookingAvailability' => 'should not be a string',
+            'calendarType' => 'permanent',
+            'location' => [
+                '@id' => 'http://io.uitdatabank.be/place/9a344f43-1174-4149-ad9a-3e2e92565e35',
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.0',
+                ],
+            ],
+        ];
+
+        $expectedErrors = [
+            'bookingAvailability must be of the type array',
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_invalid_top_level_booking_availability_type(): void
+    {
+        $event = [
+            '@id' => 'https://io.uitdatabank.be/events/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Example name',
+            ],
+            'bookingAvailability' => [
+                'type' => 'Wrong type',
+            ],
+            'calendarType' => 'permanent',
+            'location' => [
+                '@id' => 'http://io.uitdatabank.be/place/9a344f43-1174-4149-ad9a-3e2e92565e35',
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.0',
+                ],
+            ],
+        ];
+
+        $expectedErrors = [
+            'At least one of these rules must pass for type',
+            'type must be equal to "Available"',
+            'type must be equal to "Unavailable"',
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throws_on_invalid_booking_availability_structure_on_sub_events(): void
+    {
+        $event = [
+            '@id' => 'https://io.uitdatabank.be/events/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Example name',
+            ],
+            'calendarType' => 'single',
+            'startDate' => '2018-02-28T13:44:09+01:00',
+            'endDate' => '2018-03-05T13:44:09+01:00',
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-02-28T13:44:09+01:00',
+                    'endDate' => '2018-03-01T13:44:09+01:00',
+                    'bookingAvailability' => 'Can not be a string',
+                ],
+            ],
+            'location' => [
+                '@id' => 'http://io.uitdatabank.be/place/9a344f43-1174-4149-ad9a-3e2e92565e35',
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.0',
+                ],
+            ],
+        ];
+
+        $expectedErrors = [
+            'bookingAvailability must be of the type array',
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throws_on_invalid_booking_availability_type_value_on_sub_events(): void
+    {
+        $event = [
+            '@id' => 'https://io.uitdatabank.be/events/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Example name',
+            ],
+            'calendarType' => 'single',
+            'startDate' => '2018-02-28T13:44:09+01:00',
+            'endDate' => '2018-03-05T13:44:09+01:00',
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-02-28T13:44:09+01:00',
+                    'endDate' => '2018-03-01T13:44:09+01:00',
+                    'bookingAvailability' => [
+                        'type' => 'Unsupported',
+                    ],
+                ],
+            ],
+            'location' => [
+                '@id' => 'http://io.uitdatabank.be/place/9a344f43-1174-4149-ad9a-3e2e92565e35',
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.0',
+                ],
+            ],
+        ];
+
+        $expectedErrors = [
+            'At least one of these rules must pass for type',
+            'type must be equal to "Available"',
+            'type must be equal to "Unavailable"',
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_an_exception_if_organizer_id_is_in_an_invalid_format()
     {
         $event = [

--- a/tests/Model/Validation/Place/PlaceValidatorTest.php
+++ b/tests/Model/Validation/Place/PlaceValidatorTest.php
@@ -1578,6 +1578,44 @@ class PlaceValidatorTest extends TestCase
     /**
      * @test
      */
+    public function it_should_throw_if_booking_availability_is_invalid(): void
+    {
+        $place = [
+            '@id' => 'http://io.uitdatabank.be/place/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Test place',
+            ],
+            'bookingAvailability' => 'should not be a string',
+            'calendarType' => 'permanent',
+            'location' => [
+                '@id' => 'http://io.uitdatabank.be/place/9a344f43-1174-4149-ad9a-3e2e92565e35',
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.0',
+                ],
+            ],
+            'address' => [
+                'nl' => [
+                    'streetAddress' => 'Henegouwenkaai 41-43',
+                    'postalCode' => '1080',
+                    'addressLocality' => 'Brussel',
+                    'addressCountry' => 'BE',
+                ],
+            ],
+        ];
+
+        $expectedErrors = [
+            'bookingAvailability must be of the type array',
+        ];
+
+        $this->assertValidationErrors($place, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_an_exception_if_organizer_id_is_in_an_invalid_format()
     {
         $place = [

--- a/tests/Model/ValueObject/Calendar/BookingAvailabilityTest.php
+++ b/tests/Model/ValueObject/Calendar/BookingAvailabilityTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
+
+use PHPUnit\Framework\TestCase;
+
+final class BookingAvailabilityTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_supports_exactly_two_availabilities(): void
+    {
+        $availableBooking = BookingAvailability::Available();
+        $unavailableBooking = BookingAvailability::Unavailable();
+
+        $this->assertEquals('Available', $availableBooking->toString());
+        $this->assertEquals('Unavailable', $unavailableBooking->toString());
+    }
+}

--- a/tests/Model/ValueObject/Calendar/BookingAvailabilityTest.php
+++ b/tests/Model/ValueObject/Calendar/BookingAvailabilityTest.php
@@ -13,8 +13,8 @@ final class BookingAvailabilityTest extends TestCase
      */
     public function it_supports_exactly_two_availabilities(): void
     {
-        $availableBooking = BookingAvailability::Available();
-        $unavailableBooking = BookingAvailability::Unavailable();
+        $availableBooking = BookingAvailabilityType::Available();
+        $unavailableBooking = BookingAvailabilityType::Unavailable();
 
         $this->assertEquals('Available', $availableBooking->toString());
         $this->assertEquals('Unavailable', $unavailableBooking->toString());

--- a/tests/Model/ValueObject/Calendar/BookingAvailabilityTypeTest.php
+++ b/tests/Model/ValueObject/Calendar/BookingAvailabilityTypeTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 use PHPUnit\Framework\TestCase;
 
-final class BookingAvailabilityTest extends TestCase
+final class BookingAvailabilityTypeTest extends TestCase
 {
     /**
      * @test

--- a/tests/Model/ValueObject/Calendar/DateRangesTest.php
+++ b/tests/Model/ValueObject/Calendar/DateRangesTest.php
@@ -56,7 +56,7 @@ class DateRangesTest extends TestCase
                     DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             );
         };
 

--- a/tests/Model/ValueObject/Calendar/DateRangesTest.php
+++ b/tests/Model/ValueObject/Calendar/DateRangesTest.php
@@ -56,7 +56,7 @@ class DateRangesTest extends TestCase
                     DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             );
         };
 

--- a/tests/Model/ValueObject/Calendar/DateRangesTest.php
+++ b/tests/Model/ValueObject/Calendar/DateRangesTest.php
@@ -55,7 +55,8 @@ class DateRangesTest extends TestCase
                     DateTimeImmutable::createFromFormat(DATE_ATOM, $from),
                     DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             );
         };
 

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -4,10 +4,39 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class MultipleSubEventsCalendarTest extends TestCase
 {
+    private SubEvents $subEvents;
+
+    private MultipleSubEventsCalendar $multipleSubEventsCalendar;
+
+    protected function setUp(): void
+    {
+        $this->subEvents = new SubEvents(
+            new SubEvent(
+                new DateRange(
+                    DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+                    DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+                ),
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
+            ),
+            new SubEvent(
+                new DateRange(
+                    DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
+                    DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
+                ),
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
+            )
+        );
+
+        $this->multipleSubEventsCalendar = new MultipleSubEventsCalendar($this->subEvents);
+    }
+
     /**
      * @test
      */
@@ -34,32 +63,14 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_should_return_a_start_and_end_date(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-
-        $dateRanges = new SubEvents(
-            new SubEvent(
-                new DateRange(
-                    $startDate,
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            ),
-            new SubEvent(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                    $endDate
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            )
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+            $this->multipleSubEventsCalendar->getStartDate()
         );
-
-        $calendar = new MultipleSubEventsCalendar($dateRanges);
-
-        $this->assertEquals($startDate, $calendar->getStartDate());
-        $this->assertEquals($endDate, $calendar->getEndDate());
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018'),
+            $this->multipleSubEventsCalendar->getEndDate()
+        );
     }
 
     /**
@@ -67,31 +78,7 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_should_return_multiple_sub_events(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-
-        $dateRanges = new SubEvents(
-            new SubEvent(
-                new DateRange(
-                    $startDate,
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            ),
-            new SubEvent(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                    $endDate
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            )
-        );
-
-        $calendar = new MultipleSubEventsCalendar($dateRanges);
-
-        $this->assertEquals($dateRanges, $calendar->getSubEvents());
+        $this->assertEquals($this->subEvents, $this->multipleSubEventsCalendar->getSubEvents());
     }
 
     /**
@@ -99,31 +86,7 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_should_return_a_calendar_type(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-
-        $dateRanges = new SubEvents(
-            new SubEvent(
-                new DateRange(
-                    $startDate,
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            ),
-            new SubEvent(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                    $endDate
-                ),
-                new Status(StatusType::Available()),
-                BookingAvailability::Available()
-            )
-        );
-
-        $calendar = new MultipleSubEventsCalendar($dateRanges);
-
-        $this->assertEquals(CalendarType::multiple(), $calendar->getType());
+        $this->assertEquals(CalendarType::multiple(), $this->multipleSubEventsCalendar->getType());
     }
 
     /**
@@ -131,31 +94,7 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_should_return_a_default_available_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-
-        $dateRanges = new SubEvents(
-            new SubEvent(
-                new DateRange(
-                    $startDate,
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
-                ),
-                new Status(StatusType::Unavailable()),
-                BookingAvailability::Available()
-            ),
-            new SubEvent(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                    $endDate
-                ),
-                new Status(StatusType::TemporarilyUnavailable()),
-                BookingAvailability::Available()
-            )
-        );
-
-        $calendar = new MultipleSubEventsCalendar($dateRanges);
-
-        $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
+        $this->assertEquals(new Status(StatusType::Available()), $this->multipleSubEventsCalendar->getStatus());
     }
 
     /**
@@ -163,31 +102,7 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-
-        $dateRanges = new SubEvents(
-            new SubEvent(
-                new DateRange(
-                    $startDate,
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
-                ),
-                new Status(StatusType::Unavailable()),
-                BookingAvailability::Available()
-            ),
-            new SubEvent(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                    $endDate
-                ),
-                new Status(StatusType::TemporarilyUnavailable()),
-                BookingAvailability::Available()
-            )
-        );
-
-        $calendar = new MultipleSubEventsCalendar($dateRanges);
-
-        $calendar = $calendar->withStatus(new Status(StatusType::Available()));
+        $calendar = $this->multipleSubEventsCalendar->withStatus(new Status(StatusType::Available()));
 
         $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
     }

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -100,10 +100,31 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
+    public function it_has_a_default_booking_availability(): void
+    {
+        $this->assertEquals(
+            BookingAvailability::Available(),
+            $this->multipleSubEventsCalendar->getBookingAvailability()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_allows_setting_an_explicit_status(): void
     {
         $calendar = $this->multipleSubEventsCalendar->withStatus(new Status(StatusType::Available()));
 
         $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_setting_an_explicit_booking_availability(): void
+    {
+        $calendar = $this->multipleSubEventsCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+
+        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
     }
 }

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -22,7 +22,7 @@ class MultipleSubEventsCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             ),
             new SubEvent(
                 new DateRange(
@@ -30,7 +30,7 @@ class MultipleSubEventsCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
 
@@ -48,7 +48,7 @@ class MultipleSubEventsCalendarTest extends TestCase
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
 
@@ -103,7 +103,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     public function it_has_a_default_booking_availability(): void
     {
         $this->assertEquals(
-            BookingAvailabilityType::Available(),
+            new BookingAvailability(BookingAvailabilityType::Available()),
             $this->multipleSubEventsCalendar->getBookingAvailability()
         );
     }
@@ -123,8 +123,13 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->multipleSubEventsCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
+        $calendar = $this->multipleSubEventsCalendar->withBookingAvailability(
+            new BookingAvailability(BookingAvailabilityType::Unavailable())
+        );
 
-        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Unavailable()),
+            $calendar->getBookingAvailability()
+        );
     }
 }

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -16,7 +16,11 @@ class MultipleSubEventsCalendarTest extends TestCase
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018');
         $dateRanges = new SubEvents(
-            new SubEvent(new DateRange($startDate, $endDate), new Status(StatusType::Available()))
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
+            )
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -39,14 +43,16 @@ class MultipleSubEventsCalendarTest extends TestCase
                     $startDate,
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
                     $endDate
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 
@@ -70,14 +76,16 @@ class MultipleSubEventsCalendarTest extends TestCase
                     $startDate,
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
                     $endDate
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 
@@ -100,14 +108,16 @@ class MultipleSubEventsCalendarTest extends TestCase
                     $startDate,
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
                     $endDate
                 ),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 
@@ -130,14 +140,16 @@ class MultipleSubEventsCalendarTest extends TestCase
                     $startDate,
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
-                new Status(StatusType::Unavailable())
+                new Status(StatusType::Unavailable()),
+                BookingAvailability::Available()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
                     $endDate
                 ),
-                new Status(StatusType::TemporarilyUnavailable())
+                new Status(StatusType::TemporarilyUnavailable()),
+                BookingAvailability::Available()
             )
         );
 
@@ -160,14 +172,16 @@ class MultipleSubEventsCalendarTest extends TestCase
                     $startDate,
                     \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
-                new Status(StatusType::Unavailable())
+                new Status(StatusType::Unavailable()),
+                BookingAvailability::Available()
             ),
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
                     $endDate
                 ),
-                new Status(StatusType::TemporarilyUnavailable())
+                new Status(StatusType::TemporarilyUnavailable()),
+                BookingAvailability::Available()
             )
         );
 

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -11,7 +11,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_require_at_least_two_sub_events()
+    public function it_should_require_at_least_two_sub_events(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018');
@@ -32,7 +32,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_start_and_end_date()
+    public function it_should_return_a_start_and_end_date(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -65,7 +65,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_multiple_sub_events()
+    public function it_should_return_multiple_sub_events(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -97,7 +97,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_calendar_type()
+    public function it_should_return_a_calendar_type(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -129,7 +129,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_default_available_status()
+    public function it_should_return_a_default_available_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -161,7 +161,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_allows_setting_an_explicit_status()
+    public function it_allows_setting_an_explicit_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');

--- a/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -22,7 +22,7 @@ class MultipleSubEventsCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             ),
             new SubEvent(
                 new DateRange(
@@ -30,7 +30,7 @@ class MultipleSubEventsCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
 
@@ -48,7 +48,7 @@ class MultipleSubEventsCalendarTest extends TestCase
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
 
@@ -103,7 +103,7 @@ class MultipleSubEventsCalendarTest extends TestCase
     public function it_has_a_default_booking_availability(): void
     {
         $this->assertEquals(
-            BookingAvailability::Available(),
+            BookingAvailabilityType::Available(),
             $this->multipleSubEventsCalendar->getBookingAvailability()
         );
     }
@@ -123,8 +123,8 @@ class MultipleSubEventsCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->multipleSubEventsCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+        $calendar = $this->multipleSubEventsCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
 
-        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
     }
 }

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -90,7 +90,7 @@ class PeriodicCalendarTest extends TestCase
                     new Hour(9),
                     new Minute(0)
                 ),
-                $closingTime = new Time(
+                new Time(
                     new Hour(12),
                     new Minute(0)
                 )
@@ -101,7 +101,7 @@ class PeriodicCalendarTest extends TestCase
                     new Hour(13),
                     new Minute(0)
                 ),
-                $closingTime = new Time(
+                new Time(
                     new Hour(17),
                     new Minute(0)
                 )

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -16,17 +16,25 @@ use PHPUnit\Framework\TestCase;
 
 class PeriodicCalendarTest extends TestCase
 {
+    private PeriodicCalendar $periodicCalendar;
+
+    protected function setUp(): void
+    {
+        $this->periodicCalendar = new PeriodicCalendar(
+            new DateRange(
+                DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+                DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
+            ),
+            new OpeningHours()
+        );
+    }
+
     /**
      * @test
      */
     public function it_should_return_a_calendar_type(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $openingHours = new OpeningHours();
-        $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
-
-        $this->assertEquals(CalendarType::periodic(), $calendar->getType());
+        $this->assertEquals(CalendarType::periodic(), $this->periodicCalendar->getType());
     }
 
     /**
@@ -34,12 +42,7 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_a_default_available_status(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $openingHours = new OpeningHours();
-        $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
-
-        $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
+        $this->assertEquals(new Status(StatusType::Available()), $this->periodicCalendar->getStatus());
     }
 
     /**
@@ -47,11 +50,7 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_status(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $openingHours = new OpeningHours();
-        $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
-        $calendar = $calendar->withStatus(new Status(StatusType::Unavailable()));
+        $calendar = $this->periodicCalendar->withStatus(new Status(StatusType::Unavailable()));
 
         $this->assertEquals(new Status(StatusType::Unavailable()), $calendar->getStatus());
     }
@@ -61,13 +60,14 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_the_injected_start_and_end_date(): void
     {
-        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $openingHours = new OpeningHours();
-        $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
-
-        $this->assertEquals($startDate, $calendar->getStartDate());
-        $this->assertEquals($endDate, $calendar->getEndDate());
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+            $this->periodicCalendar->getStartDate()
+        );
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018'),
+            $this->periodicCalendar->getEndDate()
+        );
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class PeriodicCalendarTest extends TestCase
@@ -20,8 +21,8 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_a_calendar_type(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
+        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
+        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
         $openingHours = new OpeningHours();
         $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
 
@@ -33,8 +34,8 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_a_default_available_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
+        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
+        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
         $openingHours = new OpeningHours();
         $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
 
@@ -46,8 +47,8 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
+        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
+        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
         $openingHours = new OpeningHours();
         $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
         $calendar = $calendar->withStatus(new Status(StatusType::Unavailable()));
@@ -60,8 +61,8 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_the_injected_start_and_end_date(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
+        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
+        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
         $openingHours = new OpeningHours();
         $calendar = new PeriodicCalendar(new DateRange($startDate, $endDate), $openingHours);
 
@@ -74,8 +75,8 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_should_return_the_injected_opening_hours(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
+        $startDate = DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
+        $endDate = DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
 
         $days = new Days(
             Day::monday(),

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -18,7 +18,7 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_calendar_type()
+    public function it_should_return_a_calendar_type(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -31,7 +31,7 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_default_available_status()
+    public function it_should_return_a_default_available_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -44,7 +44,7 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_allows_setting_an_explicit_status()
+    public function it_allows_setting_an_explicit_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -58,7 +58,7 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_the_injected_start_and_end_date()
+    public function it_should_return_the_injected_start_and_end_date(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -72,7 +72,7 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_the_injected_opening_hours()
+    public function it_should_return_the_injected_opening_hours(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -48,11 +48,29 @@ class PeriodicCalendarTest extends TestCase
     /**
      * @test
      */
+    public function it_has_a_default_booking_availability(): void
+    {
+        $this->assertEquals(BookingAvailability::Available(), $this->periodicCalendar->getBookingAvailability());
+    }
+
+    /**
+     * @test
+     */
     public function it_allows_setting_an_explicit_status(): void
     {
         $calendar = $this->periodicCalendar->withStatus(new Status(StatusType::Unavailable()));
 
         $this->assertEquals(new Status(StatusType::Unavailable()), $calendar->getStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_setting_an_explicit_booking_availability(): void
+    {
+        $calendar = $this->periodicCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+
+        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -50,7 +50,10 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_has_a_default_booking_availability(): void
     {
-        $this->assertEquals(BookingAvailabilityType::Available(), $this->periodicCalendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Available()),
+            $this->periodicCalendar->getBookingAvailability()
+        );
     }
 
     /**
@@ -68,9 +71,14 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->periodicCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
+        $calendar = $this->periodicCalendar->withBookingAvailability(
+            new BookingAvailability(BookingAvailabilityType::Unavailable())
+        );
 
-        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Unavailable()),
+            $calendar->getBookingAvailability()
+        );
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PeriodicCalendarTest.php
@@ -50,7 +50,7 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_has_a_default_booking_availability(): void
     {
-        $this->assertEquals(BookingAvailability::Available(), $this->periodicCalendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Available(), $this->periodicCalendar->getBookingAvailability());
     }
 
     /**
@@ -68,9 +68,9 @@ class PeriodicCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->periodicCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+        $calendar = $this->periodicCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
 
-        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
@@ -41,7 +41,7 @@ class PermanentCalendarTest extends TestCase
     {
         $calendar = new PermanentCalendar(new OpeningHours());
 
-        $this->assertEquals(BookingAvailability::Available(), $calendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Available(), $calendar->getBookingAvailability());
     }
 
     /**
@@ -61,9 +61,9 @@ class PermanentCalendarTest extends TestCase
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
         $calendar = new PermanentCalendar(new OpeningHours());
-        $calendar = $calendar->withBookingAvailability(BookingAvailability::Unavailable());
+        $calendar = $calendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
 
-        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
@@ -41,7 +41,10 @@ class PermanentCalendarTest extends TestCase
     {
         $calendar = new PermanentCalendar(new OpeningHours());
 
-        $this->assertEquals(BookingAvailabilityType::Available(), $calendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Available()),
+            $calendar->getBookingAvailability()
+        );
     }
 
     /**
@@ -61,9 +64,14 @@ class PermanentCalendarTest extends TestCase
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
         $calendar = new PermanentCalendar(new OpeningHours());
-        $calendar = $calendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
+        $calendar = $calendar->withBookingAvailability(
+            new BookingAvailability(BookingAvailabilityType::Unavailable())
+        );
 
-        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Unavailable()),
+            $calendar->getBookingAvailability()
+        );
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
@@ -18,7 +18,7 @@ class PermanentCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_calendar_type()
+    public function it_should_return_a_calendar_type(): void
     {
         $calendar = new PermanentCalendar(new OpeningHours());
         $this->assertEquals(CalendarType::permanent(), $calendar->getType());
@@ -27,7 +27,7 @@ class PermanentCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_default_available_status()
+    public function it_should_return_a_default_available_status(): void
     {
         $calendar = new PermanentCalendar(new OpeningHours());
 
@@ -38,6 +38,10 @@ class PermanentCalendarTest extends TestCase
      * @test
      */
     public function it_allows_setting_an_explicit_status()
+    /**
+     * @test
+     */
+    public function it_allows_setting_an_explicit_status(): void
     {
         $calendar = new PermanentCalendar(new OpeningHours());
         $calendar = $calendar->withStatus(new Status(StatusType::Unavailable()));
@@ -48,7 +52,7 @@ class PermanentCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_the_injected_opening_hours()
+    public function it_should_return_the_injected_opening_hours(): void
     {
         $days = new Days(
             Day::monday(),

--- a/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
@@ -67,7 +67,7 @@ class PermanentCalendarTest extends TestCase
                     new Hour(9),
                     new Minute(0)
                 ),
-                $closingTime = new Time(
+                new Time(
                     new Hour(12),
                     new Minute(0)
                 )
@@ -78,7 +78,7 @@ class PermanentCalendarTest extends TestCase
                     new Hour(13),
                     new Minute(0)
                 ),
-                $closingTime = new Time(
+                new Time(
                     new Hour(17),
                     new Minute(0)
                 )

--- a/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/PermanentCalendarTest.php
@@ -37,7 +37,13 @@ class PermanentCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_allows_setting_an_explicit_status()
+    public function it_has_a_default_booking_availability(): void
+    {
+        $calendar = new PermanentCalendar(new OpeningHours());
+
+        $this->assertEquals(BookingAvailability::Available(), $calendar->getBookingAvailability());
+    }
+
     /**
      * @test
      */
@@ -47,6 +53,17 @@ class PermanentCalendarTest extends TestCase
         $calendar = $calendar->withStatus(new Status(StatusType::Unavailable()));
 
         $this->assertEquals(new Status(StatusType::Unavailable()), $calendar->getStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_setting_an_explicit_booking_availability(): void
+    {
+        $calendar = new PermanentCalendar(new OpeningHours());
+        $calendar = $calendar->withBookingAvailability(BookingAvailability::Unavailable());
+
+        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -44,11 +44,29 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
+    public function it_has_a_default_booking_availability(): void
+    {
+        $this->assertEquals(BookingAvailability::Available(), $this->singleSubEventCalendar->getBookingAvailability());
+    }
+
+    /**
+     * @test
+     */
     public function it_allows_setting_an_explicit_status(): void
     {
         $calendar = $this->singleSubEventCalendar->withStatus(new Status(StatusType::Unavailable()));
 
         $this->assertEquals(new Status(StatusType::Unavailable()), $calendar->getStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_setting_an_explicit_booking_availability(): void
+    {
+        $calendar = $this->singleSubEventCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+
+        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**

--- a/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -11,7 +11,7 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_calendar_type()
+    public function it_should_return_a_calendar_type(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -28,7 +28,7 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_default_available_status()
+    public function it_should_return_a_default_available_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -45,7 +45,7 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_allows_setting_an_explicit_status()
+    public function it_allows_setting_an_explicit_status(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -63,7 +63,7 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_the_injected_start_and_end_date()
+    public function it_should_return_the_injected_start_and_end_date(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
@@ -81,7 +81,7 @@ class SingleSubEventCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_single_sub_event()
+    public function it_should_return_a_single_sub_event(): void
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');

--- a/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -20,7 +20,7 @@ class SingleSubEventCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
     }
@@ -46,7 +46,10 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_has_a_default_booking_availability(): void
     {
-        $this->assertEquals(BookingAvailabilityType::Available(), $this->singleSubEventCalendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Available()),
+            $this->singleSubEventCalendar->getBookingAvailability()
+        );
     }
 
     /**
@@ -64,9 +67,14 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->singleSubEventCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
+        $calendar = $this->singleSubEventCalendar->withBookingAvailability(
+            new BookingAvailability(BookingAvailabilityType::Unavailable())
+        );
 
-        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(
+            new BookingAvailability(BookingAvailabilityType::Unavailable()),
+            $calendar->getBookingAvailability()
+        );
     }
 
     /**
@@ -96,7 +104,7 @@ class SingleSubEventCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
 

--- a/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -4,25 +4,33 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class SingleSubEventCalendarTest extends TestCase
 {
+    private SingleSubEventCalendar $singleSubEventCalendar;
+
+    protected function setUp(): void
+    {
+        $this->singleSubEventCalendar = new SingleSubEventCalendar(
+            new SubEvent(
+                new DateRange(
+                    DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+                    DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
+                ),
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
+            )
+        );
+    }
+
     /**
      * @test
      */
     public function it_should_return_a_calendar_type(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleSubEventCalendar(
-            new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Available())
-            )
-        );
-
-        $this->assertEquals(CalendarType::single(), $calendar->getType());
+        $this->assertEquals(CalendarType::single(), $this->singleSubEventCalendar->getType());
     }
 
     /**
@@ -30,16 +38,7 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_should_return_a_default_available_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleSubEventCalendar(
-            new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Unavailable())
-            )
-        );
-
-        $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
+        $this->assertEquals(new Status(StatusType::Available()), $this->singleSubEventCalendar->getStatus());
     }
 
     /**
@@ -47,17 +46,9 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_status(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleSubEventCalendar(
-            new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Unavailable())
-            )
-        );
-        $calendar = $calendar->withStatus(new Status(StatusType::Available()));
+        $calendar = $this->singleSubEventCalendar->withStatus(new Status(StatusType::Unavailable()));
 
-        $this->assertEquals(new Status(StatusType::Available()), $calendar->getStatus());
+        $this->assertEquals(new Status(StatusType::Unavailable()), $calendar->getStatus());
     }
 
     /**
@@ -65,17 +56,14 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_should_return_the_injected_start_and_end_date(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleSubEventCalendar(
-            new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Available())
-            )
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+            $this->singleSubEventCalendar->getStartDate()
         );
-
-        $this->assertEquals($startDate, $calendar->getStartDate());
-        $this->assertEquals($endDate, $calendar->getEndDate());
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018'),
+            $this->singleSubEventCalendar->getEndDate()
+        );
     }
 
     /**
@@ -83,22 +71,17 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_should_return_a_single_sub_event(): void
     {
-        $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
-        $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleSubEventCalendar(
-            new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Available())
-            )
-        );
-
         $expected = new SubEvents(
             new SubEvent(
-                new DateRange($startDate, $endDate),
-                new Status(StatusType::Available())
+                new DateRange(
+                    DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018'),
+                    DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
+                ),
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 
-        $this->assertEquals($expected, $calendar->getSubEvents());
+        $this->assertEquals($expected, $this->singleSubEventCalendar->getSubEvents());
     }
 }

--- a/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/Model/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -20,7 +20,7 @@ class SingleSubEventCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
     }
@@ -46,7 +46,7 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_has_a_default_booking_availability(): void
     {
-        $this->assertEquals(BookingAvailability::Available(), $this->singleSubEventCalendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Available(), $this->singleSubEventCalendar->getBookingAvailability());
     }
 
     /**
@@ -64,9 +64,9 @@ class SingleSubEventCalendarTest extends TestCase
      */
     public function it_allows_setting_an_explicit_booking_availability(): void
     {
-        $calendar = $this->singleSubEventCalendar->withBookingAvailability(BookingAvailability::Unavailable());
+        $calendar = $this->singleSubEventCalendar->withBookingAvailability(BookingAvailabilityType::Unavailable());
 
-        $this->assertEquals(BookingAvailability::Unavailable(), $calendar->getBookingAvailability());
+        $this->assertEquals(BookingAvailabilityType::Unavailable(), $calendar->getBookingAvailability());
     }
 
     /**
@@ -96,7 +96,7 @@ class SingleSubEventCalendarTest extends TestCase
                     DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018')
                 ),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
 

--- a/tests/Model/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/Model/ValueObject/Moderation/AvailableToTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -38,7 +39,7 @@ class AvailableToTest extends TestCase
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available()),
-                BookingAvailabilityType::Available()
+                new BookingAvailability(BookingAvailabilityType::Available())
             )
         );
 

--- a/tests/Model/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/Model/ValueObject/Moderation/AvailableToTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
@@ -38,7 +38,7 @@ class AvailableToTest extends TestCase
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available()),
-                BookingAvailability::Available()
+                BookingAvailabilityType::Available()
             )
         );
 

--- a/tests/Model/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/Model/ValueObject/Moderation/AvailableToTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
@@ -36,7 +37,8 @@ class AvailableToTest extends TestCase
         $singleDateRangeCalendar = new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange($startDate, $endDate),
-                new Status(StatusType::Available())
+                new Status(StatusType::Available()),
+                BookingAvailability::Available()
             )
         );
 

--- a/tests/Offer/ValueObjects/BookingAvailabilityTest.php
+++ b/tests/Offer/ValueObjects/BookingAvailabilityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
 use PHPUnit\Framework\TestCase;
 
 final class BookingAvailabilityTest extends TestCase
@@ -52,5 +53,17 @@ final class BookingAvailabilityTest extends TestCase
         $this->assertFalse(
             BookingAvailability::fromNative('Unavailable')->equals(BookingAvailability::available())
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_created_from_an_imported_udb3_model_value(): void
+    {
+        $bookingAvailability = BookingAvailability::fromUdb3ModelBookingAvailability(
+            Udb3ModelBookingAvailability::Unavailable()
+        );
+
+        $this->assertTrue(BookingAvailability::unavailable()->equals($bookingAvailability));
     }
 }

--- a/tests/Offer/ValueObjects/BookingAvailabilityTest.php
+++ b/tests/Offer/ValueObjects/BookingAvailabilityTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailabilityType;
 use PHPUnit\Framework\TestCase;
 
 final class BookingAvailabilityTest extends TestCase
@@ -61,7 +62,7 @@ final class BookingAvailabilityTest extends TestCase
     public function it_can_be_created_from_an_imported_udb3_model_value(): void
     {
         $bookingAvailability = BookingAvailability::fromUdb3ModelBookingAvailability(
-            Udb3ModelBookingAvailability::Unavailable()
+            new Udb3ModelBookingAvailability(Udb3ModelBookingAvailabilityType::Unavailable())
         );
 
         $this->assertTrue(BookingAvailability::unavailable()->equals($bookingAvailability));

--- a/tests/Offer/ValueObjects/BookingAvailabilityTest.php
+++ b/tests/Offer/ValueObjects/BookingAvailabilityTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ValueObjects;
 
-use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability as Udb3ModelBookingAvailability;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailabilityType as Udb3ModelBookingAvailability;
 use PHPUnit\Framework\TestCase;
 
 final class BookingAvailabilityTest extends TestCase

--- a/tests/TimestampTest.php
+++ b/tests/TimestampTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use DateTime;
+use DateTimeInterface;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -28,8 +29,8 @@ class TimestampTest extends TestCase
     public function setUp(): void
     {
         $this->timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
         );
     }
 
@@ -39,12 +40,12 @@ class TimestampTest extends TestCase
     public function it_stores_a_start_and_end_date(): void
     {
         $this->assertEquals(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
             $this->timestamp->getStartDate()
         );
 
         $this->assertEquals(
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             $this->timestamp->getEndDate()
         );
     }
@@ -60,8 +61,8 @@ class TimestampTest extends TestCase
         $this->expectExceptionMessage('End date can not be earlier than start date.');
 
         new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, $pastDate)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, $pastDate)
         );
     }
 
@@ -71,8 +72,8 @@ class TimestampTest extends TestCase
     public function it_will_add_the_default_event_status(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
         );
 
         $this->assertEquals(
@@ -87,8 +88,8 @@ class TimestampTest extends TestCase
     public function it_has_a_default_booking_availability(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
         );
 
         $this->assertEquals(BookingAvailability::available(), $timestamp->getBookingAvailability());
@@ -100,8 +101,8 @@ class TimestampTest extends TestCase
     public function it_can_serialize_and_deserialize(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             new Status(
                 StatusType::unavailable(),
                 [
@@ -135,8 +136,8 @@ class TimestampTest extends TestCase
     public function itCanChangeStatus(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             new Status(StatusType::available(), [])
         );
 
@@ -148,8 +149,8 @@ class TimestampTest extends TestCase
         );
 
         $expected = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             $newStatus
         );
 
@@ -165,16 +166,16 @@ class TimestampTest extends TestCase
     public function it_allows_changing_the_booking_availability(): void
     {
         $timestamp = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
         );
 
         $updatedTimestamp = $timestamp->withBookingAvailability(BookingAvailability::unavailable());
 
         $this->assertEquals(
             new Timestamp(
-                DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-                DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
                 new Status(StatusType::available(), []),
                 BookingAvailability::unavailable()
             ),
@@ -188,8 +189,8 @@ class TimestampTest extends TestCase
     public function it_will_set_end_date_to_start_date_when_deserializing_incorrect_events(): void
     {
         $expected = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             new Status(StatusType::available(), [])
         );
 

--- a/tests/TimestampTest.php
+++ b/tests/TimestampTest.php
@@ -21,10 +21,7 @@ class TimestampTest extends TestCase
     public const START_DATE = '2016-01-03T01:01:01+01:00';
     public const END_DATE = '2016-01-07T01:01:01+01:00';
 
-    /**
-     * @var Timestamp
-     */
-    private $timestamp;
+    private Timestamp $timestamp;
 
     public function setUp(): void
     {


### PR DESCRIPTION
### Added
- Added `BookingAvailability` VO inside the UDB3 Models
- Added denormalising of `BookingAvailability` inside `Calendar`

### Changed
- Extended the various Calendars inside the UDB3 Models with BookingAvailability
- Used properties to cleanup code duplication inside unit tests
- Used the time formats from the `DateTimeInterface` instead of `DateTime`. This was removed since PHP 7.2

---
Ticket: https://jira.uitdatabank.be/browse/III-4150
