### PR TITLE
Add trailing slash to deprecated route registrations

### DIFF
--- a/app/Offer/OfferControllerProvider.php
+++ b/app/Offer/OfferControllerProvider.php
@@ -76,7 +76,7 @@ class OfferControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers->post('/{cdbid}/{lang}/description/', "{$controllerName}:updateDescription");
         $controllers->post('/{cdbid}/facilities/', "{$controllerName}:updateFacilitiesWithLabel");
         $controllers->get('/{offerId}/permission/', "{$deprecatedPermissionControllerName}:currentUserHasPermission");
-        $controllers->get('/{offerId}/permission/{userId}', "{$deprecatedPermissionControllerName}:givenUserHasPermission");
+        $controllers->get('/{offerId}/permission/{userId}/', "{$deprecatedPermissionControllerName}:givenUserHasPermission");
 
         return $controllers;
     }


### PR DESCRIPTION
### Added

- [internal] Added trailing slashes to deprecated routes

### Fixed

- Fixed deprecated routes like `GET /event/{eventId}/permission` not working because it got rewritten to `GET /events/{eventId}/permission/`, and it didn't match with any registered route because the route did not have a trailing slash internally.
