### PR TITLE
III-4168 Add RequestHandler interface

### DIFF
--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -76,8 +76,6 @@ class EventControllerProvider implements ControllerProviderInterface
         $controllers->get('/{cdbid}/calsum', 'event_controller:getCalendarSummary');
 
         $controllers->patch('/{eventId}/subEvents', UpdateSubEventsRequestHandler::class . ':handle');
-        $controllers->put('/{offerId}/status', UpdateStatusRequestHandler::class . ':handle');
-        $controllers->put('/{offerId}/bookingAvailability', UpdateBookingAvailabilityRequestHandler::class . ':handle');
 
         return $controllers;
     }

--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -7,8 +7,6 @@ namespace CultuurNet\UDB3\Silex\Event;
 use CultuurNet\UDB3\Http\Event\EditEventRestController;
 use CultuurNet\UDB3\Http\Event\ReadEventRestController;
 use CultuurNet\UDB3\Http\Event\UpdateSubEventsRequestHandler;
-use CultuurNet\UDB3\Http\Offer\UpdateBookingAvailabilityRequestHandler;
-use CultuurNet\UDB3\Http\Offer\UpdateStatusRequestHandler;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;

--- a/app/Offer/OfferControllerProvider.php
+++ b/app/Offer/OfferControllerProvider.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Event\EventFacilityResolver;
 use CultuurNet\UDB3\Http\Deserializer\PriceInfo\PriceInfoDataValidator;
 use CultuurNet\UDB3\Http\Offer\UpdateBookingAvailabilityRequestHandler;
 use CultuurNet\UDB3\Http\Offer\UpdateStatusRequestHandler;
-use CultuurNet\UDB3\Http\Offer\UpdateStatusValidator;
 use CultuurNet\UDB3\LabelJSONDeserializer;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Offer\OfferType;

--- a/app/Offer/OfferControllerProvider.php
+++ b/app/Offer/OfferControllerProvider.php
@@ -38,10 +38,7 @@ class OfferControllerProvider implements ControllerProviderInterface
     {
         $app[UpdateStatusRequestHandler::class] = $app->share(
             function (Application $app) {
-                return new UpdateStatusRequestHandler(
-                    $app['event_command_bus'],
-                    new UpdateStatusValidator()
-                );
+                return new UpdateStatusRequestHandler($app['event_command_bus']);
             }
         );
 

--- a/app/Offer/OfferControllerProvider.php
+++ b/app/Offer/OfferControllerProvider.php
@@ -124,6 +124,9 @@ class OfferControllerProvider implements ControllerProviderInterface
                 }
             );
 
+            $controllers->put("{$offerType}/{offerId}/status", UpdateStatusRequestHandler::class . ':handle');
+            $controllers->put("{$offerType}/{offerId}/bookingAvailability", UpdateBookingAvailabilityRequestHandler::class . ':handle');
+
             $controllers->put("{$offerType}/{cdbid}/calendar", "{$controllerName}:updateCalendar");
             $controllers->put("{$offerType}/{cdbid}/type/{typeId}", "{$controllerName}:updateType");
             $controllers->put("{$offerType}/{cdbid}/theme/{themeId}", "{$controllerName}:updateTheme");

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Place;
 
-use CultuurNet\UDB3\Http\Offer\UpdateBookingAvailabilityRequestHandler;
 use CultuurNet\UDB3\Http\Place\EditPlaceRestController;
 use CultuurNet\UDB3\Http\Place\HistoryPlaceRestController;
 use CultuurNet\UDB3\Http\Place\ReadPlaceRestController;
-use CultuurNet\UDB3\Http\Offer\UpdateStatusRequestHandler;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -72,8 +72,6 @@ class PlaceControllerProvider implements ControllerProviderInterface
         $controllers->put('/{itemId}/images/{mediaObjectId}', 'place_editing_controller:updateImage');
 
         $controllers->get('/{cdbid}/calsum', 'place_controller:getCalendarSummary');
-        $controllers->put('/{offerId}/status', UpdateStatusRequestHandler::class . ':handle');
-        $controllers->put('/{offerId}/bookingAvailability', UpdateBookingAvailabilityRequestHandler::class . ':handle');
 
         return $controllers;
     }

--- a/src/Http/Event/UpdateSubEventsRequestHandler.php
+++ b/src/Http/Event/UpdateSubEventsRequestHandler.php
@@ -14,6 +14,8 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RequestHandler;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
@@ -21,7 +23,7 @@ use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class UpdateSubEventsRequestHandler
+class UpdateSubEventsRequestHandler implements RequestHandler
 {
     private CommandBus $commandBus;
 
@@ -36,8 +38,11 @@ class UpdateSubEventsRequestHandler
         );
     }
 
-    public function handle(ServerRequestInterface $request, string $eventId): ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $routeParameters = new RouteParameters($request);
+        $eventId = $routeParameters->get('eventId');
+
         $updates = $this->updateSubEventsParser->parse($request)->getParsedBody();
 
         $updateSubEvents = [];

--- a/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
+++ b/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
@@ -23,15 +23,13 @@ use Psr\Http\Message\ServerRequestInterface;
 final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
 {
     private CommandBus $commandBus;
-
-    private RequestBodyParser $updateBookingAvailabilityParser;
+    private RequestBodyParser $parser;
 
     public function __construct(
         CommandBus $commandBus
     ) {
         $this->commandBus = $commandBus;
-
-        $this->updateBookingAvailabilityParser = RequestBodyParserFactory::createBaseParser(
+        $this->parser = RequestBodyParserFactory::createBaseParser(
             JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY)
         );
     }
@@ -41,7 +39,7 @@ final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
         $routeParameters = new RouteParameters($request);
         $offerId = $routeParameters->get('offerId');
 
-        $data = (object) $this->updateBookingAvailabilityParser->parse($request)->getParsedBody();
+        $data = (object) $this->parser->parse($request)->getParsedBody();
 
         try {
             $this->commandBus->dispatch(

--- a/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
+++ b/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
@@ -10,6 +10,8 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RequestHandler;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Offer\Commands\UpdateBookingAvailability;
 use CultuurNet\UDB3\Offer\CalendarTypeNotSupported;
@@ -18,7 +20,7 @@ use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailabilityType;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-final class UpdateBookingAvailabilityRequestHandler
+final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
 {
     private CommandBus $commandBus;
 
@@ -34,8 +36,11 @@ final class UpdateBookingAvailabilityRequestHandler
         );
     }
 
-    public function handle(ServerRequestInterface $request, string $offerId): ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $routeParameters = new RouteParameters($request);
+        $offerId = $routeParameters->get('offerId');
+
         $data = (object) $this->updateBookingAvailabilityParser->parse($request)->getParsedBody();
 
         try {

--- a/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
+++ b/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
@@ -32,7 +32,7 @@ final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
         $this->commandBus = $commandBus;
 
         $this->updateBookingAvailabilityParser = RequestBodyParserFactory::createBaseParser(
-            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::EVENT_BOOKING_AVAILABILITY_PUT)
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY)
         );
     }
 

--- a/src/Http/Offer/UpdateStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateStatusRequestHandler.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
 use CultuurNet\UDB3\Http\Request\RequestHandler;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
@@ -19,12 +23,14 @@ use Psr\Http\Message\ServerRequestInterface;
 class UpdateStatusRequestHandler implements RequestHandler
 {
     private CommandBus $commandBus;
-    private UpdateStatusValidator $validator;
+    private RequestBodyParser $parser;
 
-    public function __construct(CommandBus $commandBus, UpdateStatusValidator $validator)
+    public function __construct(CommandBus $commandBus)
     {
         $this->commandBus = $commandBus;
-        $this->validator = $validator;
+        $this->parser = RequestBodyParserFactory::createBaseParser(
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_STATUS)
+        );
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -32,12 +38,11 @@ class UpdateStatusRequestHandler implements RequestHandler
         $routeParameters = new RouteParameters($request);
         $offerId = $routeParameters->get('offerId');
 
-        $data = json_decode((string) $request->getBody(), true);
-
-        $this->validator->validate($data);
+        $request = $this->parser->parse($request);
+        $data = (object) $request->getParsedBody();
 
         $newStatus = new Status(
-            StatusType::fromNative($data['type']),
+            StatusType::fromNative($data->type),
             $this->parseReason($data)
         );
 
@@ -49,14 +54,14 @@ class UpdateStatusRequestHandler implements RequestHandler
     /**
      * @return StatusReason[]
      */
-    private function parseReason(array $data): array
+    private function parseReason(object $data): array
     {
-        if (!isset($data['reason'])) {
+        if (!isset($data->reason)) {
             return [];
         }
 
         $reason = [];
-        foreach ($data['reason'] as $language => $translatedReason) {
+        foreach ($data->reason as $language => $translatedReason) {
             $reason[] = new StatusReason(new Language($language), $translatedReason);
         }
 

--- a/src/Http/Offer/UpdateStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateStatusRequestHandler.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Language;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -62,7 +63,14 @@ class UpdateStatusRequestHandler implements RequestHandler
 
         $reason = [];
         foreach ($data->reason as $language => $translatedReason) {
-            $reason[] = new StatusReason(new Language($language), $translatedReason);
+            try {
+                $language = new Language($language);
+            } catch (InvalidArgumentException $e) {
+                // Skip unsupported language codes to avoid any extra properties that are passed but not supported from
+                // resulting in an error response.
+                continue;
+            }
+            $reason[] = new StatusReason($language, $translatedReason);
         }
 
         return $reason;

--- a/src/Http/Offer/UpdateStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateStatusRequestHandler.php
@@ -18,15 +18,8 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class UpdateStatusRequestHandler implements RequestHandler
 {
-    /**
-     * @var CommandBus
-     */
-    private $commandBus;
-
-    /**
-     * @var UpdateStatusValidator
-     */
-    private $validator;
+    private CommandBus $commandBus;
+    private UpdateStatusValidator $validator;
 
     public function __construct(CommandBus $commandBus, UpdateStatusValidator $validator)
     {

--- a/src/Http/Offer/UpdateStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateStatusRequestHandler.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\RequestHandler;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Offer\Commands\Status\UpdateStatus;
 use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
-use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use CultuurNet\UDB3\Language;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
-class UpdateStatusRequestHandler
+class UpdateStatusRequestHandler implements RequestHandler
 {
     /**
      * @var CommandBus
@@ -32,9 +34,12 @@ class UpdateStatusRequestHandler
         $this->validator = $validator;
     }
 
-    public function handle(Request $request, string $offerId): Response
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $data = json_decode($request->getContent(), true);
+        $routeParameters = new RouteParameters($request);
+        $offerId = $routeParameters->get('offerId');
+
+        $data = json_decode((string) $request->getBody(), true);
 
         $this->validator->validate($data);
 
@@ -45,7 +50,7 @@ class UpdateStatusRequestHandler
 
         $this->commandBus->dispatch(new UpdateStatus($offerId, $newStatus));
 
-        return new NoContent();
+        return new NoContentResponse();
     }
 
     /**

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -16,6 +16,7 @@ final class JsonSchemaLocator
 
     // For OFFER schemas, use the ones for events
     public const OFFER_BOOKING_AVAILABILITY = 'event-bookingAvailability.json';
+    public const OFFER_STATUS = 'event-status.json';
 
     public static function setSchemaDirectory(string $schemaDirectory): void
     {

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -12,7 +12,7 @@ final class JsonSchemaLocator
 {
     private static ?string $schemaDirectory;
 
-    public const EVENT_BOOKING_AVAILABILITY_PUT = 'event-bookingAvailability-put.json';
+    public const EVENT_BOOKING_AVAILABILITY_PUT = 'event-bookingAvailability.json';
     public const EVENT_SUB_EVENT_PATCH = 'event-subEvent-patch.json';
 
     public static function setSchemaDirectory(string $schemaDirectory): void

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -12,8 +12,10 @@ final class JsonSchemaLocator
 {
     private static ?string $schemaDirectory;
 
-    public const EVENT_BOOKING_AVAILABILITY_PUT = 'event-bookingAvailability.json';
     public const EVENT_SUB_EVENT_PATCH = 'event-subEvent-patch.json';
+
+    // For OFFER schemas, use the ones for events
+    public const OFFER_BOOKING_AVAILABILITY = 'event-bookingAvailability.json';
 
     public static function setSchemaDirectory(string $schemaDirectory): void
     {

--- a/src/Http/Request/RequestHandler.php
+++ b/src/Http/Request/RequestHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+interface RequestHandler
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface;
+}

--- a/src/Http/Request/RouteParameters.php
+++ b/src/Http/Request/RouteParameters.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+
+final class RouteParameters
+{
+    private array $routeParameters;
+
+    public function __construct(ServerRequestInterface $request)
+    {
+        $attributes = $request->getAttributes();
+        $this->routeParameters = $attributes['_route_params'] ?? [];
+    }
+
+    public function get(string $parameterName): string
+    {
+        if (!isset($this->routeParameters[$parameterName])) {
+            throw new RuntimeException('Route parameter ' . $parameterName . ' not found in given ServerRequestInterface!');
+        }
+        return (string) $this->routeParameters[$parameterName];
+    }
+}

--- a/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
@@ -42,8 +42,10 @@ final class UpdateSubEventsRequestHandlerTest extends TestCase
     public function it_does_not_throw_when_given_valid_data($data, UpdateSubEvents $expectedCommand): void
     {
         $this->requestHandler->handle(
-            (new Psr7RequestBuilder())->withBodyFromString(json_encode($data))->build('PUT'),
-            self::EVENT_ID
+            (new Psr7RequestBuilder())
+                ->withBodyFromString(json_encode($data))
+                ->withRouteParameter('eventId', self::EVENT_ID)
+                ->build('PUT')
         );
         $this->assertEquals([$expectedCommand], $this->commandBus->getRecordedCommands());
     }
@@ -188,8 +190,10 @@ final class UpdateSubEventsRequestHandlerTest extends TestCase
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(...$expectedSchemaErrors),
             fn () => $this->requestHandler->handle(
-                (new Psr7RequestBuilder())->withBodyFromString(json_encode($data))->build('PUT'),
-                self::EVENT_ID
+                (new Psr7RequestBuilder())
+                    ->withBodyFromString(json_encode($data))
+                    ->withRouteParameter('eventId', self::EVENT_ID)
+                    ->build('PUT')
             )
         );
 

--- a/tests/Http/Offer/UpdateBookingAvailabilityRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingAvailabilityRequestHandlerTest.php
@@ -34,7 +34,7 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_allows_valid_data(): void
+    public function it_allows_a_valid_type(): void
     {
         $given = $this->requestBuilder
             ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')

--- a/tests/Http/Offer/UpdateBookingAvailabilityRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateBookingAvailabilityRequestHandlerTest.php
@@ -36,9 +36,12 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
      */
     public function it_allows_valid_data(): void
     {
-        $given = $this->requestBuilder->withBodyFromString('{"type":"Available"}')->build('PUT');
+        $given = $this->requestBuilder
+            ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')
+            ->withBodyFromString('{"type":"Available"}')
+            ->build('PUT');
 
-        $this->requestHandler->handle($given, '609a8214-51c9-48c0-903f-840a4f38852f');
+        $this->requestHandler->handle($given);
 
         $this->assertEquals(
             [
@@ -56,11 +59,14 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
      */
     public function it_fails_on_empty_body(): void
     {
-        $given = $this->requestBuilder->withBodyFromString('')->build('PUT');
+        $given = $this->requestBuilder
+            ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')
+            ->withBodyFromString('')
+            ->build('PUT');
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyMissing(),
-            fn () => $this->requestHandler->handle($given, '609a8214-51c9-48c0-903f-840a4f38852f')
+            fn () => $this->requestHandler->handle($given)
         );
 
         $this->assertEquals([], $this->commandBus->getRecordedCommands());
@@ -71,11 +77,14 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
      */
     public function it_fails_on_unparsable_body(): void
     {
-        $given = $this->requestBuilder->withBodyFromString('{{}')->build('PUT');
+        $given = $this->requestBuilder
+            ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')
+            ->withBodyFromString('{{}')
+            ->build('PUT');
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidSyntax('JSON'),
-            fn () => $this->requestHandler->handle($given, '609a8214-51c9-48c0-903f-840a4f38852f')
+            fn () => $this->requestHandler->handle($given)
         );
 
         $this->assertEquals([], $this->commandBus->getRecordedCommands());
@@ -86,11 +95,14 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
      */
     public function it_fails_on_missing_type(): void
     {
-        $given = $this->requestBuilder->withBodyFromString('{}')->build('PUT');
+        $given = $this->requestBuilder
+            ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')
+            ->withBodyFromString('{}')
+            ->build('PUT');
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(new SchemaError('/', 'The required properties (type) are missing')),
-            fn () => $this->requestHandler->handle($given, '609a8214-51c9-48c0-903f-840a4f38852f')
+            fn () => $this->requestHandler->handle($given)
         );
 
         $this->assertEquals([], $this->commandBus->getRecordedCommands());
@@ -101,11 +113,14 @@ class UpdateBookingAvailabilityRequestHandlerTest extends TestCase
      */
     public function it_fails_on_invalid_type(): void
     {
-        $given = $this->requestBuilder->withBodyFromString('{"type":"foo"}')->build('PUT');
+        $given = $this->requestBuilder
+            ->withRouteParameter('offerId', '609a8214-51c9-48c0-903f-840a4f38852f')
+            ->withBodyFromString('{"type":"foo"}')
+            ->build('PUT');
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::bodyInvalidData(new SchemaError('/type', 'The data should match one item from enum')),
-            fn () => $this->requestHandler->handle($given, '609a8214-51c9-48c0-903f-840a4f38852f')
+            fn () => $this->requestHandler->handle($given)
         );
 
         $this->assertEquals([], $this->commandBus->getRecordedCommands());

--- a/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
@@ -194,7 +194,7 @@ class UpdateStatusRequestHandlerTest extends TestCase
             ],
             'invalid_type' => [
                 'data' => (object) [
-                    'type' => 'foo'
+                    'type' => 'foo',
                 ],
                 'expectedSchemaErrors' => [
                     new SchemaError('/type', 'The data should match one item from enum'),

--- a/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateStatusRequestHandlerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Event\ValueObjects\Status;
+use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
+use CultuurNet\UDB3\Event\ValueObjects\StatusType;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Offer\Commands\Status\UpdateStatus;
+use PHPUnit\Framework\TestCase;
+
+class UpdateStatusRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+    private UpdateStatusRequestHandler $requestHandler;
+
+    private const OFFER_ID = '609a8214-51c9-48c0-903f-840a4f38852f';
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->requestHandler = new UpdateStatusRequestHandler($this->commandBus);
+
+        $this->commandBus->record();
+    }
+
+    /**
+     * @test
+     * @dataProvider validDataProvider
+     */
+    public function it_does_not_throw_when_given_valid_data($data, UpdateStatus $expectedCommand): void
+    {
+        $this->requestHandler->handle(
+            (new Psr7RequestBuilder())
+                ->withBodyFromString(json_encode($data))
+                ->withRouteParameter('offerId', self::OFFER_ID)
+                ->build('PUT')
+        );
+        $this->assertEquals([$expectedCommand], $this->commandBus->getRecordedCommands());
+    }
+
+    public function validDataProvider(): array
+    {
+        return [
+            'type_available' => [
+                'data' => (object) [
+                    'type' => 'Available',
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(StatusType::available(), [])
+                ),
+            ],
+            'type_unavailable' => [
+                'data' => (object) [
+                    'type' => 'Unavailable',
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(StatusType::unavailable(), [])
+                ),
+            ],
+            'type_temporarily_unavailable' => [
+                'data' => (object) [
+                    'type' => 'TemporarilyUnavailable',
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(StatusType::temporarilyUnavailable(), [])
+                ),
+            ],
+            'type_available_with_reason' => [
+                'data' => (object) [
+                    'type' => 'Available',
+                    'reason' => [
+                        'nl' => 'Corona',
+                        'en' => 'Covid',
+                    ],
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(
+                        StatusType::available(),
+                        [
+                            new StatusReason(new Language('nl'), 'Corona'),
+                            new StatusReason(new Language('en'), 'Covid'),
+                        ]
+                    )
+                ),
+            ],
+            'type_unavailable_with_reason' => [
+                'data' => (object) [
+                    'type' => 'Unavailable',
+                    'reason' => [
+                        'nl' => 'Corona',
+                        'en' => 'Covid',
+                    ],
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(
+                        StatusType::unavailable(),
+                        [
+                            new StatusReason(new Language('nl'), 'Corona'),
+                            new StatusReason(new Language('en'), 'Covid'),
+                        ]
+                    )
+                ),
+            ],
+            'type_temporarily_unavailable_with_reason' => [
+                'data' => (object) [
+                    'type' => 'TemporarilyUnavailable',
+                    'reason' => [
+                        'nl' => 'Corona',
+                        'en' => 'Covid',
+                    ],
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(
+                        StatusType::temporarilyUnavailable(),
+                        [
+                            new StatusReason(new Language('nl'), 'Corona'),
+                            new StatusReason(new Language('en'), 'Covid'),
+                        ]
+                    )
+                ),
+            ],
+            'unknown_language_code' => [
+                'data' => (object) [
+                    'type' => 'Unavailable',
+                    'reason' => [
+                        'nl' => 'Corona',
+                        'en' => 'Covid',
+                        'foo' => 'bar',
+                    ],
+                ],
+                'expected_command' => new UpdateStatus(
+                    self::OFFER_ID,
+                    new Status(
+                        StatusType::unavailable(),
+                        [
+                            new StatusReason(new Language('nl'), 'Corona'),
+                            new StatusReason(new Language('en'), 'Covid'),
+                        ]
+                    )
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDataProvider
+     */
+    public function it_throws_an_api_problem_when_given_invalid_data($data, array $expectedSchemaErrors): void
+    {
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(...$expectedSchemaErrors),
+            fn () => $this->requestHandler->handle(
+                (new Psr7RequestBuilder())
+                    ->withBodyFromString(json_encode($data))
+                    ->withRouteParameter('offerId', self::OFFER_ID)
+                    ->build('PUT')
+            )
+        );
+
+        $this->assertEquals([], $this->commandBus->getRecordedCommands());
+    }
+
+    public function invalidDataProvider(): array
+    {
+        return [
+            'not_an_object' => [
+                'data' => [],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/', 'The data (array) must match the type: object'),
+                ],
+            ],
+            'missing_type' => [
+                'data' => (object) [],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/', 'The required properties (type) are missing'),
+                ],
+            ],
+            'invalid_type' => [
+                'data' => (object) [
+                    'type' => 'foo'
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/type', 'The data should match one item from enum'),
+                ],
+            ],
+            'invalid_reason_type' => [
+                'data' => (object) [
+                    'type' => 'Available',
+                    'reason' => 'foo',
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/reason', 'The data (string) must match the type: object'),
+                ],
+            ],
+            'invalid_reason_value_type' => [
+                'data' => (object) [
+                    'type' => 'Available',
+                    'reason' => (object) ['nl' => 123],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/reason/nl', 'The data (integer) must match the type: string'),
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Http/Request/Psr7RequestBuilder.php
+++ b/tests/Http/Request/Psr7RequestBuilder.php
@@ -25,6 +25,8 @@ final class Psr7RequestBuilder
 
     private ?StreamInterface $body = null;
 
+    private array $routeParameters = [];
+
     public function withUriFromString(string $uri): self
     {
         $c = clone $this;
@@ -49,16 +51,25 @@ final class Psr7RequestBuilder
         return $c;
     }
 
+    public function withRouteParameter(string $parameterName, string $parameterValue): self
+    {
+        $c = clone $this;
+        $c->routeParameters[$parameterName] = $parameterValue;
+        return $c;
+    }
+
     public function build(string $method): ServerRequestInterface
     {
-        return new Request(
-            $method,
-            $this->uri ?? self::getUriFactory()->createUri(),
-            $this->headers ?? new Headers(),
-            [],
-            [],
-            $this->body ?? self::getStreamFactory()->createStream()
-        );
+        return (
+            new Request(
+                $method,
+                $this->uri ?? self::getUriFactory()->createUri(),
+                $this->headers ?? new Headers(),
+                [],
+                [],
+                $this->body ?? self::getStreamFactory()->createStream()
+            )
+        )->withAttribute('_route_params', $this->routeParameters);
     }
 
     private static function getUriFactory(): UriFactory

--- a/tests/Http/Request/RouteParametersTest.php
+++ b/tests/Http/Request/RouteParametersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RouteParametersTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_return_an_existing_route_parameter_from_the_request_as_string(): void
+    {
+        $request = (new Psr7RequestBuilder())->build('PUT');
+        $request = $request->withAttribute('_route_params', ['foo' => 'bar']);
+        $routeParameters = new RouteParameters($request);
+
+        $this->assertEquals('bar', $routeParameters->get('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_a_runtime_exception_if_a_parameter_is_requested_that_is_not_set(): void
+    {
+        $request = (new Psr7RequestBuilder())->build('PUT');
+        $request = $request->withAttribute('_route_params', []);
+        $routeParameters = new RouteParameters($request);
+
+        $this->expectException(RuntimeException::class);
+        $routeParameters->get('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_a_runtime_exception_if_a_parameter_is_requested_and_none_are_set(): void
+    {
+        $request = (new Psr7RequestBuilder())->build('PUT');
+        $routeParameters = new RouteParameters($request);
+
+        $this->expectException(RuntimeException::class);
+        $routeParameters->get('foo');
+    }
+}


### PR DESCRIPTION
### Added

- `RequestHandler` interface
- `RouteParameters` class to get route parameters from `ServerRequestInterface` instead of `handle()` method arguments

### Changed

- Implemented `RequestHandler` on `UpdateStatusRequestHandler`
- Implemented `RequestHandler` on `UpdateBookingAvailabilityRequestHandler`
- Implemented `RequestHandler` on `UpdateSubEventsRequestHandler`
- Used JSON schema validation in `UpdateStatusRequestHandler`
- Moved registration of shared offer routes from Event- and PlaceControllerProvider to OfferControllerProvider

---
Ticket: https://jira.uitdatabank.be/browse/III-4168 (as preparation for new request handler for calendar endpoint)
