### PR TITLE
III-4168 fix $ref in schemas

### DIFF
--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Request\Body;
 
 use InvalidArgumentException;
-use Opis\JsonSchema\Parsers\SchemaParser;
 use Opis\JsonSchema\Resolvers\SchemaResolver;
-use Opis\JsonSchema\SchemaLoader;
 use Opis\JsonSchema\Uri;
 use Opis\JsonSchema\Validator;
 use ReflectionClass;

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -39,12 +39,6 @@ final class JsonSchemaLocator
         return $resolver;
     }
 
-    public static function createValidator(int $maxErrors = 1): Validator
-    {
-        $loader = new SchemaLoader(new SchemaParser(), self::createSchemaResolver());
-        return new Validator($loader, $maxErrors);
-    }
-
     public static function createSchemaUri(string $schemaFileName): Uri
     {
         // Prevent usages of hardcoded strings so we can easily refactor the file locations later if they ever change.

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -23,7 +23,8 @@ final class JsonSchemaLocator
         if (!is_dir($schemaDirectory)) {
             throw new InvalidArgumentException($schemaDirectory . ' could not be found or is not a directory.');
         }
-        self::$schemaDirectory = rtrim($schemaDirectory, '/');
+        // Use realpath() to resolve symbolic directories like ".." and ".", which is needed for the validator to work.
+        self::$schemaDirectory = realpath($schemaDirectory);
     }
 
     public static function loadSchema(string $schemaFileName): string

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -32,11 +32,16 @@ final class JsonSchemaLocator
         self::$schemaDirectory = realpath($schemaDirectory);
     }
 
-    public static function createValidator(int $maxErrors = 1): Validator
+    public static function createSchemaResolver(): SchemaResolver
     {
         $resolver = new SchemaResolver();
         $resolver->registerPrefix(self::getSchemaDirectoryUri(), self::getSchemaDirectory());
-        $loader = new SchemaLoader(new SchemaParser(), $resolver);
+        return $resolver;
+    }
+
+    public static function createValidator(int $maxErrors = 1): Validator
+    {
+        $loader = new SchemaLoader(new SchemaParser(), self::createSchemaResolver());
         return new Validator($loader, $maxErrors);
     }
 

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Request\Body;
 use InvalidArgumentException;
 use Opis\JsonSchema\Resolvers\SchemaResolver;
 use Opis\JsonSchema\Uri;
-use Opis\JsonSchema\Validator;
 use ReflectionClass;
 use RuntimeException;
 

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Request\Body;
 
 use InvalidArgumentException;
+use Opis\JsonSchema\Parsers\SchemaParser;
+use Opis\JsonSchema\Resolvers\SchemaResolver;
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Validator;
 use ReflectionClass;
 use RuntimeException;
 
@@ -55,6 +59,29 @@ final class JsonSchemaLocator
         }
 
         return $schema;
+    }
+
+    public static function createValidator(int $maxErrors = 1): Validator
+    {
+        $resolver = new SchemaResolver();
+        $resolver->registerPrefix(self::getSchemaDirectoryUri(), self::getSchemaDirectory());
+        $loader = new SchemaLoader(new SchemaParser(), $resolver);
+        return new Validator($loader, $maxErrors);
+    }
+
+    private static function getSchemaDirectory(): string
+    {
+        if (self::$schemaDirectory === null) {
+            throw new RuntimeException(
+                'JsonSchemaLocator::setSchemaDirectory() should have been called at least once first.'
+            );
+        }
+        return self::$schemaDirectory;
+    }
+
+    private static function getSchemaDirectoryUri(): string
+    {
+        return 'file://' . self::getSchemaDirectory() . '/';
     }
 
     private static function getConstants(): array

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Opis\JsonSchema\Parsers\SchemaParser;
 use Opis\JsonSchema\Resolvers\SchemaResolver;
 use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Uri;
 use Opis\JsonSchema\Validator;
 use ReflectionClass;
 use RuntimeException;
@@ -67,6 +68,24 @@ final class JsonSchemaLocator
         $resolver->registerPrefix(self::getSchemaDirectoryUri(), self::getSchemaDirectory());
         $loader = new SchemaLoader(new SchemaParser(), $resolver);
         return new Validator($loader, $maxErrors);
+    }
+
+    public static function createSchemaUri(string $schemaFileName): Uri
+    {
+        // Prevent usages of hardcoded strings so we can easily refactor the file locations later if they ever change.
+        if (!in_array($schemaFileName, self::getConstants(), true)) {
+            throw new InvalidArgumentException(
+                $schemaFileName . ' is not in the list of known schema files, please use a predefined constant on the JsonSchemaLocator class (or add one).'
+            );
+        }
+
+        $schemaFileName = ltrim($schemaFileName, '/');
+        $schemaFileLocation = self::getSchemaDirectory() . '/' . $schemaFileName;
+        if (!is_file($schemaFileLocation)) {
+            throw new RuntimeException($schemaFileLocation . ' is not a file.');
+        }
+
+        return Uri::create(self::getSchemaDirectoryUri() . $schemaFileName);
     }
 
     private static function getSchemaDirectory(): string

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -32,36 +32,6 @@ final class JsonSchemaLocator
         self::$schemaDirectory = realpath($schemaDirectory);
     }
 
-    public static function loadSchema(string $schemaFileName): string
-    {
-        if (self::$schemaDirectory === null) {
-            throw new RuntimeException(
-                'JsonSchemaLocator::setSchemaDirectory() should be called at least once before calling getSchema().'
-            );
-        }
-
-        // Prevent usages of hardcoded strings so we can easily refactor the file locations later if they ever change.
-        if (!in_array($schemaFileName, self::getConstants(), true)) {
-            throw new InvalidArgumentException(
-                $schemaFileName . ' is not in the list of known schema files, please use a predefined constant on the JsonSchemaLocator class (or add one).'
-            );
-        }
-
-        $schemaFileLocation = self::$schemaDirectory . '/' . ltrim($schemaFileName, '/');
-        if (!is_file($schemaFileLocation)) {
-            throw new RuntimeException($schemaFileLocation . ' is not a file.');
-        }
-
-        $schema = file_get_contents($schemaFileLocation);
-        if ($schema === false) {
-            throw new RuntimeException(
-                'Could not read ' . $schemaFileLocation
-            );
-        }
-
-        return $schema;
-    }
-
     public static function createValidator(int $maxErrors = 1): Validator
     {
         $resolver = new SchemaResolver();

--- a/src/Http/Request/Body/JsonSchemaValidatingRequestBodyParser.php
+++ b/src/Http/Request/Body/JsonSchemaValidatingRequestBodyParser.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
+use Opis\Uri\Uri;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
@@ -16,12 +17,12 @@ final class JsonSchemaValidatingRequestBodyParser implements RequestBodyParser
     private const MAX_ERRORS = 100;
 
     private Validator $validator;
-    private string $jsonSchema;
+    private Uri $jsonSchema;
 
-    public function __construct(string $jsonSchema)
+    private function __construct(Validator $validator, Uri $jsonSchema)
     {
         $this->jsonSchema = $jsonSchema;
-        $this->validator = new Validator(null, self::MAX_ERRORS);
+        $this->validator = $validator;
     }
 
     /**
@@ -30,7 +31,10 @@ final class JsonSchemaValidatingRequestBodyParser implements RequestBodyParser
      */
     public static function fromFile(string $jsonSchemaLocatorFile): self
     {
-        return new self(JsonSchemaLocator::loadSchema($jsonSchemaLocatorFile));
+        return new self(
+            JsonSchemaLocator::createValidator(self::MAX_ERRORS),
+            JsonSchemaLocator::createSchemaUri($jsonSchemaLocatorFile)
+        );
     }
 
     public function parse(ServerRequestInterface $request): ServerRequestInterface

--- a/tests/Http/Request/Body/JsonSchemaLocatorTest.php
+++ b/tests/Http/Request/Body/JsonSchemaLocatorTest.php
@@ -15,15 +15,14 @@ class JsonSchemaLocatorTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_validator_with_a_resolver_for_the_previously_set_schema_directory(): void
+    public function it_returns_a_resolver_for_the_previously_set_schema_directory(): void
     {
         $directory = realpath(__DIR__ . '/../../../../vendor/publiq/stoplight-docs-uitdatabank/models');
 
         $expectedResolver = new SchemaResolver();
         $expectedResolver->registerPrefix('file://' . $directory . '/', $directory);
 
-        $validator = JsonSchemaLocator::createValidator(100);
-        $actualResolver = $validator->resolver();
+        $actualResolver = JsonSchemaLocator::createSchemaResolver();
 
         $this->assertEquals($expectedResolver, $actualResolver);
     }


### PR DESCRIPTION
### Changed

- Load JSON schemas via URI, by configuring a resolver on the `Validator`

### Fixed

- Resolving of `$ref` in JSON schema validation

---
Ticket: https://jira.uitdatabank.be/browse/III-4168

I noticed this while working with `$ref` in the changes to make the calendar endpoint work with JSON schema validation. So the next PR will better cover this with tests, when I add tests for the JSON schema validation of that endpoint.
