### PR TITLE
III-4168 Use associative arrays in request handlers

### DIFF
--- a/src/Http/Event/UpdateSubEventsRequestHandler.php
+++ b/src/Http/Event/UpdateSubEventsRequestHandler.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Event\ValueObjects\Status;
 use CultuurNet\UDB3\Event\ValueObjects\StatusReason;
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Event\ValueObjects\SubEventUpdate;
-use CultuurNet\UDB3\Http\Request\Body\AssociativeArrayRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
@@ -35,8 +34,7 @@ class UpdateSubEventsRequestHandler implements RequestHandler
         $this->commandBus = $commandBus;
 
         $this->updateSubEventsParser = RequestBodyParserFactory::createBaseParser(
-            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::EVENT_SUB_EVENT_PATCH),
-            new AssociativeArrayRequestBodyParser()
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::EVENT_SUB_EVENT_PATCH)
         );
     }
 

--- a/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
+++ b/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\Body\AssociativeArrayRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
@@ -30,7 +31,8 @@ final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
     ) {
         $this->commandBus = $commandBus;
         $this->parser = RequestBodyParserFactory::createBaseParser(
-            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY)
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY),
+            new AssociativeArrayRequestBodyParser()
         );
     }
 
@@ -39,13 +41,13 @@ final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
         $routeParameters = new RouteParameters($request);
         $offerId = $routeParameters->get('offerId');
 
-        $data = (object) $this->parser->parse($request)->getParsedBody();
+        $data = $this->parser->parse($request)->getParsedBody();
 
         try {
             $this->commandBus->dispatch(
                 new UpdateBookingAvailability(
                     $offerId,
-                    new BookingAvailability(BookingAvailabilityType::fromNative($data->type))
+                    new BookingAvailability(BookingAvailabilityType::fromNative($data['type']))
                 )
             );
         } catch (CalendarTypeNotSupported $exception) {

--- a/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
+++ b/src/Http/Offer/UpdateBookingAvailabilityRequestHandler.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Http\Request\Body\AssociativeArrayRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
@@ -31,8 +30,7 @@ final class UpdateBookingAvailabilityRequestHandler implements RequestHandler
     ) {
         $this->commandBus = $commandBus;
         $this->parser = RequestBodyParserFactory::createBaseParser(
-            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY),
-            new AssociativeArrayRequestBodyParser()
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_BOOKING_AVAILABILITY)
         );
     }
 

--- a/src/Http/Offer/UpdateStatusRequestHandler.php
+++ b/src/Http/Offer/UpdateStatusRequestHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Http\Request\Body\AssociativeArrayRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
@@ -31,8 +30,7 @@ class UpdateStatusRequestHandler implements RequestHandler
     {
         $this->commandBus = $commandBus;
         $this->parser = RequestBodyParserFactory::createBaseParser(
-            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_STATUS),
-            new AssociativeArrayRequestBodyParser()
+            JsonSchemaValidatingRequestBodyParser::fromFile(JsonSchemaLocator::OFFER_STATUS)
         );
     }
 

--- a/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
+++ b/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request\Body;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AssociativeArrayRequestBodyParser implements RequestBodyParser
+{
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        return $request->withParsedBody(
+            $this->convertToAssociativeArray(
+                $request->getParsedBody()
+            )
+        );
+    }
+
+    /**
+     * Converts any objects inside the data to associative arrays, including $data itself.
+     *
+     * If $data is a string, integer, boolean, null etc it will just be returned.
+     * If $data is an array, the function will loop over all entries and call itself on the values.
+     * If $data is an object, it will be cast to an array first and then the function will handle it like arrays.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    private function convertToAssociativeArray($data)
+    {
+        if (!is_array($data) && !is_object($data)) {
+            return $data;
+        }
+        $data = (array) $data;
+        foreach ($data as $key => $value) {
+            $data[$key] = $this->convertToAssociativeArray($value);
+        }
+        return $data;
+    }
+}

--- a/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
+++ b/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
@@ -27,8 +27,6 @@ final class AssociativeArrayRequestBodyParser implements RequestBodyParser
      * If $data is an array, the function will loop over all entries and call itself on the values.
      * If $data is an object, it will be cast to an array first and then the function will handle it like arrays.
      *
-     * @param mixed $data
-     * @return mixed
      */
     private function convertToAssociativeArray($data)
     {

--- a/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
+++ b/src/Http/Request/Body/AssociativeArrayRequestBodyParser.php
@@ -6,6 +6,9 @@ namespace CultuurNet\UDB3\Http\Request\Body;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Converts any objects inside the parsed body on the request to associative arrays.
+ */
 final class AssociativeArrayRequestBodyParser implements RequestBodyParser
 {
     public function parse(ServerRequestInterface $request): ServerRequestInterface

--- a/src/Http/Request/Body/RequestBodyParserFactory.php
+++ b/src/Http/Request/Body/RequestBodyParserFactory.php
@@ -15,6 +15,8 @@ final class RequestBodyParserFactory
      */
     public static function createBaseParser(RequestBodyParser ...$customParsers): RequestBodyParser
     {
+        $customParsers[] = new AssociativeArrayRequestBodyParser();
+
         return new CombinedRequestBodyParser(
             new JsonRequestBodyParser(),
             ...$customParsers


### PR DESCRIPTION
### Changed

- Parsed body is now associative arrays instead of objects (after validation), so we can use the existing denormalization/deserialization/etc logic to convert the JSON to value objects

---
Ticket: https://jira.uitdatabank.be/browse/III-4168
