### PR TITLE
III-4246 Refactor get place details endpoint

### DIFF
--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Event;
 
 use CultuurNet\UDB3\Http\Event\EditEventRestController;
-use CultuurNet\UDB3\Http\Event\EventDetailRequestHandler;
+use CultuurNet\UDB3\Http\Event\GetEventDetailRequestHandler;
 use CultuurNet\UDB3\Http\Event\ReadEventRestController;
 use CultuurNet\UDB3\Http\Event\UpdateCalendarRequestHandler;
 use CultuurNet\UDB3\Http\Event\UpdateMajorInfoRequestHandler;
@@ -23,7 +23,7 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/', 'event_editing_controller:createEvent');
-        $controllers->get('/{eventId}/', EventDetailRequestHandler::class);
+        $controllers->get('/{eventId}/', GetEventDetailRequestHandler::class);
         $controllers->delete('/{cdbid}/', 'event_editing_controller:deleteEvent');
 
         $controllers->get('/{cdbid}/history/', 'event_controller:history');
@@ -67,9 +67,9 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
 
     public function register(Application $app): void
     {
-        $app[EventDetailRequestHandler::class] = $app->share(
+        $app[GetEventDetailRequestHandler::class] = $app->share(
             function (Application $app) {
-                return new EventDetailRequestHandler($app['event_jsonld_repository']);
+                return new GetEventDetailRequestHandler($app['event_jsonld_repository']);
             }
         );
 

--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Event;
 
 use CultuurNet\UDB3\Http\Event\EditEventRestController;
+use CultuurNet\UDB3\Http\Event\EventDetailRequestHandler;
 use CultuurNet\UDB3\Http\Event\ReadEventRestController;
 use CultuurNet\UDB3\Http\Event\UpdateCalendarRequestHandler;
 use CultuurNet\UDB3\Http\Event\UpdateMajorInfoRequestHandler;
@@ -22,7 +23,7 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/', 'event_editing_controller:createEvent');
-        $controllers->get('/{cdbid}/', 'event_controller:get');
+        $controllers->get('/{eventId}/', EventDetailRequestHandler::class);
         $controllers->delete('/{cdbid}/', 'event_editing_controller:deleteEvent');
 
         $controllers->get('/{cdbid}/history/', 'event_controller:history');
@@ -66,6 +67,12 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
 
     public function register(Application $app): void
     {
+        $app[EventDetailRequestHandler::class] = $app->share(
+            function (Application $app) {
+                return new EventDetailRequestHandler($app['event_jsonld_repository']);
+            }
+        );
+
         $app['event_controller'] = $app->share(
             function (Application $app) {
                 return new ReadEventRestController(

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Place;
 
+use CultuurNet\UDB3\Http\Place\GetPlaceDetailRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler;
 use CultuurNet\UDB3\Http\Place\EditPlaceRestController;
 use CultuurNet\UDB3\Http\Place\HistoryPlaceRestController;
@@ -22,7 +23,7 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers = $app['controllers_factory'];
 
         $controllers->post('/', 'place_editing_controller:createPlace');
-        $controllers->get('/{cdbid}/', 'place_controller:get');
+        $controllers->get('/{placeId}/', GetPlaceDetailRequestHandler::class);
         $controllers->delete('/{cdbid}/', 'place_editing_controller:deletePlace');
 
         $controllers->get('/{placeId}/history/', 'place_history_controller:get');
@@ -64,6 +65,10 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
 
     public function register(Application $app): void
     {
+        $app[GetPlaceDetailRequestHandler::class] = $app->share(
+            fn (Application $app) => new GetPlaceDetailRequestHandler($app['place_jsonld_repository'])
+        );
+
         $app['place_controller'] = $app->share(
             function (Application $app) {
                 return new ReadPlaceRestController($app['place_jsonld_repository']);

--- a/src/Http/Event/EventDetailRequestHandler.php
+++ b/src/Http/Event/EventDetailRequestHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Event;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\QueryParameters;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\JsonLdResponse;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EventDetailRequestHandler implements RequestHandlerInterface
+{
+    private DocumentRepository $documentRepository;
+
+    public function __construct(DocumentRepository $documentRepository)
+    {
+        $this->documentRepository = $documentRepository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $eventId = $routeParameters->get('eventId');
+        $queryParameters = new QueryParameters($request);
+        $includeMetadata = $queryParameters->getAsBoolean('includeMetadata');
+
+        try {
+            $eventDocument = $this->documentRepository->fetch($eventId, $includeMetadata);
+        } catch (DocumentDoesNotExist $e) {
+            throw ApiProblem::notFound(
+                'The event with id "' . $eventId . '" was not found.'
+            );
+        }
+
+        return new JsonLdResponse($eventDocument->getAssocBody());
+    }
+}

--- a/src/Http/Event/GetEventDetailRequestHandler.php
+++ b/src/Http/Event/GetEventDetailRequestHandler.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-final class EventDetailRequestHandler implements RequestHandlerInterface
+final class GetEventDetailRequestHandler implements RequestHandlerInterface
 {
     private DocumentRepository $documentRepository;
 

--- a/src/Http/Event/ReadEventRestController.php
+++ b/src/Http/Event/ReadEventRestController.php
@@ -8,7 +8,6 @@ use CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter;
 use CultuurNet\CalendarSummaryV3\CalendarPlainTextFormatter;
 use CultuurNet\CalendarSummaryV3\Offer\Offer;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
@@ -44,20 +43,6 @@ class ReadEventRestController
         $this->jsonRepository = $jsonRepository;
         $this->historyRepository = $historyRepository;
         $this->userIsGodUser = $userIsGodUser;
-    }
-
-    public function get(string $cdbid, Request $request): JsonResponse
-    {
-        $includeMetadata = (bool) $request->query->get('includeMetadata', false);
-
-        $event = $this->fetchEventJson($cdbid, $includeMetadata);
-
-        $response = JsonLdResponse::create()
-            ->setContent($event->getRawBody());
-
-        $response->headers->set('Vary', 'Origin');
-
-        return $response;
     }
 
     public function history(string $cdbid): JsonResponse

--- a/src/Http/Place/GetPlaceDetailRequestHandler.php
+++ b/src/Http/Place/GetPlaceDetailRequestHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Place;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\QueryParameters;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\JsonLdResponse;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class GetPlaceDetailRequestHandler implements RequestHandlerInterface
+{
+    private DocumentRepository $documentRepository;
+
+    public function __construct(DocumentRepository $documentRepository)
+    {
+        $this->documentRepository = $documentRepository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $placeId = $routeParameters->get('placeId');
+        $queryParameters = new QueryParameters($request);
+        $includeMetadata = $queryParameters->getAsBoolean('includeMetadata');
+
+        try {
+            $placeDocument = $this->documentRepository->fetch($placeId, $includeMetadata);
+        } catch (DocumentDoesNotExist $e) {
+            throw ApiProblem::notFound(
+                'The place with id "' . $placeId . '" was not found.'
+            );
+        }
+
+        return new JsonLdResponse($placeDocument->getAssocBody());
+    }
+}

--- a/src/Http/Place/ReadPlaceRestController.php
+++ b/src/Http/Place/ReadPlaceRestController.php
@@ -31,20 +31,6 @@ class ReadPlaceRestController
         $this->documentRepository = $documentRepository;
     }
 
-    public function get(string $cdbid, Request $request): JsonResponse
-    {
-        $includeMetadata = (bool) $request->query->get('includeMetadata', false);
-
-        $place = $this->fetchPlaceJson($cdbid, $includeMetadata);
-
-        $response = JsonLdResponse::create()
-            ->setContent($place->getRawBody());
-
-        $response->headers->set('Vary', 'Origin');
-
-        return $response;
-    }
-
     public function getCalendarSummary($cdbid, Request $request): Response
     {
         $style = $request->query->get('style', 'text');

--- a/src/Http/Request/QueryParameters.php
+++ b/src/Http/Request/QueryParameters.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class QueryParameters
+{
+    private array $queryParameters;
+
+    public function __construct(ServerRequestInterface $request)
+    {
+        $this->queryParameters = $request->getQueryParams();
+    }
+
+    public function get(string $parameterName, ?string $default = null): ?string
+    {
+        if (isset($this->queryParameters[$parameterName])) {
+            return (string) $this->queryParameters[$parameterName];
+        }
+        return $default;
+    }
+
+    public function getAsBoolean(string $parameterName, ?bool $default = null): bool
+    {
+        $defaultAsString = $default === null ? null : (string) $default;
+        $valueAsString = $this->get($parameterName, $defaultAsString);
+
+        // Do not just use (bool) to cast to boolean but also use filter_var() with FILTER_VALIDATE_BOOL to prevent for
+        // example "false" as being cast to true (because a non-empty string = true when casting to bool).
+        // See https://stackoverflow.com/questions/7336861/how-to-convert-string-to-boolean-php/15075609
+        return (bool) filter_var($valueAsString, FILTER_VALIDATE_BOOL);
+    }
+}

--- a/src/ReadModel/InMemoryDocumentRepository.php
+++ b/src/ReadModel/InMemoryDocumentRepository.php
@@ -17,7 +17,15 @@ class InMemoryDocumentRepository implements DocumentRepository
             throw DocumentDoesNotExist::withId($id);
         }
 
-        return $this->documents[$id];
+        $document = $this->documents[$id];
+
+        if (!$includeMetadata) {
+            $body = $document->getAssocBody();
+            unset($body['metadata']);
+            $document = $document->withAssocBody($body);
+        }
+
+        return $document;
     }
 
     public function save(JsonDocument $readModel): void

--- a/tests/Http/Event/EventDetailRequestHandlerTest.php
+++ b/tests/Http/Event/EventDetailRequestHandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Event;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+
+class EventDetailRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private InMemoryDocumentRepository $documentRepository;
+    private EventDetailRequestHandler $eventDetailRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->documentRepository = new InMemoryDocumentRepository();
+        $this->eventDetailRequestHandler = new EventDetailRequestHandler($this->documentRepository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_requested_event_json_ld_if_found(): void
+    {
+        $this->mockEventDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/events/c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->eventDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayNotHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_includes_metadata_if_the_parameter_is_set_to_true(): void
+    {
+        $this->mockEventDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/events/c09b7a51-b17c-4121-b278-eef71ef04e47?includeMetadata=true')
+            ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->eventDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_include_metadata_if_the_parameter_is_set_to_false(): void
+    {
+        $this->mockEventDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/events/c09b7a51-b17c-4121-b278-eef71ef04e47?includeMetadata=false')
+            ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->eventDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayNotHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_url_not_found_if_the_event_does_not_exist(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/events/c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::notFound('The event with id "c09b7a51-b17c-4121-b278-eef71ef04e47" was not found.'),
+            fn () => $this->eventDetailRequestHandler->handle($request)
+        );
+    }
+
+    private function mockEventDocument(string $eventId): void
+    {
+        $jsonLd = json_encode(
+            [
+                '@id' => '/events/' . $eventId,
+                'metadata' => ['foo' => 'bar'],
+            ],
+            JSON_THROW_ON_ERROR
+        );
+
+        $document = new JsonDocument($eventId, $jsonLd);
+        $this->documentRepository->save($document);
+    }
+}

--- a/tests/Http/Event/GetEventDetailRequestHandlerTest.php
+++ b/tests/Http/Event/GetEventDetailRequestHandlerTest.php
@@ -11,17 +11,17 @@ use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
 
-class EventDetailRequestHandlerTest extends TestCase
+class GetEventDetailRequestHandlerTest extends TestCase
 {
     use AssertApiProblemTrait;
 
     private InMemoryDocumentRepository $documentRepository;
-    private EventDetailRequestHandler $eventDetailRequestHandler;
+    private GetEventDetailRequestHandler $getEventDetailRequestHandler;
 
     protected function setUp(): void
     {
         $this->documentRepository = new InMemoryDocumentRepository();
-        $this->eventDetailRequestHandler = new EventDetailRequestHandler($this->documentRepository);
+        $this->getEventDetailRequestHandler = new GetEventDetailRequestHandler($this->documentRepository);
     }
 
     /**
@@ -36,7 +36,7 @@ class EventDetailRequestHandlerTest extends TestCase
             ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
             ->build('GET');
 
-        $response = $this->eventDetailRequestHandler->handle($request);
+        $response = $this->getEventDetailRequestHandler->handle($request);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
 
@@ -57,7 +57,7 @@ class EventDetailRequestHandlerTest extends TestCase
             ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
             ->build('GET');
 
-        $response = $this->eventDetailRequestHandler->handle($request);
+        $response = $this->getEventDetailRequestHandler->handle($request);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
 
@@ -78,7 +78,7 @@ class EventDetailRequestHandlerTest extends TestCase
             ->withRouteParameter('eventId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
             ->build('GET');
 
-        $response = $this->eventDetailRequestHandler->handle($request);
+        $response = $this->getEventDetailRequestHandler->handle($request);
         $responseBody = $response->getBody()->getContents();
         $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
 
@@ -99,7 +99,7 @@ class EventDetailRequestHandlerTest extends TestCase
 
         $this->assertCallableThrowsApiProblem(
             ApiProblem::notFound('The event with id "c09b7a51-b17c-4121-b278-eef71ef04e47" was not found.'),
-            fn () => $this->eventDetailRequestHandler->handle($request)
+            fn () => $this->getEventDetailRequestHandler->handle($request)
         );
     }
 

--- a/tests/Http/Event/ReadEventRestControllerTest.php
+++ b/tests/Http/Event/ReadEventRestControllerTest.php
@@ -178,47 +178,6 @@ class ReadEventRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_http_response_with_json_get_for_an_event(): void
-    {
-        $request = new Request();
-
-        $controller = $this->createController(true);
-        $jsonResponse = $controller->get(self::EXISTING_ID, $request);
-
-        $this->assertEquals(Response::HTTP_OK, $jsonResponse->getStatusCode());
-        $this->assertEquals($this->jsonDocument->getRawBody(), $jsonResponse->getContent());
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_a_http_response_with_json_including_metadata_for_an_event(): void
-    {
-        $request = new Request(['includeMetadata' => 'true']);
-
-        $controller = $this->createController(true);
-        $jsonResponse = $controller->get(self::EXISTING_ID, $request);
-
-        $this->assertEquals(Response::HTTP_OK, $jsonResponse->getStatusCode());
-        $this->assertEquals($this->jsonDocumentWithMetadata->getRawBody(), $jsonResponse->getContent());
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_an_api_problem_exception_for_getting_a_non_existing_event(): void
-    {
-        $this->expectException(ApiProblem::class);
-
-        $request = new Request();
-
-        $controller = $this->createController(true);
-        $controller->get(self::NON_EXISTING_ID, $request);
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_a_http_response_with_a_calendar_summary_for_an_event(): void
     {
         $request = new Request(['style' => 'text', 'format' => 'lg']);

--- a/tests/Http/Place/GetPlaceDetailRequestHandlerTest.php
+++ b/tests/Http/Place/GetPlaceDetailRequestHandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Place;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+
+class GetPlaceDetailRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private InMemoryDocumentRepository $documentRepository;
+    private GetPlaceDetailRequestHandler $getPlaceDetailRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->documentRepository = new InMemoryDocumentRepository();
+        $this->getPlaceDetailRequestHandler = new GetPlaceDetailRequestHandler($this->documentRepository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_requested_place_json_ld_if_found(): void
+    {
+        $this->mockPlaceDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/places/c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->withRouteParameter('placeId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->getPlaceDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayNotHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_includes_metadata_if_the_parameter_is_set_to_true(): void
+    {
+        $this->mockPlaceDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/places/c09b7a51-b17c-4121-b278-eef71ef04e47?includeMetadata=true')
+            ->withRouteParameter('placeId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->getPlaceDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_include_metadata_if_the_parameter_is_set_to_false(): void
+    {
+        $this->mockPlaceDocument('c09b7a51-b17c-4121-b278-eef71ef04e47');
+
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/places/c09b7a51-b17c-4121-b278-eef71ef04e47?includeMetadata=false')
+            ->withRouteParameter('placeId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $response = $this->getPlaceDetailRequestHandler->handle($request);
+        $responseBody = $response->getBody()->getContents();
+        $decodedResponseBody = json_decode($responseBody, true, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('@id', $decodedResponseBody);
+        $this->assertArrayNotHasKey('metadata', $decodedResponseBody);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_url_not_found_if_the_place_does_not_exist(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/places/c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->withRouteParameter('placeId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
+            ->build('GET');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::notFound('The place with id "c09b7a51-b17c-4121-b278-eef71ef04e47" was not found.'),
+            fn () => $this->getPlaceDetailRequestHandler->handle($request)
+        );
+    }
+
+    private function mockPlaceDocument(string $placeId): void
+    {
+        $jsonLd = json_encode(
+            [
+                '@id' => '/places/' . $placeId,
+                'metadata' => ['foo' => 'bar'],
+            ],
+            JSON_THROW_ON_ERROR
+        );
+
+        $document = new JsonDocument($placeId, $jsonLd);
+        $this->documentRepository->save($document);
+    }
+}

--- a/tests/Http/Place/ReadPlaceRestControllerTest.php
+++ b/tests/Http/Place/ReadPlaceRestControllerTest.php
@@ -95,38 +95,6 @@ class ReadPlaceRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_http_response_with_json_get_for_an_event(): void
-    {
-        $jsonResponse = $this->placeRestController->get(self::EXISTING_ID, new Request());
-
-        $this->assertEquals(Response::HTTP_OK, $jsonResponse->getStatusCode());
-        $this->assertEquals($this->jsonDocument->getRawBody(), $jsonResponse->getContent());
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_a_http_response_with_json_including_metadata_for_an_event(): void
-    {
-        $request = new Request(['includeMetadata' => true]);
-        $jsonResponse = $this->placeRestController->get(self::EXISTING_ID, $request);
-
-        $this->assertEquals(Response::HTTP_OK, $jsonResponse->getStatusCode());
-        $this->assertEquals($this->jsonDocumentWithMetadata->getRawBody(), $jsonResponse->getContent());
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_an_api_problem_exception_for_getting_a_non_existing_event(): void
-    {
-        $this->expectException(ApiProblem::class);
-        $this->placeRestController->get(self::NON_EXISTING_ID, new Request());
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_a_http_response_with_a_calendar_summary_for_a_place(): void
     {
         $request = new Request(['style' => 'text', 'format' => 'lg']);

--- a/tests/Http/Request/QueryParametersTest.php
+++ b/tests/Http/Request/QueryParametersTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request;
+
+use PHPUnit\Framework\TestCase;
+
+class QueryParametersTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_the_parameter_value_as_a_string(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/example?foo=bar')
+            ->build('GET');
+
+        $queryParameters = new QueryParameters($request);
+        $this->assertSame('bar', $queryParameters->get('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_default_value_if_the_parameter_is_not_set(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/example')
+            ->build('GET');
+
+        $queryParameters = new QueryParameters($request);
+        $this->assertSame('ipsum', $queryParameters->get('foo', 'ipsum'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_if_the_parameter_is_not_set_and_no_default_is_given(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/example')
+            ->build('GET');
+
+        $queryParameters = new QueryParameters($request);
+        $this->assertNull($queryParameters->get('foo'));
+    }
+
+    /**
+     * @test
+     * @dataProvider booleanDataProvider
+     */
+    public function it_parses_parameters_as_booleans(string $valueAsString, ?bool $expectedResult = null): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withUriFromString('/example?foo=' . $valueAsString)
+            ->build('GET');
+
+        $queryParameters = new QueryParameters($request);
+        $this->assertSame($expectedResult, $queryParameters->getAsBoolean('foo'));
+    }
+
+    public function booleanDataProvider(): array
+    {
+        return [
+            [
+                'valueAsString' => '1',
+                'expectedResult' => true,
+            ],
+            [
+                'valueAsString' => 'true',
+                'expectedResult' => true,
+            ],
+            [
+                'valueAsString' => 'anystring',
+                'expectedResult' => false,
+            ],
+            [
+                'valueAsString' => 'false',
+                'expectedResult' => false,
+            ],
+            [
+                'valueAsString' => '0',
+                'expectedResult' => false,
+            ],
+            [
+                'valueAsString' => '',
+                'expectedResult' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Added

- [internal] Added `GetPlaceDetailRequestHandler` class to replace old controller method for `GET /places/{placeId}`

### Removed

- [internal] Removed `ReadPlaceRestController::get()` method

---
Ticket: https://jira.uitdatabank.be/browse/III-4246
