### PR TITLE
III-4275 Allow requests to old `/calsum` endpoint without token

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -76,7 +76,7 @@ $app['security.firewalls'] = array(
             ->with(new RequestMatcher('^/(events|event|places|place)/$', null, 'GET'))
             ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '$', null, 'GET'))
             ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '$', null, 'GET'))
-            ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '/calendar-summary', null, 'GET'))
+            ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '/(calendar-summary|calsum)', null, 'GET'))
             ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '/permissions/.+$', null, 'GET'))
             ->with(new RequestMatcher('^/(events|event|places|place)/' . $app['id_pattern'] . '/permission/.+$', null, 'GET'))
             ->with(new RequestMatcher('^/label/' . $app['id_pattern'] . '$', null, 'GET'))


### PR DESCRIPTION
### Fixed

- Fixed bug that made a token required on deprecated `GET /events/{eventId}/calsum` and `GET /places/{placeId}/calsum` endpoints

---
Ticket: https://jira.uitdatabank.be/browse/III-4275

Note: Apparently the firewall kicks in before our catch-all route that rewrites incoming URLs, so we also need to add paths that get rewritten and should not require a token to the firewall configuration.
