### PR TITLE
III-4310 Improve error response for JWT that cannot be parsed

### DIFF
--- a/src/Jwt/Symfony/Firewall/JwtListener.php
+++ b/src/Jwt/Symfony/Firewall/JwtListener.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Response\ApiProblemJsonResponse;
 use CultuurNet\UDB3\Jwt\Symfony\Authentication\JsonWebToken;
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -47,7 +48,7 @@ class JwtListener implements ListenerInterface
 
         try {
             $token = new JsonWebToken($jwtString);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException | RuntimeException $e) {
             $response = (new ApiProblemJsonResponse(
                 ApiProblem::unauthorized('Could not parse the given JWT.')
             ))->toHttpFoundationResponse();


### PR DESCRIPTION
### Fixed

- Improved error response for JWT with invalid syntax

---
Ticket: https://jira.uitdatabank.be/browse/III-4310
