### PR TITLE
III-4148 ignore trailing slashes

### DIFF
--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -22,30 +22,30 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/', 'event_editing_controller:createEvent');
-        $controllers->get('/{cdbid}', 'event_controller:get');
-        $controllers->delete('/{cdbid}', 'event_editing_controller:deleteEvent');
+        $controllers->get('/{cdbid}/', 'event_controller:get');
+        $controllers->delete('/{cdbid}/', 'event_editing_controller:deleteEvent');
 
-        $controllers->get('/{cdbid}/history', 'event_controller:history');
+        $controllers->get('/{cdbid}/history/', 'event_controller:history');
 
-        $controllers->put('/{cdbid}/audience', 'event_editing_controller:updateAudience');
-        $controllers->put('/{cdbid}/booking-info', 'event_editing_controller:updateBookingInfo');
-        $controllers->put('/{cdbid}/contact-point', 'event_editing_controller:updateContactPoint');
-        $controllers->put('/{eventId}/major-info', UpdateMajorInfoRequestHandler::class);
-        $controllers->put('/{cdbid}/location/{locationId}', 'event_editing_controller:updateLocation');
-        $controllers->put('/{cdbid}/organizer/{organizerId}', 'event_editing_controller:updateOrganizer');
-        $controllers->delete('/{cdbid}/organizer/{organizerId}', 'event_editing_controller:deleteOrganizer');
-        $controllers->put('/{cdbid}/typical-age-range', 'event_editing_controller:updateTypicalAgeRange');
-        $controllers->delete('/{cdbid}/typical-age-range', 'event_editing_controller:deleteTypicalAgeRange');
+        $controllers->put('/{cdbid}/audience/', 'event_editing_controller:updateAudience');
+        $controllers->put('/{cdbid}/booking-info/', 'event_editing_controller:updateBookingInfo');
+        $controllers->put('/{cdbid}/contact-point/', 'event_editing_controller:updateContactPoint');
+        $controllers->put('/{eventId}/major-info/', UpdateMajorInfoRequestHandler::class);
+        $controllers->put('/{cdbid}/location/{locationId}/', 'event_editing_controller:updateLocation');
+        $controllers->put('/{cdbid}/organizer/{organizerId}/', 'event_editing_controller:updateOrganizer');
+        $controllers->delete('/{cdbid}/organizer/{organizerId}/', 'event_editing_controller:deleteOrganizer');
+        $controllers->put('/{cdbid}/typical-age-range/', 'event_editing_controller:updateTypicalAgeRange');
+        $controllers->delete('/{cdbid}/typical-age-range/', 'event_editing_controller:deleteTypicalAgeRange');
 
         $controllers->post('/{itemId}/images/', 'event_editing_controller:addImage');
-        $controllers->put('/{itemId}/images/main', 'event_editing_controller:selectMainImage');
-        $controllers->delete('/{itemId}/images/{mediaObjectId}', 'event_editing_controller:removeImage');
-        $controllers->put('/{itemId}/images/{mediaObjectId}', 'event_editing_controller:updateImage');
+        $controllers->put('/{itemId}/images/main/', 'event_editing_controller:selectMainImage');
+        $controllers->delete('/{itemId}/images/{mediaObjectId}/', 'event_editing_controller:removeImage');
+        $controllers->put('/{itemId}/images/{mediaObjectId}/', 'event_editing_controller:updateImage');
 
-        $controllers->get('/{cdbid}/calsum', 'event_controller:getCalendarSummary');
+        $controllers->get('/{cdbid}/calsum/', 'event_controller:getCalendarSummary');
 
-        $controllers->put('/{eventId}/calendar', UpdateCalendarRequestHandler::class);
-        $controllers->patch('/{eventId}/sub-events', UpdateSubEventsRequestHandler::class);
+        $controllers->put('/{eventId}/calendar/', UpdateCalendarRequestHandler::class);
+        $controllers->patch('/{eventId}/sub-events/', UpdateSubEventsRequestHandler::class);
 
         $controllers->post('/{cdbid}/copies/', 'event_editing_controller:copyEvent');
 
@@ -53,13 +53,13 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
          * Legacy routes that we need to keep for backward compatibility.
          * These routes usually used an incorrect HTTP method.
          */
-        $controllers->post('/{itemId}/images/main', 'event_editing_controller:selectMainImage');
-        $controllers->post('/{itemId}/images/{mediaObjectId}', 'event_editing_controller:updateImage');
-        $controllers->post('/{eventId}/major-info', UpdateMajorInfoRequestHandler::class);
-        $controllers->post('/{cdbid}/booking-info', 'event_editing_controller:updateBookingInfo');
-        $controllers->post('/{cdbid}/contact-point', 'event_editing_controller:updateContactPoint');
-        $controllers->post('/{cdbid}/typical-age-range', 'event_editing_controller:updateTypicalAgeRange');
-        $controllers->post('/{cdbid}/organizer', 'event_editing_controller:updateOrganizerFromJsonBody');
+        $controllers->post('/{itemId}/images/main/', 'event_editing_controller:selectMainImage');
+        $controllers->post('/{itemId}/images/{mediaObjectId}/', 'event_editing_controller:updateImage');
+        $controllers->post('/{eventId}/major-info/', UpdateMajorInfoRequestHandler::class);
+        $controllers->post('/{cdbid}/booking-info/', 'event_editing_controller:updateBookingInfo');
+        $controllers->post('/{cdbid}/contact-point/', 'event_editing_controller:updateContactPoint');
+        $controllers->post('/{cdbid}/typical-age-range/', 'event_editing_controller:updateTypicalAgeRange');
+        $controllers->post('/{cdbid}/organizer/', 'event_editing_controller:updateOrganizerFromJsonBody');
 
         return $controllers;
     }

--- a/app/Event/ProductionControllerProvider.php
+++ b/app/Event/ProductionControllerProvider.php
@@ -52,14 +52,14 @@ class ProductionControllerProvider implements ControllerProviderInterface
         $controllers = $app['controllers_factory'];
         $controllers->get('/', ProductionsSearchController::class . ':search');
         $controllers->post('/', ProductionsWriteController::class . ':create');
-        $controllers->put('/{productionId}/events/{eventId}', ProductionsWriteController::class . ':addEventToProduction');
-        $controllers->delete('/{productionId}/events/{eventId}', ProductionsWriteController::class . ':removeEventFromProduction');
-        $controllers->post('/{productionId}/merge/{fromProductionId}', ProductionsWriteController::class . ':mergeProductions');
-        $controllers->put('/{productionId}/name', ProductionsWriteController::class . ':renameProduction');
+        $controllers->put('/{productionId}/events/{eventId}/', ProductionsWriteController::class . ':addEventToProduction');
+        $controllers->delete('/{productionId}/events/{eventId}/', ProductionsWriteController::class . ':removeEventFromProduction');
+        $controllers->post('/{productionId}/merge/{fromProductionId}/', ProductionsWriteController::class . ':mergeProductions');
+        $controllers->put('/{productionId}/name/', ProductionsWriteController::class . ':renameProduction');
 
-        $controllers->post('/skip', ProductionsWriteController::class . ':skipEvents');
+        $controllers->post('/skip/', ProductionsWriteController::class . ':skipEvents');
 
-        $controllers->get('/suggestion', ProductionSuggestionController::class . ':nextSuggestion');
+        $controllers->get('/suggestion/', ProductionSuggestionController::class . ':nextSuggestion');
 
         return $controllers;
     }

--- a/app/Export/ExportControllerProvider.php
+++ b/app/Export/ExportControllerProvider.php
@@ -49,9 +49,9 @@ class ExportControllerProvider implements ControllerProviderInterface
         /** @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->post('/json', 'json_export_controller:handle');
-        $controllers->post('/ooxml', 'ooxml_export_controller:handle');
-        $controllers->post('/pdf', 'pdf_export_controller:handle');
+        $controllers->post('/json/', 'json_export_controller:handle');
+        $controllers->post('/ooxml/', 'ooxml_export_controller:handle');
+        $controllers->post('/pdf/', 'pdf_export_controller:handle');
 
         return $controllers;
     }

--- a/app/Import/ImportControllerProvider.php
+++ b/app/Import/ImportControllerProvider.php
@@ -55,13 +55,13 @@ class ImportControllerProvider implements ControllerProviderInterface
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/events/', 'event_import_controller:importWithoutId');
-        $controllers->put('/events/{cdbid}', 'event_import_controller:importWithId');
+        $controllers->put('/events/{cdbid}/', 'event_import_controller:importWithId');
 
         $controllers->post('/places/', 'place_import_controller:importWithoutId');
-        $controllers->put('/places/{cdbid}', 'place_import_controller:importWithId');
+        $controllers->put('/places/{cdbid}/', 'place_import_controller:importWithId');
 
         $controllers->post('/organizers/', 'organizer_import_controller:importWithoutId');
-        $controllers->put('/organizers/{cdbid}', 'organizer_import_controller:importWithId');
+        $controllers->put('/organizers/{cdbid}/', 'organizer_import_controller:importWithId');
 
         return $controllers;
     }

--- a/app/JSONLD/ContextControllerProvider.php
+++ b/app/JSONLD/ContextControllerProvider.php
@@ -35,7 +35,7 @@ class ContextControllerProvider implements ControllerProviderInterface
             }
         );
 
-        $controllers->get('/{entityName}', self::JSONLD_CONTEXT_CONTROLLER . ':get');
+        $controllers->get('/{entityName}/', self::JSONLD_CONTEXT_CONTROLLER . ':get');
 
         return $controllers;
     }

--- a/app/Jobs/JobsControllerProvider.php
+++ b/app/Jobs/JobsControllerProvider.php
@@ -25,7 +25,7 @@ class JobsControllerProvider implements ControllerProviderInterface
 
         /** @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
-        $controllers->get('/{jobId}', 'jobs.read_rest_controller:get');
+        $controllers->get('/{jobId}/', 'jobs.read_rest_controller:get');
 
         return $controllers;
     }

--- a/app/Labels/LabelsControllerProvider.php
+++ b/app/Labels/LabelsControllerProvider.php
@@ -56,8 +56,8 @@ class LabelsControllerProvider implements ControllerProviderInterface
      */
     private function setControllerPaths(ControllerCollection $controllers)
     {
-        $controllers->get('/{id}', self::READ_REST_CONTROLLER . ':get');
-        $controllers->patch('/{id}', self::EDIT_REST_CONTROLLER . ':patch');
+        $controllers->get('/{id}/', self::READ_REST_CONTROLLER . ':get');
+        $controllers->patch('/{id}/', self::EDIT_REST_CONTROLLER . ':patch');
         $controllers->get('/', self::READ_REST_CONTROLLER . ':search');
         $controllers->post('/', self::EDIT_REST_CONTROLLER . ':create');
 

--- a/app/LegacyRoutesServiceProvider.php
+++ b/app/LegacyRoutesServiceProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Response\ApiProblemJsonResponse;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class LegacyRoutesServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app): void
+    {
+    }
+
+    public function boot(Application $app): void
+    {
+        // NOTE: THIS CATCH-ALL ROUTE HAS TO BE REGISTERED INSIDE boot() SO THAT (DYNAMICALLY GENERATED) OPTIONS ROUTES
+        // FOR CORS GET REGISTERED FIRST BEFORE THIS ONE.
+        // Matches any path that does not match a registered route, and rewrites it using a set of predefined pattern
+        // replacements and sends an internal sub-request to try and match an existing route. If the sub-request does
+        // not return a response either an error response will be returned.
+        // This makes it possible to support old endpoint names without having to register controllers/request handlers
+        // twice. When we have a router with support for PSR-15 middlewares, we should refactor this URL rewriting to a
+        // PSR-15 middleware instead.
+        $app->match(
+            '/{path}',
+            function (Request $originalRequest, string $path) use ($app) {
+                $rewrites = [
+                    // Pluralize /event and /place
+                    '/^(event|place)($|\/.*)/' => '${1}s${2}',
+
+                    // Convert known legacy camelCase resource/collection names to kebab-case
+                    '/bookingAvailability/' => 'booking-availability',
+                    '/bookingInfo/' => 'booking-info',
+                    '/cardSystems/' => 'card-systems',
+                    '/contactPoint/' => 'contact-point',
+                    '/distributionKey/' => 'distribution-key',
+                    '/majorInfo/' => 'major-info',
+                    '/priceInfo/' => 'price-info',
+                    '/subEvents/' => 'sub-events',
+                    '/typicalAgeRange/' => 'typical-age-range',
+
+                    // Add trailing slash if missing
+                    '/^(.*)(?<!\/)$/' => '${1}/',
+                ];
+                $rewrittenPath = preg_replace(array_keys($rewrites), array_values($rewrites), $path);
+
+                // Prevent an infinite loop by stopping if the path was not changed.
+                if (!$rewrittenPath || $rewrittenPath === $path) {
+                    return new ApiProblemJsonResponse(ApiProblem::notFound());
+                }
+
+                // Create a new Request object with the rewritten path, because it's basically impossible to overwrite
+                // the path of an existing Request object even with initialize() or duplicate(). Approach copied from
+                // https://github.com/graze/silex-trailing-slash-handler/blob/1.x/src/TrailingSlashControllerProvider.php
+                $request = Request::create(
+                    $rewrittenPath,
+                    $originalRequest->getMethod(),
+                    [],
+                    $originalRequest->cookies->all(),
+                    $originalRequest->files->all(),
+                    $originalRequest->server->all(),
+                    $originalRequest->getContent()
+                );
+                $request = $request->duplicate(
+                    $originalRequest->query->all(),
+                    $originalRequest->request->all()
+                );
+                $request->headers->replace($app['request']->headers->all());
+
+                // Handle the request with the rewritten path.
+                return $app->handle($request, HttpKernelInterface::SUB_REQUEST);
+            }
+        )->assert('path', '^.+$');
+    }
+}

--- a/app/Media/MediaControllerProvider.php
+++ b/app/Media/MediaControllerProvider.php
@@ -37,11 +37,11 @@ class MediaControllerProvider implements ControllerProviderInterface
         /* @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->post('images/', 'media_editing_controller:upload');
-        $controllers->get('images/{id}', 'media_controller:get');
+        $controllers->post('/images/', 'media_editing_controller:upload');
+        $controllers->get('/images/{id}/', 'media_controller:get');
 
         /* @deprecated */
-        $controllers->get('media/{id}', 'media_controller:get');
+        $controllers->get('/media/{id}/', 'media_controller:get');
 
         return $controllers;
     }

--- a/app/Offer/BulkLabelOfferControllerProvider.php
+++ b/app/Offer/BulkLabelOfferControllerProvider.php
@@ -41,8 +41,8 @@ class BulkLabelOfferControllerProvider implements ControllerProviderInterface
         /* @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->post('/query/labels', 'bulk_label_query_controller:handle');
-        $controllers->post('/offers/labels', 'bulk_label_selection_controller:handle');
+        $controllers->post('/query/labels/', 'bulk_label_query_controller:handle');
+        $controllers->post('/offers/labels/', 'bulk_label_selection_controller:handle');
 
         return $controllers;
     }

--- a/app/Offer/OfferControllerProvider.php
+++ b/app/Offer/OfferControllerProvider.php
@@ -45,22 +45,22 @@ class OfferControllerProvider implements ControllerProviderInterface, ServicePro
         /** @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->put('/{offerId}/status', UpdateStatusRequestHandler::class);
-        $controllers->put('/{offerId}/booking-availability', UpdateBookingAvailabilityRequestHandler::class);
+        $controllers->put('/{offerId}/status/', UpdateStatusRequestHandler::class);
+        $controllers->put('/{offerId}/booking-availability/', UpdateBookingAvailabilityRequestHandler::class);
 
-        $controllers->put('/{cdbid}/type/{typeId}', "{$controllerName}:updateType");
-        $controllers->put('/{cdbid}/theme/{themeId}', "{$controllerName}:updateTheme");
+        $controllers->put('/{cdbid}/type/{typeId}/', "{$controllerName}:updateType");
+        $controllers->put('/{cdbid}/theme/{themeId}/', "{$controllerName}:updateTheme");
         $controllers->put('/{cdbid}/facilities/', "{$controllerName}:updateFacilities");
 
-        $controllers->delete('/{cdbid}/labels/{label}', "{$controllerName}:removeLabel");
-        $controllers->put('/{cdbid}/labels/{label}', "{$controllerName}:addLabel");
+        $controllers->delete('/{cdbid}/labels/{label}/', "{$controllerName}:removeLabel");
+        $controllers->put('/{cdbid}/labels/{label}/', "{$controllerName}:addLabel");
 
-        $controllers->put('/{cdbid}/name/{lang}', "{$controllerName}:updateTitle");
-        $controllers->put('/{cdbid}/description/{lang}', "{$controllerName}:updateDescription");
-        $controllers->put('/{cdbid}/price-info', "{$controllerName}:updatePriceInfo");
-        $controllers->patch('/{cdbid}', "{$patchControllerName}:handle");
+        $controllers->put('/{cdbid}/name/{lang}/', "{$controllerName}:updateTitle");
+        $controllers->put('/{cdbid}/description/{lang}/', "{$controllerName}:updateDescription");
+        $controllers->put('/{cdbid}/price-info/', "{$controllerName}:updatePriceInfo");
+        $controllers->patch('/{cdbid}/', "{$patchControllerName}:handle");
         $controllers->get('/{offerId}/permissions/', "{$permissionsControllerName}:getPermissionsForCurrentUser");
-        $controllers->get('/{offerId}/permissions/{userId}', "{$permissionsControllerName}:getPermissionsForGivenUser");
+        $controllers->get('/{offerId}/permissions/{userId}/', "{$permissionsControllerName}:getPermissionsForGivenUser");
 
         /**
          * Legacy routes that we need to keep for backward compatibility.

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -51,58 +51,58 @@ class OrganizerControllerProvider implements ControllerProviderInterface
         $controllers->post('/', 'organizer_edit_controller:create');
 
         $controllers
-            ->get('/{cdbid}', 'organizer_controller:get')
+            ->get('/{cdbid}/', 'organizer_controller:get')
             ->bind('organizer');
 
-        $controllers->delete('/{cdbid}', 'organizer_edit_controller:delete');
+        $controllers->delete('/{cdbid}/', 'organizer_edit_controller:delete');
 
         $controllers->put(
-            '/{organizerId}/url',
+            '/{organizerId}/url/',
             'organizer_edit_controller:updateUrl'
         );
 
         $controllers->put(
-            '/{organizerId}/name',
+            '/{organizerId}/name/',
             'organizer_edit_controller:updateNameDeprecated'
         );
 
         $controllers->put(
-            '/{organizerId}/name/{lang}',
+            '/{organizerId}/name/{lang}/',
             'organizer_edit_controller:updateName'
         );
 
         $controllers->put(
-            '/{organizerId}/address',
+            '/{organizerId}/address/',
             'organizer_edit_controller:updateAddressDeprecated'
         );
 
         $controllers->put(
-            '/{organizerId}/address/{lang}',
+            '/{organizerId}/address/{lang}/',
             'organizer_edit_controller:updateAddress'
         );
 
         $controllers->delete(
-            '/{organizerId}/address',
+            '/{organizerId}/address/',
             'organizer_edit_controller:removeAddress'
         );
 
         $controllers->put(
-            '/{organizerId}/contact-point',
+            '/{organizerId}/contact-point/',
             'organizer_edit_controller:updateContactPoint'
         );
 
         $controllers->put(
-            '/{organizerId}/labels/{labelName}',
+            '/{organizerId}/labels/{labelName}/',
             'organizer_edit_controller:addLabel'
         );
 
         $controllers->delete(
-            '{organizerId}/labels/{labelName}',
+            '/{organizerId}/labels/{labelName}/',
             'organizer_edit_controller:removeLabel'
         );
 
-        $controllers->get('{offerId}/permissions/', 'organizer_permissions_controller:getPermissionsForCurrentUser');
-        $controllers->get('{offerId}/permissions/{userId}', 'organizer_permissions_controller:getPermissionsForGivenUser');
+        $controllers->get('/{offerId}/permissions/', 'organizer_permissions_controller:getPermissionsForCurrentUser');
+        $controllers->get('/{offerId}/permissions/{userId}/', 'organizer_permissions_controller:getPermissionsForGivenUser');
 
         return $controllers;
     }

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -22,42 +22,42 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/', 'place_editing_controller:createPlace');
-        $controllers->get('/{cdbid}', 'place_controller:get');
-        $controllers->delete('/{cdbid}', 'place_editing_controller:deletePlace');
+        $controllers->get('/{cdbid}/', 'place_controller:get');
+        $controllers->delete('/{cdbid}/', 'place_editing_controller:deletePlace');
 
-        $controllers->get('/{placeId}/history', 'place_history_controller:get');
+        $controllers->get('/{placeId}/history/', 'place_history_controller:get');
 
-        $controllers->put('/{cdbid}/address/{lang}', 'place_editing_controller:updateAddress');
-        $controllers->put('/{cdbid}/booking-info', 'place_editing_controller:updateBookingInfo');
-        $controllers->put('/{cdbid}/contact-point', 'place_editing_controller:updateContactPoint');
-        $controllers->put('/{placeId}/major-info', UpdateMajorInfoRequestHandler::class);
-        $controllers->put('/{cdbid}/organizer/{organizerId}', 'place_editing_controller:updateOrganizer');
-        $controllers->delete('/{cdbid}/organizer/{organizerId}', 'place_editing_controller:deleteOrganizer');
-        $controllers->delete('/{cdbid}/typical-age-range', 'place_editing_controller:deleteTypicalAgeRange');
-        $controllers->put('/{cdbid}/typical-age-range', 'place_editing_controller:updateTypicalAgeRange');
+        $controllers->put('/{cdbid}/address/{lang}/', 'place_editing_controller:updateAddress');
+        $controllers->put('/{cdbid}/booking-info/', 'place_editing_controller:updateBookingInfo');
+        $controllers->put('/{cdbid}/contact-point/', 'place_editing_controller:updateContactPoint');
+        $controllers->put('/{placeId}/major-info/', UpdateMajorInfoRequestHandler::class);
+        $controllers->put('/{cdbid}/organizer/{organizerId}/', 'place_editing_controller:updateOrganizer');
+        $controllers->delete('/{cdbid}/organizer/{organizerId}/', 'place_editing_controller:deleteOrganizer');
+        $controllers->delete('/{cdbid}/typical-age-range/', 'place_editing_controller:deleteTypicalAgeRange');
+        $controllers->put('/{cdbid}/typical-age-range/', 'place_editing_controller:updateTypicalAgeRange');
 
         $controllers->post('/{itemId}/images/', 'place_editing_controller:addImage');
-        $controllers->put('/{itemId}/images/main', 'place_editing_controller:selectMainImage');
-        $controllers->delete('/{itemId}/images/{mediaObjectId}', 'place_editing_controller:removeImage');
-        $controllers->put('/{itemId}/images/{mediaObjectId}', 'place_editing_controller:updateImage');
+        $controllers->put('/{itemId}/images/main/', 'place_editing_controller:selectMainImage');
+        $controllers->delete('/{itemId}/images/{mediaObjectId}/', 'place_editing_controller:removeImage');
+        $controllers->put('/{itemId}/images/{mediaObjectId}/', 'place_editing_controller:updateImage');
 
-        $controllers->get('/{cdbid}/calsum', 'place_controller:getCalendarSummary');
+        $controllers->get('/{cdbid}/calsum/', 'place_controller:getCalendarSummary');
 
-        $controllers->put('/{placeId}/calendar', UpdateCalendarRequestHandler::class);
+        $controllers->put('/{placeId}/calendar/', UpdateCalendarRequestHandler::class);
 
         /**
          * Legacy routes that we need to keep for backward compatibility.
          * These routes usually used an incorrect HTTP method.
          */
-        $controllers->get('/{cdbid}/events', 'place_editing_controller:getEvents');
-        $controllers->post('/{itemId}/images/main', 'place_editing_controller:selectMainImage');
-        $controllers->post('/{itemId}/images/{mediaObjectId}', 'place_editing_controller:updateImage');
-        $controllers->post('/{cdbid}/address/{lang}', 'place_editing_controller:updateAddress');
-        $controllers->post('/{cdbid}/typical-age-range', 'place_editing_controller:updateTypicalAgeRange');
-        $controllers->post('/{placeId}/major-info', UpdateMajorInfoRequestHandler::class);
-        $controllers->post('/{cdbid}/booking-info', 'place_editing_controller:updateBookingInfo');
-        $controllers->post('/{cdbid}/contact-point', 'place_editing_controller:updateContactPoint');
-        $controllers->post('/{cdbid}/organizer', 'place_editing_controller:updateOrganizerFromJsonBody');
+        $controllers->get('/{cdbid}/events/', 'place_editing_controller:getEvents');
+        $controllers->post('/{itemId}/images/main/', 'place_editing_controller:selectMainImage');
+        $controllers->post('/{itemId}/images/{mediaObjectId}/', 'place_editing_controller:updateImage');
+        $controllers->post('/{cdbid}/address/{lang}/', 'place_editing_controller:updateAddress');
+        $controllers->post('/{cdbid}/typical-age-range/', 'place_editing_controller:updateTypicalAgeRange');
+        $controllers->post('/{placeId}/major-info/', UpdateMajorInfoRequestHandler::class);
+        $controllers->post('/{cdbid}/booking-info/', 'place_editing_controller:updateBookingInfo');
+        $controllers->post('/{cdbid}/contact-point/', 'place_editing_controller:updateContactPoint');
+        $controllers->post('/{cdbid}/organizer/', 'place_editing_controller:updateOrganizerFromJsonBody');
 
         return $controllers;
     }

--- a/app/Role/RoleControllerProvider.php
+++ b/app/Role/RoleControllerProvider.php
@@ -61,11 +61,11 @@ class RoleControllerProvider implements ControllerProviderInterface
         );
 
         $controllers
-            ->get('/roles/{id}', 'role_controller:get')
+            ->get('/roles/{id}/', 'role_controller:get')
             ->bind('role');
 
         $controllers->patch(
-            '/roles/{id}',
+            '/roles/{id}/',
             'role_edit_controller:update'
         );
 
@@ -74,7 +74,7 @@ class RoleControllerProvider implements ControllerProviderInterface
             'role_edit_controller:addConstraint'
         );
         $controllers->post(
-            '/roles/{id}/constraints/{sapiVersion}',
+            '/roles/{id}/constraints/{sapiVersion}/',
             'role_edit_controller:addConstraint'
         );
 
@@ -83,7 +83,7 @@ class RoleControllerProvider implements ControllerProviderInterface
             'role_edit_controller:updateConstraint'
         );
         $controllers->put(
-            '/roles/{id}/constraints/{sapiVersion}',
+            '/roles/{id}/constraints/{sapiVersion}/',
             'role_edit_controller:updateConstraint'
         );
 
@@ -92,11 +92,11 @@ class RoleControllerProvider implements ControllerProviderInterface
             'role_edit_controller:removeConstraint'
         );
         $controllers->delete(
-            '/roles/{id}/constraints/{sapiVersion}',
+            '/roles/{id}/constraints/{sapiVersion}/',
             'role_edit_controller:removeConstraint'
         );
 
-        $controllers->delete('/roles/{id}', 'role_edit_controller:delete');
+        $controllers->delete('/roles/{id}/', 'role_edit_controller:delete');
 
         $controllers
             ->get('/permissions/', 'role_controller:getPermissions');
@@ -110,12 +110,12 @@ class RoleControllerProvider implements ControllerProviderInterface
         );
 
         $controllers->put(
-            '/roles/{roleId}/permissions/{permissionKey}',
+            '/roles/{roleId}/permissions/{permissionKey}/',
             'role_edit_controller:addPermission'
         );
 
         $controllers->delete(
-            '/roles/{roleId}/permissions/{permissionKey}',
+            '/roles/{roleId}/permissions/{permissionKey}/',
             'role_edit_controller:removePermission'
         );
 
@@ -125,22 +125,22 @@ class RoleControllerProvider implements ControllerProviderInterface
         );
 
         $controllers->put(
-            '/roles/{roleId}/labels/{labelIdentifier}',
+            '/roles/{roleId}/labels/{labelIdentifier}/',
             'role_edit_controller:addLabel'
         );
 
         $controllers->delete(
-            '/roles/{roleId}/labels/{labelIdentifier}',
+            '/roles/{roleId}/labels/{labelIdentifier}/',
             'role_edit_controller:removeLabel'
         );
 
         $controllers->put(
-            '/roles/{roleId}/users/{userId}',
+            '/roles/{roleId}/users/{userId}/',
             'role_edit_controller:addUser'
         );
 
         $controllers->delete(
-            '/roles/{roleId}/users/{userId}',
+            '/roles/{roleId}/users/{userId}/',
             'role_edit_controller:removeUser'
         );
 

--- a/app/Role/RoleControllerProvider.php
+++ b/app/Role/RoleControllerProvider.php
@@ -73,26 +73,14 @@ class RoleControllerProvider implements ControllerProviderInterface
             '/roles/{id}/constraints/',
             'role_edit_controller:addConstraint'
         );
-        $controllers->post(
-            '/roles/{id}/constraints/{sapiVersion}/',
-            'role_edit_controller:addConstraint'
-        );
 
         $controllers->put(
             '/roles/{id}/constraints/',
             'role_edit_controller:updateConstraint'
         );
-        $controllers->put(
-            '/roles/{id}/constraints/{sapiVersion}/',
-            'role_edit_controller:updateConstraint'
-        );
 
         $controllers->delete(
             '/roles/{id}/constraints/',
-            'role_edit_controller:removeConstraint'
-        );
-        $controllers->delete(
-            '/roles/{id}/constraints/{sapiVersion}/',
             'role_edit_controller:removeConstraint'
         );
 

--- a/app/SavedSearches/SavedSearchesControllerProvider.php
+++ b/app/SavedSearches/SavedSearchesControllerProvider.php
@@ -38,10 +38,10 @@ class SavedSearchesControllerProvider implements ControllerProviderInterface
         /* @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->get('/v3', 'saved_searches_read_controller:ownedByCurrentUser');
+        $controllers->get('/v3/', 'saved_searches_read_controller:ownedByCurrentUser');
 
-        $controllers->post('/v3', 'saved_searches_edit_controller:save');
-        $controllers->delete('/v3/{id}', 'saved_searches_edit_controller:delete');
+        $controllers->post('/v3/', 'saved_searches_edit_controller:save');
+        $controllers->delete('/v3/{id}/', 'saved_searches_edit_controller:delete');
 
         return $controllers;
     }

--- a/app/UiTPASService/UiTPASServiceEventControllerProvider.php
+++ b/app/UiTPASService/UiTPASServiceEventControllerProvider.php
@@ -40,7 +40,7 @@ class UiTPASServiceEventControllerProvider implements ControllerProviderInterfac
         $controllers = $app['controllers_factory'];
 
         $controllers->get(
-            '/{eventId}',
+            '/{eventId}/',
             'uitpas.event_detail_controller:get'
         )->bind(self::EVENT_DETAIL);
 
@@ -54,16 +54,16 @@ class UiTPASServiceEventControllerProvider implements ControllerProviderInterfac
             'uitpas.event_card_systems_controller:set'
         );
         $controllers->put(
-            '/{eventId}/card-systems/{cardSystemId}',
+            '/{eventId}/card-systems/{cardSystemId}/',
             'uitpas.event_card_systems_controller:add'
         );
         $controllers->put(
-            '/{eventId}/card-systems/{cardSystemId}/distribution-key/{distributionKeyId}',
+            '/{eventId}/card-systems/{cardSystemId}/distribution-key/{distributionKeyId}/',
             'uitpas.event_card_systems_controller:add'
         );
 
         $controllers->delete(
-            '/{eventId}/card-systems/{cardSystemId}',
+            '/{eventId}/card-systems/{cardSystemId}/',
             'uitpas.event_card_systems_controller:delete'
         );
 

--- a/app/User/UserControllerProvider.php
+++ b/app/User/UserControllerProvider.php
@@ -26,8 +26,8 @@ class UserControllerProvider implements ControllerProviderInterface
         /** @var ControllerCollection $controllers */
         $controllers = $app['controllers_factory'];
 
-        $controllers->get('users/emails/{emailAddress}', UserIdentityController::class . ':getByEmailAddress');
-        $controllers->get('user', UserIdentityController::class . ':getCurrentUser');
+        $controllers->get('users/emails/{emailAddress}/', UserIdentityController::class . ':getByEmailAddress');
+        $controllers->get('user/', UserIdentityController::class . ':getCurrentUser');
 
         return $controllers;
     }

--- a/web/index.php
+++ b/web/index.php
@@ -2,9 +2,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
-use CultuurNet\UDB3\Http\Response\ApiProblemJsonResponse;
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\AnyOfRequestMatcher;
 use CultuurNet\UDB3\HttpFoundation\RequestMatcher\PreflightRequestMatcher;
 use CultuurNet\UDB3\Jwt\Silex\JwtServiceProvider;
@@ -16,6 +14,7 @@ use CultuurNet\UDB3\Silex\Error\ErrorLogger;
 use CultuurNet\UDB3\Silex\Event\EventControllerProvider;
 use CultuurNet\UDB3\Silex\Http\RequestHandlerControllerServiceProvider;
 use CultuurNet\UDB3\Silex\Import\ImportControllerProvider;
+use CultuurNet\UDB3\Silex\LegacyRoutesServiceProvider;
 use CultuurNet\UDB3\Silex\Offer\OfferControllerProvider;
 use CultuurNet\UDB3\Silex\Place\PlaceControllerProvider;
 use CultuurNet\UDB3\Silex\Role\UserPermissionsServiceProvider;
@@ -27,7 +26,6 @@ use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceOrganizerControllerProvider
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 
 /** @var Application $app */
@@ -244,62 +242,7 @@ $app->mount('/uitpas/organizers', new UiTPASServiceOrganizerControllerProvider()
 
 $app->mount(ImportControllerProvider::PATH, new ImportControllerProvider());
 
-// Match any path that does not match a registered route, rewrite it using a set of predefined pattern replacements and
-// send an internal sub-request to try and match an existing route. If the sub-request does not return a response either
-// an error response will be returned.
-// This makes it possible to support old endpoint names without having to register controllers/request handlers twice.
-// When we have a router with support for PSR-15 middlewares, we should refactor this URL rewriting to a PSR-15
-// middleware instead.
-$app->match(
-    '/{path}',
-    function (Request $originalRequest, string $path) use ($app) {
-        $rewrites = [
-            // Pluralize /event and /place
-            '/^(event|place)($|\/.*)/' => '${1}s${2}',
-
-            // Convert known legacy camelCase resource/collection names to kebab-case
-            '/bookingAvailability/' => 'booking-availability',
-            '/bookingInfo/' => 'booking-info',
-            '/cardSystems/' => 'card-systems',
-            '/contactPoint/' => 'contact-point',
-            '/distributionKey/' => 'distribution-key',
-            '/majorInfo/' => 'major-info',
-            '/priceInfo/' => 'price-info',
-            '/subEvents/' => 'sub-events',
-            '/typicalAgeRange/' => 'typical-age-range',
-
-            // Add trailing slash if missing
-            '/^(.*)(?<!\/)$/' => '${1}/',
-        ];
-        $rewrittenPath = preg_replace(array_keys($rewrites), array_values($rewrites), $path);
-
-        // Prevent an infinite loop by stopping if the path was not changed.
-        if (!$rewrittenPath || $rewrittenPath === $path) {
-            return new ApiProblemJsonResponse(ApiProblem::notFound());
-        }
-
-        // Create a new Request object with the rewritten path, because it's basically impossible to overwrite the path
-        // of an existing Request object even with initialize() or duplicate(). Approach copied from
-        // https://github.com/graze/silex-trailing-slash-handler/blob/1.x/src/TrailingSlashControllerProvider.php
-        $request = Request::create(
-            $rewrittenPath,
-            $originalRequest->getMethod(),
-            [],
-            $originalRequest->cookies->all(),
-            $originalRequest->files->all(),
-            $originalRequest->server->all(),
-            $originalRequest->getContent()
-        );
-        $request = $request->duplicate(
-            $originalRequest->query->all(),
-            $originalRequest->request->all()
-        );
-        $request->headers->replace($app['request']->headers->all());
-
-        // Handle the request with the rewritten path.
-        return $app->handle($request, HttpKernelInterface::SUB_REQUEST);
-    }
-)->assert('path', '^.+$');
+$app->register(new LegacyRoutesServiceProvider());
 
 JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/stoplight-docs-uitdatabank/models');
 

--- a/web/index.php
+++ b/web/index.php
@@ -273,6 +273,9 @@ $app->match(
             '/priceInfo/' => 'price-info',
             '/subEvents/' => 'sub-events',
             '/typicalAgeRange/' => 'typical-age-range',
+
+            // Add trailing slash if missing
+            '/^(.*)(?<!\/)$/' => '${1}/',
         ];
         $rewrittenPath = preg_replace(array_keys($rewrites), array_values($rewrites), $path);
 

--- a/web/index.php
+++ b/web/index.php
@@ -229,12 +229,6 @@ $app->mount('/places', $placeOfferControllerProvider);
 $app->mount('/events', $eventControllerProvider);
 $app->mount('/events', $eventOfferControllerProvider);
 
-// Workaround to make the old POST /place(s) and POST /event(s) work (without trailing slash).
-// Those requests will not be handled by the PlaceControllerProvider and EventControllerProvider registered above,
-// because those controller providers can only handle routes under /places/ and /events/ (note the trailing slash).
-$app->post('/places', 'place_editing_controller:createPlace');
-$app->post('/events', 'event_editing_controller:createEvent');
-
 $app->mount('/organizers', new \CultuurNet\UDB3\Silex\Organizer\OrganizerControllerProvider());
 $app->mount('/', new \CultuurNet\UDB3\Silex\Media\MediaControllerProvider());
 $app->mount('/', new \CultuurNet\UDB3\Silex\Offer\BulkLabelOfferControllerProvider());


### PR DESCRIPTION
### Changed

- Routes can now be accessed with our without trailing slash, but they MUST be registered with a trailing slash for this to work! If you register a route without a trailing slash it will work without the trailing slash, but it won't work with a trailing slash.

---
Ticket: https://jira.uitdatabank.be/browse/III-4148

Note: For this to be possible the internal routes have to be registered in a consistent manner, so either all with or all without trailing slash. I had to pick trailing slash, because if you do for example `$app->mount('/places', new PlaceControllerProvider())` and then `$app->post('/', function () { ... });` in that mounted controller provider, the `POST` is registered as `POST /places/` (so with trailing slash). And there is now way to do something like `$app->post('', function () { ... })` (no path).

This behavior is consistent with the logic that `/example` CAN be `/example/`, but it's not necessarily always the same. For example `/file.html` is not the same as `/file.html/`. So in some cases the route without trailing slash is the same as the route with trailing slash, unless you register it without trailing slash. Then it's only accessible without trailing slash.

See also https://github.com/silexphp/Silex/issues/149
