### PR TITLE
III-4087 Add client name to history projection

### DIFF
--- a/app/CommandHandling/ContextFactory.php
+++ b/app/CommandHandling/ContextFactory.php
@@ -36,6 +36,10 @@ final class ContextFactory
             $contextValues['auth_api_client_id'] = $jwt->getClientId();
         }
 
+        if ($jwt && $jwt->getClientName()) {
+            $contextValues['auth_api_client_name'] = $jwt->getClientName();
+        }
+
         if ($apiKey) {
             $contextValues['auth_api_key'] = $apiKey;
         }

--- a/src/History/Log.php
+++ b/src/History/Log.php
@@ -44,6 +44,11 @@ class Log implements JsonSerializable
     /**
      * @var string
      */
+    private $auth0ClientName;
+
+    /**
+     * @var string
+     */
     private $api;
 
     /**
@@ -58,6 +63,7 @@ class Log implements JsonSerializable
         string $author = null,
         string $apiKey = null,
         string $auth0ClientId = null,
+        string $auth0ClientName = null,
         string $api = null,
         string $consumerName = null
     ) {
@@ -67,6 +73,7 @@ class Log implements JsonSerializable
         $this->author = $author;
         $this->apiKey = $apiKey;
         $this->auth0ClientId = $auth0ClientId;
+        $this->auth0ClientName = $auth0ClientName;
         $this->api = $api;
         $this->consumerName = $consumerName;
     }
@@ -119,6 +126,10 @@ class Log implements JsonSerializable
             $log['auth0ClientId'] = $this->auth0ClientId;
         }
 
+        if ($this->auth0ClientName) {
+            $log['auth0ClientName'] = $this->auth0ClientName;
+        }
+
         if ($this->api) {
             $log['api'] = $this->api;
         }
@@ -150,6 +161,7 @@ class Log implements JsonSerializable
         $author = $metadata['user_id'] ?? null;
         $apiKey = $metadata['auth_api_key'] ?? null;
         $auth0ClientId = $metadata['auth_api_client_id'] ?? null;
+        $auth0ClientName = $metadata['auth_api_client_name'] ?? null;
         $api = $metadata['api'] ?? null;
         $consumer = $metadata['consumer']['name'] ?? null;
 
@@ -159,6 +171,6 @@ class Log implements JsonSerializable
             $apiKey = null;
         }
 
-        return new Log($id, $date, $description, $author, $apiKey, $auth0ClientId, $api, $consumer);
+        return new Log($id, $date, $description, $author, $apiKey, $auth0ClientId, $auth0ClientName, $api, $consumer);
     }
 }

--- a/src/History/Log.php
+++ b/src/History/Log.php
@@ -56,7 +56,7 @@ class Log implements JsonSerializable
      */
     private $consumerName;
 
-    public function __construct(
+    private function __construct(
         string $id,
         DateTime $date,
         string $description,

--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -132,6 +132,16 @@ class JsonWebToken extends AbstractToken
         return null;
     }
 
+    public function getClientName(): ?string
+    {
+        // Check first if the token has the claim, to prevent an OutOfBoundsException (thrown if the default is set to
+        // null and the claim is missing).
+        if ($this->token->hasClaim('https://publiq.be/client-name')) {
+            return (string) $this->token->getClaim('https://publiq.be/client-name');
+        }
+        return null;
+    }
+
     public function hasClaims(array $names): bool
     {
         foreach ($names as $name) {

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -261,6 +261,20 @@ class HistoryProjectorTest extends TestCase
                 'auth0ClientId',
                 'my-auth0-client-id',
             ],
+            'with auth0 client name' => [
+                new Metadata(
+                    [
+                        'user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
+                        'auth_api_client_name' => 'My Auth0 Client',
+                        'api' => 'json-api',
+                        'consumer' => [
+                            'name' => 'My super duper name',
+                        ],
+                    ]
+                ),
+                'auth0ClientName',
+                'My Auth0 Client',
+            ],
         ];
     }
 

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -235,27 +235,27 @@ class HistoryProjectorTest extends TestCase
         return [
             'with user id' => [
                 new Metadata(['user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6']),
-                ['author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6']
+                ['author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6'],
             ],
             'with api' => [
                 new Metadata(['api' => 'json-api']),
-                ['api' => 'json-api']
+                ['api' => 'json-api'],
             ],
             'with api key' => [
                 new Metadata(['auth_api_key' => 'my-super-duper-key']),
-                ['apiKey' => 'my-super-duper-key']
+                ['apiKey' => 'my-super-duper-key'],
             ],
             'with consumer name' => [
                 new Metadata(['consumer' => ['name' => 'My super duper name']]),
-                ['consumerName' => 'My super duper name']
+                ['consumerName' => 'My super duper name'],
             ],
             'with auth0 client id' => [
                 new Metadata(['auth_api_client_id' => 'my-auth0-client-id']),
-                ['auth0ClientId' => 'my-auth0-client-id']
+                ['auth0ClientId' => 'my-auth0-client-id'],
             ],
             'with auth0 client name' => [
                 new Metadata(['auth_api_client_name' => 'My Auth0 Client']),
-                ['auth0ClientName' => 'My Auth0 Client']
+                ['auth0ClientName' => 'My Auth0 Client'],
             ],
         ];
     }
@@ -299,7 +299,7 @@ class HistoryProjectorTest extends TestCase
                         'description' => 'Event aangemaakt in UiTdatabank',
                     ],
                     $expectedKeys
-                )
+                ),
             ]
         );
     }

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -233,59 +233,29 @@ class HistoryProjectorTest extends TestCase
     public function metadataProvider(): array
     {
         return [
+            'with user id' => [
+                new Metadata(['user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6']),
+                ['author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6']
+            ],
+            'with api' => [
+                new Metadata(['api' => 'json-api']),
+                ['api' => 'json-api']
+            ],
             'with api key' => [
-                new Metadata(
-                    [
-                        'user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                        'auth_api_key' => 'my-super-duper-key',
-                        'api' => 'json-api',
-                        'consumer' => [
-                            'name' => 'My super duper name',
-                        ],
-                    ]
-                ),
-                [
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                    'apiKey' => 'my-super-duper-key',
-                    'api' => 'json-api',
-                    'consumerName' => 'My super duper name',
-                ]
+                new Metadata(['auth_api_key' => 'my-super-duper-key']),
+                ['apiKey' => 'my-super-duper-key']
+            ],
+            'with consumer name' => [
+                new Metadata(['consumer' => ['name' => 'My super duper name']]),
+                ['consumerName' => 'My super duper name']
             ],
             'with auth0 client id' => [
-                new Metadata(
-                    [
-                        'user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                        'auth_api_client_id' => 'my-auth0-client-id',
-                        'api' => 'json-api',
-                        'consumer' => [
-                            'name' => 'My super duper name',
-                        ],
-                    ]
-                ),
-                [
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                    'auth0ClientId' => 'my-auth0-client-id',
-                    'api' => 'json-api',
-                    'consumerName' => 'My super duper name',
-                ]
+                new Metadata(['auth_api_client_id' => 'my-auth0-client-id']),
+                ['auth0ClientId' => 'my-auth0-client-id']
             ],
             'with auth0 client name' => [
-                new Metadata(
-                    [
-                        'user_id' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                        'auth_api_client_name' => 'My Auth0 Client',
-                        'api' => 'json-api',
-                        'consumer' => [
-                            'name' => 'My super duper name',
-                        ],
-                    ]
-                ),
-                [
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                    'auth0ClientName' => 'My Auth0 Client',
-                    'api' => 'json-api',
-                    'consumerName' => 'My super duper name',
-                ]
+                new Metadata(['auth_api_client_name' => 'My Auth0 Client']),
+                ['auth0ClientName' => 'My Auth0 Client']
             ],
         ];
     }

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -244,8 +244,12 @@ class HistoryProjectorTest extends TestCase
                         ],
                     ]
                 ),
-                'apiKey',
-                'my-super-duper-key',
+                [
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
+                    'apiKey' => 'my-super-duper-key',
+                    'api' => 'json-api',
+                    'consumerName' => 'My super duper name',
+                ]
             ],
             'with auth0 client id' => [
                 new Metadata(
@@ -258,8 +262,12 @@ class HistoryProjectorTest extends TestCase
                         ],
                     ]
                 ),
-                'auth0ClientId',
-                'my-auth0-client-id',
+                [
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
+                    'auth0ClientId' => 'my-auth0-client-id',
+                    'api' => 'json-api',
+                    'consumerName' => 'My super duper name',
+                ]
             ],
             'with auth0 client name' => [
                 new Metadata(
@@ -272,8 +280,12 @@ class HistoryProjectorTest extends TestCase
                         ],
                     ]
                 ),
-                'auth0ClientName',
-                'My Auth0 Client',
+                [
+                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
+                    'auth0ClientName' => 'My Auth0 Client',
+                    'api' => 'json-api',
+                    'consumerName' => 'My super duper name',
+                ]
             ],
         ];
     }
@@ -282,7 +294,7 @@ class HistoryProjectorTest extends TestCase
      * @test
      * @dataProvider metadataProvider
      */
-    public function it_logs_creating_an_event(Metadata $metadata, string $keyName, string $keyValue)
+    public function it_logs_creating_an_event(Metadata $metadata, array $expectedKeys)
     {
         $eventId = 'f2b227c5-4756-49f6-a25d-8286b6a2351f';
 
@@ -311,14 +323,13 @@ class HistoryProjectorTest extends TestCase
         $this->assertHistoryContainsLogs(
             $eventId,
             [
-                (object) [
-                    'date' => $now->format('c'),
-                    'author' => 'e75fa25f-18e7-4834-bb5e-6f2acaedd3c6',
-                    'description' => 'Event aangemaakt in UiTdatabank',
-                    $keyName => $keyValue,
-                    'api' => 'json-api',
-                    'consumerName' => 'My super duper name',
-                ],
+                (object) array_merge(
+                    [
+                        'date' => $now->format('c'),
+                        'description' => 'Event aangemaakt in UiTdatabank',
+                    ],
+                    $expectedKeys
+                )
             ]
         );
     }

--- a/tests/Jwt/Symfony/Authentication/JsonWebTokenTest.php
+++ b/tests/Jwt/Symfony/Authentication/JsonWebTokenTest.php
@@ -101,6 +101,30 @@ class JsonWebTokenTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_client_name_from_publiq_client_name_claim_if_present(): void
+    {
+        $jwt = JsonWebTokenFactory::createWithClaims(
+            [
+                'https://publiq.be/client-name' => 'Example',
+            ]
+        );
+
+        $this->assertEquals('Example', $jwt->getClientName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_as_client_name_if_publiq_client_name_claim_is_missing(): void
+    {
+        $jwt = JsonWebTokenFactory::createWithClaims([]);
+
+        $this->assertNull($jwt->getClientName());
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_v1_jwt_provider_token_type_if_a_uid_claim_is_present(): void
     {
         $jwt = JsonWebTokenFactory::createWithClaims(['uid' => 'mock']);


### PR DESCRIPTION
### Added

- Added `auth0ClientName` to history log projections for tokens that support it (all client & user access tokens since UID-762 has been deployed)

---
Ticket: https://jira.uitdatabank.be/browse/III-4087
