### PR TITLE
III-4099 Allow any CORS origin

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -126,10 +126,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Http\HttpServiceProvider());
 $app->register(new Silex\Provider\ServiceControllerServiceProvider());
 $app->register(new \CultuurNet\UDB3\Silex\CommandHandling\CommandBusServiceProvider());
 
-$app->register(new CorsServiceProvider(), array(
-    "cors.allowOrigin" => implode(" ", $app['config']['cors']['origins']),
-    "cors.allowCredentials" => true
-));
+$app->register(new CorsServiceProvider());
 
 $app['local_domain'] = \ValueObjects\Web\Domain::specifyType(
     parse_url($app['config']['url'])['host']

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -12,8 +12,6 @@ uitid:
 search:
   base_url: http://www.uitid.be/uitid/rest/searchv2
 sync_with_udb2: true
-cors:
-  origins: []
 log.search: []
 database:
   driver: pdo_mysql


### PR DESCRIPTION
### Changed

- Any CORS origin is now allowed (if we don't specify any allowed origins, the package we use allows every origin)

### Removed

- OPTIONS responses no longer have a `Access-Control-Allow-Credentials: true` header (which would allow the browser to send cookies via CORS requests which we don't use nor want)

---
Ticket: https://jira.uitdatabank.be/browse/III-4099
