### PR TITLE
Use DateTimeFormat constants for formatting date time

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -222,8 +222,8 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
             'bookingAvailability' => $this->bookingAvailability->serialize(),
         ];
 
-        empty($this->startDate) ?: $calendar['startDate'] = $this->startDate->format(DateTime::ATOM);
-        empty($this->endDate) ?: $calendar['endDate'] = $this->endDate->format(DateTime::ATOM);
+        empty($this->startDate) ?: $calendar['startDate'] = $this->startDate->format(DateTimeInterface::ATOM);
+        empty($this->endDate) ?: $calendar['endDate'] = $this->endDate->format(DateTimeInterface::ATOM);
         empty($serializedTimestamps) ?: $calendar['timestamps'] = $serializedTimestamps;
         empty($serializedOpeningHours) ?: $calendar['openingHours'] = $serializedOpeningHours;
 
@@ -285,7 +285,7 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
      */
     private static function deserializeDateTime(string $dateTimeData): DateTime
     {
-        $dateTime = DateTime::createFromFormat(DateTime::ATOM, $dateTimeData);
+        $dateTime = DateTime::createFromFormat(DateTimeInterface::ATOM, $dateTimeData);
 
         if ($dateTime === false) {
             $dateTime = DateTime::createFromFormat('Y-m-d\TH:i:s', $dateTimeData, new DateTimeZone('Europe/Brussels'));
@@ -307,10 +307,10 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
         if ($startDate !== null) {
-            $jsonLd['startDate'] = $startDate->format(DateTime::ATOM);
+            $jsonLd['startDate'] = $startDate->format(DateTimeInterface::ATOM);
         }
         if ($endDate !== null) {
-            $jsonLd['endDate'] = $endDate->format(DateTime::ATOM);
+            $jsonLd['endDate'] = $endDate->format(DateTimeInterface::ATOM);
         }
 
         $jsonLd['status'] = $this->determineCorrectTopStatusForProjection()->serialize();

--- a/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
+++ b/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
@@ -131,7 +131,7 @@ class TabularDataEventFormatter
         // Try to create from various formats to maintain backwards
         // compatibility with external systems with older json-ld
         // projections (eg. OMD).
-        $formats = [DateTimeInterface::ATOM, DateTimeInterface::ISO8601, 'Y-m-d\TH:i:s'];
+        $formats = [DateTimeInterface::ATOM, DateTimeInterface::ATOM, 'Y-m-d\TH:i:s'];
 
         do {
             $datetime = \DateTime::createFromFormat(current($formats), $date, $timezoneUtc);

--- a/src/Offer/Events/Moderation/AbstractPublished.php
+++ b/src/Offer/Events/Moderation/AbstractPublished.php
@@ -30,7 +30,7 @@ abstract class AbstractPublished extends AbstractEvent
     public function serialize(): array
     {
         return parent::serialize() + [
-            'publication_date' => $this->publicationDate->format(DateTime::ATOM),
+            'publication_date' => $this->publicationDate->format(DateTimeInterface::ATOM),
         ];
     }
 
@@ -38,7 +38,7 @@ abstract class AbstractPublished extends AbstractEvent
     {
         return new static(
             $data['item_id'],
-            DateTime::createFromFormat(DateTime::ATOM, $data['publication_date'])
+            DateTime::createFromFormat(DateTimeInterface::ATOM, $data['publication_date'])
         );
     }
 }

--- a/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
+++ b/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
@@ -51,7 +51,7 @@ trait HasAuthoringMetadataTrait
     public function serialize()
     {
         return [
-            'time' => $this->getTime()->format(DateTimeInterface::ISO8601),
+            'time' => $this->getTime()->format(DateTimeInterface::ATOM),
             'author' => (string) $this->getAuthor(),
         ];
     }

--- a/src/UDB2/DomainEvents/ISO8601DateTimeDeserializer.php
+++ b/src/UDB2/DomainEvents/ISO8601DateTimeDeserializer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
-use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use ValueObjects\StringLiteral\StringLiteral;
 
 class ISO8601DateTimeDeserializer
@@ -13,7 +13,7 @@ class ISO8601DateTimeDeserializer
     public static function deserialize(StringLiteral $timeString): DateTimeImmutable
     {
         $time = DateTimeImmutable::createFromFormat(
-            DateTime::ISO8601,
+            DateTimeInterface::ATOM,
             $timeString->toNative()
         );
 
@@ -22,7 +22,7 @@ class ISO8601DateTimeDeserializer
             $now = new DateTimeImmutable();
             throw new \RuntimeException(
                 'invalid time provided, please use a ISO 8601 formatted date' .
-                '& time like ' . $now->format(DateTime::ISO8601)
+                '& time like ' . $now->format(DateTimeInterface::ATOM)
             );
         }
 

--- a/tests/Calendar/CalendarConverterTest.php
+++ b/tests/Calendar/CalendarConverterTest.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Timestamp;
 use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
 use ValueObjects\DateTime\Minute;
@@ -355,8 +356,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-27T02:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-27T02:00:00+02:00')
                 ),
             ],
             []
@@ -395,8 +396,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-28T02:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00')
                 ),
             ],
             []
@@ -452,8 +453,8 @@ class CalendarConverterTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-01T09:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-07T18:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-07T18:00:00+02:00')
                 ),
             ],
             []
@@ -518,16 +519,16 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-01T09:00:00+02:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-28T02:00:00+02:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-01T09:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-07T18:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-01T09:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-07T18:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-28T02:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T21:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-28T02:00:00+02:00')
                 ),
             ],
             []
@@ -573,20 +574,20 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-25T10:00:00+02:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-06-30T16:00:00+02:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T10:00:00+02:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-30T16:00:00+02:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-25T10:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-25T16:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T10:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T16:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-25T20:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T01:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-25T20:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-05-26T01:00:00+02:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-06-28T10:00:00+02:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2017-06-30T16:00:00+02:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-28T10:00:00+02:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-06-30T16:00:00+02:00')
                 ),
             ],
             []

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -33,6 +33,7 @@ use CultuurNet\UDB3\Offer\CalendarTypeNotSupported;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
 use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
 use ValueObjects\DateTime\Minute;
@@ -54,13 +55,13 @@ class CalendarTest extends TestCase
     public function setUp(): void
     {
         $timestamp1 = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_1_START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_1_END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_END_DATE)
         );
 
         $timestamp2 = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_2_START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_2_END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_END_DATE)
         );
 
         $weekDays = (new DayOfWeekCollection())
@@ -94,8 +95,8 @@ class CalendarTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             [
                 self::TIMESTAMP_1 => $timestamp1,
                 self::TIMESTAMP_2 => $timestamp2,
@@ -118,8 +119,8 @@ class CalendarTest extends TestCase
 
         new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             [
                 'wrong timestamp',
             ]
@@ -136,8 +137,8 @@ class CalendarTest extends TestCase
 
         new Calendar(
             CalendarType::PERIODIC(),
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             [],
             [
                 'wrong opening hours',
@@ -166,8 +167,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::available()
                         ),
@@ -182,8 +183,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -198,14 +199,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::available()
                         ),
@@ -220,14 +221,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -249,8 +250,8 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
                 ),
             ]
         );
@@ -271,12 +272,12 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -325,8 +326,8 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
                 ),
             ]
         );
@@ -350,12 +351,12 @@ class CalendarTest extends TestCase
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -552,8 +553,8 @@ class CalendarTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::PERMANENT(),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
         );
 
         $this->assertEquals(
@@ -586,8 +587,8 @@ class CalendarTest extends TestCase
             new DateTime('2021-03-18T16:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T16:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T16:00:00+01:00'),
                     null,
                     BookingAvailability::unavailable()
                 ),
@@ -624,8 +625,8 @@ class CalendarTest extends TestCase
     public function it_can_deserialize_without_overwriting_the_status_of_subEvents(): void
     {
         $timestamp1 = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_1_START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_1_END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_1_END_DATE),
             new Status(
                 StatusType::unavailable(),
                 [
@@ -635,8 +636,8 @@ class CalendarTest extends TestCase
         );
 
         $timestamp2 = new Timestamp(
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_2_START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::TIMESTAMP_2_END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::TIMESTAMP_2_END_DATE),
             new Status(
                 StatusType::temporarilyUnavailable(),
                 [
@@ -647,8 +648,8 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE),
             [
                 self::TIMESTAMP_1 => $timestamp1,
                 self::TIMESTAMP_2 => $timestamp2,
@@ -687,8 +688,8 @@ class CalendarTest extends TestCase
                 new DateTime('2021-03-18T14:00:00+01:00'),
                 [
                     new Timestamp(
-                        DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00'),
-                        DateTime::createFromFormat(DateTime::ATOM, '2021-03-18T14:00:00+01:00')
+                        DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00'),
+                        DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-03-18T14:00:00+01:00')
                     ),
                 ]
             ),
@@ -717,8 +718,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                         ),
                     ]
                 ),
@@ -754,8 +755,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -802,12 +803,12 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00')
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00')
                         ),
                     ]
                 ),
@@ -854,8 +855,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -865,8 +866,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::available(),
                                 [
@@ -928,8 +929,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::temporarilyUnavailable(),
                                 [
@@ -939,8 +940,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1002,8 +1003,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1013,8 +1014,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1076,8 +1077,8 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1087,8 +1088,8 @@ class CalendarTest extends TestCase
                             )
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             new Status(
                                 StatusType::unavailable(),
                                 [
@@ -1158,14 +1159,14 @@ class CalendarTest extends TestCase
                     null,
                     [
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
                         new Timestamp(
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
-                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-03-13T12:00:00+01:00'),
                             null,
                             BookingAvailability::unavailable()
                         ),
@@ -1210,8 +1211,8 @@ class CalendarTest extends TestCase
             'periodic' => [
                 'calendar' => new Calendar(
                     CalendarType::PERIODIC(),
-                    DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-                    DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
                 ),
                 'jsonld' => [
                     'calendarType' => 'periodic',
@@ -1280,8 +1281,8 @@ class CalendarTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-            DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::START_DATE),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, self::END_DATE)
         );
 
         $calendar = Calendar::deserialize($oldCalendarData);
@@ -1337,12 +1338,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -1366,12 +1367,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00')
                 ),
             ]
         );
@@ -1395,12 +1396,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-13T12:00:00+01:00')
                 ),
             ]
         );
@@ -1424,12 +1425,12 @@ class CalendarTest extends TestCase
 
         $expected = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
             null,
             [
                 new Timestamp(
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
-                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2016-03-06T10:00:00+01:00')
                 ),
             ]
         );
@@ -1760,20 +1761,20 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $sameCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $otherCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-28T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-28T12:12:12+01:00')
         );
 
         $this->assertTrue($calendar->sameAs($sameCalendar));
@@ -1787,44 +1788,44 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
                 ),
             ]
         );
 
         $expected = [
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
             ),
         ];
 
@@ -1841,27 +1842,27 @@ class CalendarTest extends TestCase
     {
         $timestamps = [
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
             ),
             new Timestamp(
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
-                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
+                DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
             ),
         ];
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
             $timestamps
         );
 
@@ -1890,24 +1891,24 @@ class CalendarTest extends TestCase
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-30T12:12:12+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-30T12:12:12+01:00'),
             [
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-05T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-10T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-07T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-09T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-15T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-25T12:12:12+01:00')
                 ),
                 new Timestamp(
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
-                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-04-20T12:12:12+01:00')
                 ),
             ]
         );

--- a/tests/Event/Commands/UpdateCalendarTest.php
+++ b/tests/Event/Commands/UpdateCalendarTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\Commands;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class UpdateCalendarTest extends TestCase
@@ -32,8 +33,8 @@ class UpdateCalendarTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $this->updateCalendar = new UpdateCalendar(

--- a/tests/Event/EventCommandHandlerTest.php
+++ b/tests/Event/EventCommandHandlerTest.php
@@ -41,6 +41,7 @@ use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
+use DateTimeInterface;
 use ValueObjects\Money\Currency;
 
 class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
@@ -223,8 +224,8 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $this->scenario

--- a/tests/Event/EventEditingServiceTest.php
+++ b/tests/Event/EventEditingServiceTest.php
@@ -33,6 +33,7 @@ use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Title;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
@@ -411,7 +412,7 @@ class EventEditingServiceTest extends TestCase
         $calendar = new Calendar(CalendarType::PERMANENT());
         $theme = null;
         $publicationDate = \DateTimeImmutable::createFromFormat(
-            \DateTime::ATOM,
+            DateTimeInterface::ATOM,
             '2016-08-01T00:00:00+00:00'
         );
 
@@ -459,8 +460,8 @@ class EventEditingServiceTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $updateCalendar = new UpdateCalendar($eventId, $calendar);

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use DateTimeInterface;
 use RuntimeException;
 use ValueObjects\Identity\UUID;
 use ValueObjects\Money\Currency;
@@ -255,8 +256,8 @@ class EventTest extends AggregateRootScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $xmlData = $this->getSample('EventTest.cdbxml.xml');

--- a/tests/Event/Events/CalendarUpdatedTest.php
+++ b/tests/Event/Events/CalendarUpdatedTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Event\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class CalendarUpdatedTest extends TestCase
@@ -36,8 +37,8 @@ class CalendarUpdatedTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2021-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2021-01-27T12:12:12+01:00')
         );
 
         $this->calendarUpdatedAsArray = [

--- a/tests/Event/Events/EventCreatedTest.php
+++ b/tests/Event/Events/EventCreatedTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class EventCreatedTest extends TestCase
@@ -245,7 +246,7 @@ class EventCreatedTest extends TestCase
                     ),
                     null,
                     DateTimeImmutable::createFromFormat(
-                        \DateTime::ATOM,
+                        DateTimeInterface::ATOM,
                         '2016-08-01T00:00:00+02:00'
                     )
                 ),

--- a/tests/Event/Events/Moderation/PublishedTest.php
+++ b/tests/Event/Events/Moderation/PublishedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\Events\Moderation;
 
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class PublishedTest extends TestCase
@@ -42,7 +43,7 @@ class PublishedTest extends TestCase
     {
         $publishedAsArray = [
             'item_id' => $this->itemId,
-            'publication_date' => $this->publicationDate->format(\DateTime::ATOM),
+            'publication_date' => $this->publicationDate->format(DateTimeInterface::ATOM),
         ];
 
         $this->assertEquals(

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -73,6 +73,7 @@ use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 use ValueObjects\Money\Currency;
@@ -288,7 +289,7 @@ class HistoryProjectorTest extends TestCase
             4,
             $metadata,
             $eventCreated,
-            DateTime::fromString($now->format(\DateTime::ATOM))
+            DateTime::fromString($now->format(DateTimeInterface::ATOM))
         );
 
         $this->historyProjector->handle($domainMessage);
@@ -329,7 +330,7 @@ class HistoryProjectorTest extends TestCase
             4,
             new Metadata(['user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6']),
             $eventCopied,
-            DateTime::fromString($now->format(\DateTime::ATOM))
+            DateTime::fromString($now->format(DateTimeInterface::ATOM))
         );
 
         $this->historyProjector->handle($domainMessage);
@@ -1273,7 +1274,7 @@ class HistoryProjectorTest extends TestCase
         $event = new Published(
             self::EVENT_ID_1,
             DateTimeImmutable::createFromFormat(
-                \DateTime::ATOM,
+                DateTimeInterface::ATOM,
                 '2015-04-30T02:00:00+02:00'
             )
         );

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -57,6 +57,7 @@ use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Timestamp;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use ValueObjects\DateTime\Hour;
@@ -180,8 +181,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
         );
 
         $eventCreated = $this->createEventCreated($eventId, $calendar, null);
@@ -215,8 +216,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '1';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
 
@@ -262,8 +263,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '1';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
 
@@ -362,8 +363,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $originalEventId = '1';
         $originalCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2017-01-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($originalEventId, $originalCalendar, null);
 
@@ -387,18 +388,18 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = '2';
         $timestamps = [
             new Timestamp(
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-27T13:25:21+01:00')
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-27T13:25:21+01:00')
             ),
             new Timestamp(
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-28T13:25:21+01:00'),
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-29T13:25:21+01:00')
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-28T13:25:21+01:00'),
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
             ),
         ];
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-29T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00'),
             $timestamps
         );
         $eventCopied = new EventCopied($eventId, $originalEventId, $calendar);
@@ -431,8 +432,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-29T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
         );
 
         $eventCopied = new EventCopied('2', $eventCreated->getEventId(), $calendar);
@@ -538,19 +539,19 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $timestamps = [
             new Timestamp(
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-27T13:25:21+01:00')
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-27T13:25:21+01:00')
             ),
             new Timestamp(
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-28T13:25:21+01:00'),
-                \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-29T13:25:21+01:00')
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-28T13:25:21+01:00'),
+                \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00')
             ),
         ];
 
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-29T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-29T13:25:21+01:00'),
             $timestamps
         );
 
@@ -630,8 +631,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $eventId = 'a2d50a8d-5b83-4c8b-84e6-e9c0bacbb1a3';
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2017-01-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2017-01-26T13:25:21+01:00')
         );
         $eventCreated = $this->createEventCreated($eventId, $calendar, null);
         $this->mockPlaceService();
@@ -933,8 +934,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $location = new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
         $majorInfoUpdated = new MajorInfoUpdated($id, $title, $eventType, $location, $calendar, $theme);
@@ -1013,8 +1014,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $calendarUpdated = new CalendarUpdated($eventId, $calendar);
@@ -1158,8 +1159,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $location = new LocationId('395fe7eb-9bac-4647-acae-316b6446a85e');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
         $majorInfoUpdated = new MajorInfoUpdated(

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Timestamp;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
@@ -83,8 +84,8 @@ class CalendarJSONDeserializerTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00'),
             [],
             $openingHours
         );
@@ -111,8 +112,8 @@ class CalendarJSONDeserializerTest extends TestCase
 
         $expectedCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00')
         );
 
         $expectedCalendar = $expectedCalendar->withStatus(
@@ -151,8 +152,8 @@ class CalendarJSONDeserializerTest extends TestCase
             null,
             [
                 (new TimeStamp(
-                    \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-03T09:00:00+01:00'),
-                    \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00')
+                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00'),
+                    \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00')
                 ))->withBookingAvailability(BookingAvailability::unavailable()),
             ]
         ))->withBookingAvailability(BookingAvailability::unavailable());
@@ -177,11 +178,11 @@ class CalendarJSONDeserializerTest extends TestCase
             $this->calendarDataValidator
         );
 
-        $startDate1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDate1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
+        $endDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
 
-        $startDate2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDate2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
+        $endDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(
@@ -247,11 +248,11 @@ class CalendarJSONDeserializerTest extends TestCase
             $this->calendarDataValidator
         );
 
-        $startDate1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDate1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
+        $endDate1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
 
-        $startDate2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDate2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
+        $endDate2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(

--- a/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONParserTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\Timestamp;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\DateTime\Hour;
 use ValueObjects\DateTime\Minute;
@@ -43,7 +44,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_start_date()
     {
-        $startDate = \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00');
+        $startDate = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
 
         $this->assertEquals(
             $startDate,
@@ -73,7 +74,7 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_end_date()
     {
-        $endDate = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00');
+        $endDate = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
 
         $this->assertEquals(
             $endDate,
@@ -133,11 +134,11 @@ class CalendarJSONParserTest extends TestCase
      */
     public function it_can_get_the_timestamps()
     {
-        $startDatePeriod1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T09:00:00+01:00');
-        $endDatePeriod1 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-01T16:00:00+01:00');
+        $startDatePeriod1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T09:00:00+01:00');
+        $endDatePeriod1 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-01T16:00:00+01:00');
 
-        $startDatePeriod2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-03T09:00:00+01:00');
-        $endDatePeriod2 = \DateTime::createFromFormat(\DateTime::ATOM, '2020-02-10T16:00:00+01:00');
+        $startDatePeriod2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-03T09:00:00+01:00');
+        $endDatePeriod2 = \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-02-10T16:00:00+01:00');
 
         $timestamps = [
             (new Timestamp(

--- a/tests/Http/Offer/PatchOfferRestControllerTest.php
+++ b/tests/Http/Offer/PatchOfferRestControllerTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsInappropriate as FlagAsInapp
 use CultuurNet\UDB3\Place\Commands\Moderation\Reject as RejectPlace;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
 use CultuurNet\UDB3\Offer\OfferType;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -118,7 +119,7 @@ class PatchOfferRestControllerTest extends TestCase
                 'expectedCommand' => new Publish(
                     $this->itemId,
                     \DateTime::createFromFormat(
-                        \DateTime::ISO8601,
+                        DateTimeInterface::ATOM,
                         '2030-02-01T12:00:00+00:00'
                     )
                 ),

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -47,6 +47,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLink;
+use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
@@ -496,7 +497,7 @@ class ImmutableOfferTest extends TestCase
     public function it_should_return_a_copy_with_an_updated_available_from()
     {
         $availableFrom = \DateTimeImmutable::createFromFormat(
-            \DateTime::ATOM,
+            DateTimeInterface::ATOM,
             '2018-01-01T00:00:00+00:00'
         );
 
@@ -514,7 +515,7 @@ class ImmutableOfferTest extends TestCase
     public function it_should_return_a_copy_without_available_from()
     {
         $availableFrom = \DateTimeImmutable::createFromFormat(
-            \DateTime::ATOM,
+            DateTimeInterface::ATOM,
             '2018-01-01T00:00:00+00:00'
         );
 

--- a/tests/Model/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/Model/ValueObject/Moderation/AvailableToTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class AvailableToTest extends TestCase
@@ -23,7 +24,7 @@ class AvailableToTest extends TestCase
     public function it_should_return_an_immutable_datetime_set_in_2100()
     {
         $expected = '2100-01-01T00:00:00+00:00';
-        $actual = AvailableTo::forever()->format(\DateTime::ATOM);
+        $actual = AvailableTo::forever()->format(DateTimeInterface::ATOM);
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/Offer/Events/Moderation/AbstractPublishedTest.php
+++ b/tests/Offer/Events/Moderation/AbstractPublishedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Events\Moderation;
 
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -77,7 +78,7 @@ class AbstractPublishedTest extends TestCase
     {
         $expectedArray = [
             'item_id' => $this->itemId,
-            'publication_date' => $this->publicationDate->format(\DateTime::ATOM),
+            'publication_date' => $this->publicationDate->format(DateTimeInterface::ATOM),
         ];
 
         $actualArray = $this->abstractPublished->serialize();

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -55,6 +55,7 @@ use CultuurNet\UDB3\Offer\Item\Item;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use DateTimeInterface;
 use Exception;
 use ValueObjects\Identity\UUID;
 use ValueObjects\Person\Age;
@@ -1390,20 +1391,20 @@ class OfferTest extends AggregateRootScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $sameCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $otherCalendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-28T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-28T12:12:12+01:00')
         );
 
         $this->scenario

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -55,6 +55,7 @@ use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -1030,7 +1031,7 @@ class OfferLDProjectorTest extends TestCase
         $expectedItem = (object)[
             '@id' => $itemId,
             '@type' => 'event',
-            'availableFrom' => $now->format(\DateTime::ATOM),
+            'availableFrom' => $now->format(DateTimeInterface::ATOM),
             'workflowStatus' => 'READY_FOR_VALIDATION',
             'modified' => $this->recordedOn->toString(),
         ];

--- a/tests/Place/CommandHandlerTest.php
+++ b/tests/Place/CommandHandlerTest.php
@@ -41,6 +41,7 @@ use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
+use DateTimeInterface;
 use ValueObjects\Geography\Country;
 use ValueObjects\Money\Currency;
 
@@ -268,8 +269,8 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $this->scenario

--- a/tests/Place/Commands/UpdateCalendarTest.php
+++ b/tests/Place/Commands/UpdateCalendarTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Place\Commands;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class UpdateCalendarTest extends TestCase
@@ -32,8 +33,8 @@ class UpdateCalendarTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $this->updateCalendar = new UpdateCalendar(

--- a/tests/Place/DefaultPlaceEditingServiceTest.php
+++ b/tests/Place/DefaultPlaceEditingServiceTest.php
@@ -27,6 +27,7 @@ use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Title;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Geography\Country;
@@ -210,7 +211,7 @@ class DefaultPlaceEditingServiceTest extends TestCase
      */
     public function it_can_create_a_new_place_with_a_fixed_publication_date()
     {
-        $publicationDate = \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2016-08-01T00:00:00+0200');
+        $publicationDate = \DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, '2016-08-01T00:00:00+0200');
 
         $street = new Street('Kerkstraat 69');
         $locality = new Locality('Leuven');
@@ -267,8 +268,8 @@ class DefaultPlaceEditingServiceTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $updateCalendar = new UpdateCalendar($placeId, $calendar);

--- a/tests/Place/Events/CalendarUpdatedTest.php
+++ b/tests/Place/Events/CalendarUpdatedTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Place\Events;
 
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 
 class CalendarUpdatedTest extends TestCase
@@ -36,8 +37,8 @@ class CalendarUpdatedTest extends TestCase
 
         $this->calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $this->calendarUpdatedAsArray = [

--- a/tests/Place/Events/PlaceCreatedTest.php
+++ b/tests/Place/Events/PlaceCreatedTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Geography\Country;
 
@@ -287,7 +288,7 @@ class PlaceCreatedTest extends TestCase
                     ),
                     null,
                     \DateTimeImmutable::createFromFormat(
-                        \DateTime::ATOM,
+                        DateTimeInterface::ATOM,
                         '2016-08-01T00:00:00+02:00'
                     )
                 ),

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -40,6 +40,7 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
+use DateTimeInterface;
 use Ramsey\Uuid\Uuid;
 use ValueObjects\Geography\Country;
 use ValueObjects\Money\Currency;
@@ -148,8 +149,8 @@ class PlaceTest extends AggregateRootScenarioTestCase
 
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-26T11:11:11+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $cdbXml = $this->getCdbXML('/ReadModel/JSONLD/place_with_long_description.cdbxml.xml');

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -75,6 +75,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\Geography\Country;
 use ValueObjects\Identity\UUID;
@@ -777,7 +778,7 @@ class HistoryProjectorTest extends TestCase
         $event = new Published(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
             DateTimeImmutable::createFromFormat(
-                \DateTime::ATOM,
+                DateTimeInterface::ATOM,
                 '2015-04-30T02:00:00+02:00'
             )
         );

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -47,6 +47,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
+use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use ValueObjects\Geography\Country;
@@ -755,8 +756,8 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
         $eventType = new EventType('0.50.4.0.1', 'concertnew');
         $calendar = new Calendar(
             CalendarType::PERIODIC(),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-01-26T13:25:21+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2015-02-26T13:25:21+01:00')
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-01-26T13:25:21+01:00'),
+            \DateTime::createFromFormat(DateTimeInterface::ATOM, '2015-02-26T13:25:21+01:00')
         );
         $theme = new Theme('123', 'theme label');
         $majorInfoUpdated = new MajorInfoUpdated($id, $title, $eventType, $this->address, $calendar, $theme);

--- a/tests/UDB2/DomainEvents/ActorCreatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/ActorCreatedJSONDeserializerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Url;
@@ -126,7 +126,7 @@ class ActorCreatedJSONDeserializerTest extends TestCase
 
         $this->assertEquals(
             \DateTimeImmutable::createFromFormat(
-                DateTime::ISO8601,
+                DateTimeInterface::ATOM,
                 '2015-02-20T20:39:09+0100'
             ),
             $actorCreated->getTime()

--- a/tests/UDB2/DomainEvents/ActorCreatedTest.php
+++ b/tests/UDB2/DomainEvents/ActorCreatedTest.php
@@ -73,7 +73,7 @@ class ActorCreatedTest extends TestCase
         $eventCreated = $this->createActorCreated($time);
         $expectedData = [
             'actorId' => '123',
-            'time' => '2016-04-15T16:06:11+0200',
+            'time' => '2016-04-15T16:06:11+02:00',
             'author' => 'me@example.com',
             'url' => 'http://foo.bar/event/foo',
         ];

--- a/tests/UDB2/DomainEvents/ActorUpdatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/ActorUpdatedJSONDeserializerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Url;
@@ -126,7 +126,7 @@ class ActorUpdatedJSONDeserializerTest extends TestCase
 
         $this->assertEquals(
             \DateTimeImmutable::createFromFormat(
-                DateTime::ISO8601,
+                DateTimeInterface::ATOM,
                 '2015-02-20T20:39:09+0100'
             ),
             $actorUpdated->getTime()

--- a/tests/UDB2/DomainEvents/ActorUpdatedTest.php
+++ b/tests/UDB2/DomainEvents/ActorUpdatedTest.php
@@ -73,7 +73,7 @@ class ActorUpdatedTest extends TestCase
         $eventCreated = $this->createActorUpdated($time);
         $expectedData = [
             'actorId' => '123',
-            'time' => '2016-04-15T16:06:11+0200',
+            'time' => '2016-04-15T16:06:11+02:00',
             'author' => 'me@example.com',
             'url' => 'http://foo.bar/event/foo',
         ];

--- a/tests/UDB2/DomainEvents/EventCreatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/EventCreatedJSONDeserializerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Url;
@@ -132,7 +132,7 @@ class EventCreatedJSONDeserializerTest extends TestCase
 
         $this->assertEquals(
             \DateTimeImmutable::createFromFormat(
-                DateTime::ISO8601,
+                DateTimeInterface::ATOM,
                 '2015-02-20T20:39:09+0100'
             ),
             $eventCreated->getTime()

--- a/tests/UDB2/DomainEvents/EventCreatedTest.php
+++ b/tests/UDB2/DomainEvents/EventCreatedTest.php
@@ -73,7 +73,7 @@ class EventCreatedTest extends TestCase
         $eventCreated = $this->createEventCreated($time);
         $expectedData = [
             'eventId' => '123',
-            'time' => '2016-04-15T16:06:11+0200',
+            'time' => '2016-04-15T16:06:11+02:00',
             'author' => 'me@example.com',
             'url' => 'http://foo.bar/event/foo',
         ];

--- a/tests/UDB2/DomainEvents/EventUpdatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/EventUpdatedJSONDeserializerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use ValueObjects\StringLiteral\StringLiteral;
 use ValueObjects\Web\Url;
@@ -132,7 +132,7 @@ class EventUpdatedJSONDeserializerTest extends TestCase
 
         $this->assertEquals(
             \DateTimeImmutable::createFromFormat(
-                DateTime::ISO8601,
+                DateTimeInterface::ATOM,
                 '2015-02-20T20:39:09+0100'
             ),
             $eventUpdated->getTime()

--- a/tests/UDB2/DomainEvents/EventUpdatedTest.php
+++ b/tests/UDB2/DomainEvents/EventUpdatedTest.php
@@ -73,7 +73,7 @@ class EventUpdatedTest extends TestCase
         $eventCreated = $this->createEventUpdated($time);
         $expectedData = [
             'eventId' => '123',
-            'time' => '2016-04-15T16:06:11+0200',
+            'time' => '2016-04-15T16:06:11+02:00',
             'author' => 'me@example.com',
             'url' => 'http://foo.bar/event/foo',
         ];


### PR DESCRIPTION
### Changed
- Use DateTimeFormat constants for formatting date time
