### PR TITLE
Add export count query logging

### DIFF
--- a/app/Export/ExportServiceProvider.php
+++ b/app/Export/ExportServiceProvider.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Search\SearchServiceInterface;
 use CultuurNet\UDB3\Silex\Error\LoggerFactory;
 use CultuurNet\UDB3\Silex\Error\LoggerName;
 use CultuurNet\UDB3\Silex\Search\Sapi3SearchServiceProvider;
+use Psr\Log\LoggerAwareInterface;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Twig_Environment;
@@ -103,6 +104,12 @@ class ExportServiceProvider implements ServiceProviderInterface
         Application $app,
         SearchServiceInterface $searchService
     ): EventExportServiceInterface {
+        $logger = LoggerFactory::create($app, LoggerName::forResqueWorker('event-export'));
+        if ($searchService instanceof LoggerAwareInterface) {
+            $searchService = clone $searchService;
+            $searchService->setLogger($logger);
+        }
+
         return new EventExportService(
             $app['external_event_service'],
             $searchService,

--- a/src/Search/Sapi3SearchService.php
+++ b/src/Search/Sapi3SearchService.php
@@ -88,7 +88,7 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
             ->getBody()
             ->getContents();
 
-        $this->logger->debug('Send SAPI3 request with the following parameters: ' . json_encode($queryParameters));
+        $this->logger->debug('Sent SAPI3 request with the following parameters: ' . json_encode($queryParameters));
         $this->logger->debug('Response data: ' . $searchResponseData);
 
         $searchResponseData = json_decode($searchResponseData);


### PR DESCRIPTION
### Added

- Added logger to search service used for exports. It already got one via `ResultsGenerator`, but too late in the flow to debug the issue with the count that happens before the actual export.
