### PR TITLE
III-4070 Improved token cache

### DIFF
--- a/app/Auth0/Auth0ServiceProvider.php
+++ b/app/Auth0/Auth0ServiceProvider.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\User\Auth0ManagementTokenProvider;
 use CultuurNet\UDB3\User\Auth0UserIdentityResolver;
 use CultuurNet\UDB3\User\CacheRepository;
 use GuzzleHttp\Client;
-use Lcobucci\JWT\Parser;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -29,8 +28,7 @@ final class Auth0ServiceProvider implements ServiceProviderInterface
                     ),
                     new CacheRepository(
                         $app['cache']('auth0-management-token')
-                    ),
-                    new Parser()
+                    )
                 );
                 return $provider->token();
             }

--- a/src/User/Auth0ManagementTokenGenerator.php
+++ b/src/User/Auth0ManagementTokenGenerator.php
@@ -4,29 +4,18 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\User;
 
+use DateTimeImmutable;
 use GuzzleHttp\Client;
 
 class Auth0ManagementTokenGenerator
 {
-    /**
-     * @var Client
-     */
-    private $client;
+    private Client $client;
 
-    /**
-     * @var string
-     */
-    private $clientId;
+    private string $clientId;
 
-    /**
-     * @var string
-     */
-    private $domain;
+    private string $domain;
 
-    /**
-     * @var string
-     */
-    private $clientSecret;
+    private string $clientSecret;
 
     public function __construct(Client $client, string $clientId, string $domain, string $clientSecret)
     {
@@ -36,7 +25,7 @@ class Auth0ManagementTokenGenerator
         $this->clientSecret = $clientSecret;
     }
 
-    public function newToken(): string
+    public function newToken(): Auth0Token
     {
         $response = $this->client->post(
             $this->uri(),
@@ -47,7 +36,12 @@ class Auth0ManagementTokenGenerator
         );
 
         $res = json_decode($response->getBody()->getContents(), true);
-        return $res['access_token'];
+
+        return new Auth0Token(
+            $res['access_token'],
+            new DateTimeImmutable(),
+            $res['expires_in']
+        );
     }
 
     private function body(): string

--- a/src/User/Auth0ManagementTokenRepository.php
+++ b/src/User/Auth0ManagementTokenRepository.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\User;
 
 interface Auth0ManagementTokenRepository
 {
-    public function token(): ?string;
+    public function token(): ?Auth0Token;
 
-    public function store(string $token): void;
+    public function store(Auth0Token $token): void;
 }

--- a/src/User/Auth0Token.php
+++ b/src/User/Auth0Token.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\User;
+
+use DateTimeImmutable;
+
+final class Auth0Token
+{
+    private string $token;
+
+    private DateTimeImmutable $issuedAt;
+
+    private int $expiresIn;
+
+    public function __construct(string $token, DateTimeImmutable $issuedAt, int $expiresIn)
+    {
+        $this->token = $token;
+        $this->issuedAt = $issuedAt;
+        $this->expiresIn = $expiresIn;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getIssuedAt(): DateTimeImmutable
+    {
+        return $this->issuedAt;
+    }
+
+    public function getExpiresIn(): int
+    {
+        return $this->expiresIn;
+    }
+
+    public function getExpiresAt(): DateTimeImmutable
+    {
+        return $this->issuedAt->modify('+' . $this->expiresIn . 'seconds');
+    }
+}

--- a/src/User/InMemoryRepository.php
+++ b/src/User/InMemoryRepository.php
@@ -6,14 +6,14 @@ namespace CultuurNet\UDB3\User;
 
 class InMemoryRepository implements Auth0ManagementTokenRepository
 {
-    private $token = null;
+    private ?Auth0Token $token = null;
 
-    public function token(): ?string
+    public function token(): ?Auth0Token
     {
         return $this->token;
     }
 
-    public function store(string $token): void
+    public function store(Auth0Token $token): void
     {
         $this->token = $token;
     }

--- a/src/User/UserIdentityDetails.php
+++ b/src/User/UserIdentityDetails.php
@@ -6,20 +6,11 @@ namespace CultuurNet\UDB3\User;
 
 class UserIdentityDetails implements \JsonSerializable
 {
-    /**
-     * @var string
-     */
-    private $userId;
+    private string $userId;
 
-    /**
-     * @var string
-     */
-    private $userName;
+    private string $userName;
 
-    /**
-     * @var string
-     */
-    private $emailAddress;
+    private string $emailAddress;
 
     public function __construct(
         string $userId,

--- a/tests/User/Auth0ManagementTokenProviderTest.php
+++ b/tests/User/Auth0ManagementTokenProviderTest.php
@@ -7,7 +7,8 @@ namespace CultuurNet\UDB3\Silex\User;
 use CultuurNet\UDB3\User\Auth0ManagementTokenGenerator;
 use CultuurNet\UDB3\User\Auth0ManagementTokenProvider;
 use CultuurNet\UDB3\User\Auth0ManagementTokenRepository;
-use Lcobucci\JWT\Parser;
+use CultuurNet\UDB3\User\Auth0Token;
+use DateTimeImmutable;
 use Lcobucci\JWT\Token;
 use PHPUnit\Framework\TestCase;
 
@@ -16,104 +17,103 @@ class Auth0ManagementTokenProviderTest extends TestCase
     /**
      * @test
      */
-    public function it_generates_new_token_if_no_token_in_repository()
+    public function it_generates_new_token_if_no_token_in_repository(): void
     {
         $tokenRepository = $this->createMock(Auth0ManagementTokenRepository::class);
         $tokenRepository->expects($this->atLeast(1))
             ->method('token')
             ->willReturn(null);
 
+        $token = new Auth0Token(
+            'my_token',
+            new DateTimeImmutable(),
+            3600
+        );
+
         $tokenRepository->expects($this->once())
-            ->method('store');
+            ->method('store')
+            ->with($token);
 
         $tokenGenerator = $this->createMock(Auth0ManagementTokenGenerator::class);
         $tokenGenerator->expects($this->atLeast(1))
             ->method('newToken')
-            ->willReturn('Token');
-
-        $parser = $this->createMock(Parser::class);
+            ->willReturn($token);
 
         $service = new Auth0ManagementTokenProvider(
             $tokenGenerator,
-            $tokenRepository,
-            $parser
+            $tokenRepository
         );
 
         $result = $service->token();
 
-        $this->assertEquals('Token', $result);
+        $this->assertEquals('my_token', $result);
     }
 
     /**
      * @test
      */
-    public function it_returns_token_if_valid_token_is_in_repository()
+    public function it_returns_token_if_valid_token_is_in_repository(): void
     {
+        $token = new Auth0Token(
+            'my_token',
+            new DateTimeImmutable(),
+            3600
+        );
+
         $tokenRepository = $this->createMock(Auth0ManagementTokenRepository::class);
         $tokenRepository->expects($this->atLeast(1))
             ->method('token')
-            ->willReturn('Token');
+            ->willReturn($token);
 
         $tokenGenerator = $this->createMock(Auth0ManagementTokenGenerator::class);
         $tokenGenerator->expects($this->never())
             ->method('newToken');
 
-        $token = $this->createMock(Token::class);
-        $token->expects($this->atLeast(1))
-            ->method('isExpired')
-            ->willReturn(false);
-
-        $parser = $this->createMock(Parser::class);
-        $parser->expects($this->atLeast(1))
-            ->method('parse')
-            ->with('Token')
-            ->willReturn($token);
-
         $service = new Auth0ManagementTokenProvider(
             $tokenGenerator,
-            $tokenRepository,
-            $parser
+            $tokenRepository
         );
 
         $result = $service->token();
 
-        $this->assertEquals('Token', $result);
+        $this->assertEquals('my_token', $result);
     }
 
     /**
      * @test
      */
-    public function it_generates_new_token_if_current_on_is_expired()
+    public function it_generates_new_token_if_current_is_about_to_expire(): void
     {
+        // A token is also considered as expired when it will expire within 5 minutes.
+        $expiredToken = new Auth0Token(
+            'expired_token',
+            new DateTimeImmutable(),
+            300
+        );
+
+        $newToken = new Auth0Token(
+            'new_token',
+            new DateTimeImmutable(),
+            3600
+        );
+
         $tokenRepository = $this->createMock(Auth0ManagementTokenRepository::class);
         $tokenRepository->expects($this->atLeast(1))
             ->method('token')
-            ->willReturn('Token');
+            ->willReturn($expiredToken);
 
         $tokenGenerator = $this->createMock(Auth0ManagementTokenGenerator::class);
         $tokenGenerator->expects($this->atLeast(1))
             ->method('newToken')
-            ->willReturn('New-Token');
-
-        $token = $this->createMock(Token::class);
-        $token->expects($this->atLeast(1))
-            ->method('isExpired')
-            ->willReturn(true);
-
-        $parser = $this->createMock(Parser::class);
-        $parser->expects($this->atLeast(1))
-            ->method('parse')
-            ->with('Token')
-            ->willReturn($token);
+            ->willReturn($newToken);
 
         $service = new Auth0ManagementTokenProvider(
             $tokenGenerator,
-            $tokenRepository,
-            $parser
+            $tokenRepository
         );
 
         $result = $service->token();
 
-        $this->assertEquals('New-Token', $result);
+        $this->assertEquals('new_token', $result);
     }
 }


### PR DESCRIPTION
### Added
- Added new `Auth0Token`

### Changed
- Use `Auth0Token` inside `Auth0ManagementTokenRepository` and `Auth0ManagementTokenGenerator`
- Use expired value inside `Auth0ManagementTokenProvider` to determine a token that is about to expire

---
Ticket: https://jira.uitdatabank.be/browse/III-4070
