### PR TITLE
III-4287 Refactor the update organizer url

### DIFF
--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveLabelHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateTitleHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\UpdateWebsiteHandler;
 use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -51,6 +52,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[UpdateAddressHandler::class] = $app->share(
             fn (Application $application) => new UpdateAddressHandler($app['organizer_repository'])
+        );
+
+        $app[UpdateWebsiteHandler::class] = $app->share(
+            fn (Application $application) => new UpdateWebsiteHandler($app['organizer_repository'])
         );
     }
 

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Organizer;
 
 use CultuurNet\UDB3\Http\Organizer\UpdateAddressRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateTitleRequestHandler;
+use CultuurNet\UDB3\Http\Organizer\UpdateUrlRequestHandler;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Http\Offer\OfferPermissionsController;
 use CultuurNet\UDB3\Http\Organizer\EditOrganizerRestController;
@@ -31,16 +32,13 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
 
         $controllers->delete('/{cdbid}/', 'organizer_edit_controller:delete');
 
-        $controllers->put(
-            '/{organizerId}/url/',
-            'organizer_edit_controller:updateUrl'
-        );
-
         $controllers->put('/{organizerId}/name/', UpdateTitleRequestHandler::class);
         $controllers->put('/{organizerId}/name/{language}/', UpdateTitleRequestHandler::class);
 
         $controllers->put('/{organizerId}/address/', UpdateAddressRequestHandler::class);
         $controllers->put('/{organizerId}/address/{language}/', UpdateAddressRequestHandler::class);
+
+        $controllers->put('/{organizerId}/url/', UpdateUrlRequestHandler::class);
 
         $controllers->delete(
             '/{organizerId}/address/',
@@ -104,6 +102,10 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
 
         $app[UpdateAddressRequestHandler::class] = $app->share(
             fn (Application $application) => new UpdateAddressRequestHandler($app['event_command_bus'])
+        );
+
+        $app[UpdateUrlRequestHandler::class] = $app->share(
+            fn (Application $application) => new UpdateUrlRequestHandler($app['event_command_bus'])
         );
     }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -36,6 +36,7 @@ use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateTitleHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\UpdateWebsiteHandler;
 use CultuurNet\UDB3\Organizer\WebsiteNormalizer;
 use CultuurNet\UDB3\Organizer\WebsiteUniqueConstraintService;
 use CultuurNet\UDB3\Place\LocalPlaceService;
@@ -629,6 +630,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[\CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler::class]);
         $commandBus->subscribe($app[UpdateTitleHandler::class]);
         $commandBus->subscribe($app[UpdateAddressHandler::class]);
+        $commandBus->subscribe($app[UpdateWebsiteHandler::class]);
 
         $commandBus->subscribe($app[LabelServiceProvider::COMMAND_HANDLER]);
     };

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "dev-master",
-    "publiq/stoplight-docs-uitdatabank": "dev-unreleased",
+    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4287-update-organizer-url",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",
     "sentry/sdk": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5175783f8ac8203db59ced7e3142bf14",
+    "content-hash": "687539a2c97998eb082085faaa2e0ad2",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5366,16 +5366,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-unreleased",
+            "version": "dev-feature/III-4287-update-organizer-url",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "e9b457cc8350cc9d34c6c8857ac96adc491255ff"
+                "reference": "d51e3cf1b5f10180dfad14ef55273e03a2c12cc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/e9b457cc8350cc9d34c6c8857ac96adc491255ff",
-                "reference": "e9b457cc8350cc9d34c6c8857ac96adc491255ff",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/d51e3cf1b5f10180dfad14ef55273e03a2c12cc7",
+                "reference": "d51e3cf1b5f10180dfad14ef55273e03a2c12cc7",
                 "shasum": ""
             },
             "type": "library",
@@ -5392,9 +5392,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/unreleased"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4287-update-organizer-url"
             },
-            "time": "2021-10-29T09:22:17+00:00"
+            "time": "2021-10-29T11:31:07+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Organizer/EditOrganizerRestController.php
+++ b/src/Http/Organizer/EditOrganizerRestController.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Organizer\Commands\RemoveLabel;
 use CultuurNet\UDB3\Organizer\OrganizerEditingServiceInterface;
 use CultuurNet\UDB3\Http\Deserializer\ContactPoint\ContactPointJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Organizer\OrganizerCreationPayloadJSONDeserializer;
-use CultuurNet\UDB3\Http\Deserializer\Organizer\UrlJSONDeserializer;
 use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -84,31 +83,6 @@ class EditOrganizerRestController
             ],
             201
         );
-    }
-
-    public function updateUrl(string $organizerId, Request $request): Response
-    {
-        $websiteJSONDeserializer = new UrlJSONDeserializer();
-        $website = $websiteJSONDeserializer->deserialize(
-            new StringLiteral($request->getContent())
-        );
-
-        try {
-            $this->editingService->updateWebsite(
-                $organizerId,
-                $website
-            );
-        } catch (UniqueConstraintException $e) {
-            $e = new DataValidationException();
-            $e->setValidationMessages(
-                [
-                    'url' => 'Should be unique but is already in use.',
-                ]
-            );
-            throw $e;
-        }
-
-        return new NoContent();
     }
 
     public function removeAddress(string $organizerId): Response

--- a/src/Http/Organizer/UpdateUrlRequestHandler.php
+++ b/src/Http/Organizer/UpdateUrlRequestHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
+use CultuurNet\UDB3\Organizer\Serializers\UpdateWebsiteDenormalizer;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UpdateUrlRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): NoContentResponse
+    {
+        $routeParameters = new RouteParameters($request);
+        $organizerId = $routeParameters->getOrganizerId();
+
+        $requestBodyParser = RequestBodyParserFactory::createBaseParser(
+            new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::ORGANIZER_URL_PUT),
+            new DenormalizingRequestBodyParser(
+                new UpdateWebsiteDenormalizer($organizerId),
+                UpdateWebsite::class
+            )
+        );
+
+        $updateTitle = $requestBodyParser->parse($request)->getParsedBody();
+
+        $this->commandBus->dispatch($updateTitle);
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -32,6 +32,7 @@ final class JsonSchemaLocator
 
     public const ORGANIZER_NAME_PUT = 'organizer-name-put.json';
     public const ORGANIZER_ADDRESS_PUT = 'organizer-address-put.json';
+    public const ORGANIZER_URL_PUT = 'organizer-url-put.json';
 
     public static function setSchemaDirectory(string $schemaDirectory): void
     {

--- a/src/Model/Import/Organizer/OrganizerDocumentImporter.php
+++ b/src/Model/Import/Organizer/OrganizerDocumentImporter.php
@@ -82,7 +82,7 @@ class OrganizerDocumentImporter implements DocumentImporterInterface
                 new Language($mainLanguage->getCode())
             );
 
-            $commands[] = new UpdateWebsite($id, $url);
+            $commands[] = new UpdateWebsite($id, $import->getUrl());
         }
 
         $contactPoint = $adapter->getContactPoint();

--- a/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
+++ b/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Organizer\CommandHandler;
 use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
+use ValueObjects\Web\Url;
 
 final class UpdateWebsiteHandler implements CommandHandler
 {
@@ -25,7 +26,7 @@ final class UpdateWebsiteHandler implements CommandHandler
 
         $organizer = $this->organizerRepository->load($command->getItemId());
 
-        $organizer->updateWebsite($command->getWebsite());
+        $organizer->updateWebsite(Url::fromNative($command->getWebsite()->toString()));
 
         $this->organizerRepository->save($organizer);
     }

--- a/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
+++ b/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class UpdateWebsiteHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof UpdateWebsite) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getItemId());
+
+        $organizer->updateWebsite($command->getWebsite());
+
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
+++ b/src/Organizer/CommandHandler/UpdateWebsiteHandler.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Organizer\CommandHandler;
 use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
-use ValueObjects\Web\Url;
 
 final class UpdateWebsiteHandler implements CommandHandler
 {
@@ -26,7 +25,7 @@ final class UpdateWebsiteHandler implements CommandHandler
 
         $organizer = $this->organizerRepository->load($command->getItemId());
 
-        $organizer->updateWebsite(Url::fromNative($command->getWebsite()->toString()));
+        $organizer->updateWebsite($command->getWebsite());
 
         $this->organizerRepository->save($organizer);
     }

--- a/src/Organizer/Commands/UpdateWebsite.php
+++ b/src/Organizer/Commands/UpdateWebsite.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Commands;
 
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\AuthorizableCommand;
-use ValueObjects\Web\Url;
 
 final class UpdateWebsite implements AuthorizableCommand
 {

--- a/src/Organizer/DefaultOrganizerEditingService.php
+++ b/src/Organizer/DefaultOrganizerEditingService.php
@@ -19,7 +19,6 @@ use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Organizer\Commands\DeleteOrganizer;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;
-use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Title;
 use ValueObjects\Web\Url;
 
@@ -80,13 +79,6 @@ class DefaultOrganizerEditingService implements OrganizerEditingServiceInterface
         $this->organizerRepository->save($organizer);
 
         return $id;
-    }
-
-    public function updateWebsite(string $organizerId, Url $website): void
-    {
-        $this->commandBus->dispatch(
-            new UpdateWebsite($organizerId, $website)
-        );
     }
 
     /**

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
@@ -36,7 +37,7 @@ use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
 use CultuurNet\UDB3\Title as LegacyTitle;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXmlInterface, LabelAwareAggregateRoot
 {
@@ -44,7 +45,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
 
     private LegacyLanguage $mainLanguage;
 
-    private ?Url $website = null;
+    private ?LegacyUrl $website = null;
 
     /**
      * @var LegacyTitle[]
@@ -95,7 +96,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
     public static function create(
         string $id,
         LegacyLanguage $mainLanguage,
-        Url $website,
+        LegacyUrl $website,
         LegacyTitle $title
     ): Organizer {
         $organizer = new self();
@@ -120,11 +121,13 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
 
     public function updateWebsite(Url $website): void
     {
-        if (is_null($this->website) || !$this->website->sameValueAs($website)) {
+        $newWebsite = LegacyUrl::fromNative($website->toString());
+
+        if (is_null($this->website) || !$this->website->sameValueAs($newWebsite)) {
             $this->apply(
                 new WebsiteUpdated(
                     $this->actorId,
-                    $website
+                    $newWebsite
                 )
             );
         }

--- a/src/Organizer/OrganizerCommandHandler.php
+++ b/src/Organizer/OrganizerCommandHandler.php
@@ -45,7 +45,6 @@ class OrganizerCommandHandler implements CommandHandler
     protected function getCommandHandlerMethods()
     {
         return [
-            UpdateWebsite::class => 'updateWebsite',
             RemoveAddress::class => 'removeAddress',
             UpdateContactPoint::class => 'updateContactPoint',
             DeleteOrganizer::class => 'deleteOrganizer',

--- a/src/Organizer/OrganizerCommandHandler.php
+++ b/src/Organizer/OrganizerCommandHandler.php
@@ -9,7 +9,6 @@ use Broadway\Repository\Repository;
 use CultuurNet\UDB3\Organizer\Commands\DeleteOrganizer;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;
-use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 
 class OrganizerCommandHandler implements CommandHandler
 {
@@ -61,16 +60,6 @@ class OrganizerCommandHandler implements CommandHandler
             $method = $handlers[$class];
             $this->{$method}($command);
         }
-    }
-
-
-    protected function updateWebsite(UpdateWebsite $updateWebsite)
-    {
-        $organizer = $this->loadOrganizer($updateWebsite->getItemId());
-
-        $organizer->updateWebsite($updateWebsite->getWebsite());
-
-        $this->organizerRepository->save($organizer);
     }
 
     public function removeAddress(RemoveAddress $removeAddress)

--- a/src/Organizer/OrganizerEditingServiceInterface.php
+++ b/src/Organizer/OrganizerEditingServiceInterface.php
@@ -20,8 +20,6 @@ interface OrganizerEditingServiceInterface
         ?ContactPoint $contactPoint = null
     ): string;
 
-    public function updateWebsite(string $organizerId, Url $website): void;
-
     public function removeAddress(string $organizerId): void;
 
     public function updateContactPoint(string $organizerId, ContactPoint $contactPoint): void;

--- a/src/Organizer/Serializers/UpdateWebsiteDenormalizer.php
+++ b/src/Organizer/Serializers/UpdateWebsiteDenormalizer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Serializers;
 
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use ValueObjects\Web\Url;
 
 final class UpdateWebsiteDenormalizer implements DenormalizerInterface
 {
@@ -19,7 +19,7 @@ final class UpdateWebsiteDenormalizer implements DenormalizerInterface
 
     public function denormalize($data, $type, $format = null, array $context = []): UpdateWebsite
     {
-        return new UpdateWebsite($this->organizerId, Url::fromNative($data['url']));
+        return new UpdateWebsite($this->organizerId, new Url($data['url']));
     }
 
     public function supportsDenormalization($data, $type, $format = null): bool

--- a/src/Organizer/Serializers/UpdateWebsiteDenormalizer.php
+++ b/src/Organizer/Serializers/UpdateWebsiteDenormalizer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Serializers;
+
+use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use ValueObjects\Web\Url;
+
+final class UpdateWebsiteDenormalizer implements DenormalizerInterface
+{
+    private string $organizerId;
+
+    public function __construct(string $organizerId)
+    {
+        $this->organizerId = $organizerId;
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = []): UpdateWebsite
+    {
+        return new UpdateWebsite($this->organizerId, Url::fromNative($data['url']));
+    }
+
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return $type === UpdateWebsite::class;
+    }
+}

--- a/tests/Http/Organizer/EditOrganizerRestControllerTest.php
+++ b/tests/Http/Organizer/EditOrganizerRestControllerTest.php
@@ -142,32 +142,6 @@ class EditOrganizerRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_updates_the_url_of_an_organizer()
-    {
-        $organizerId = '5e1d6fec-d0ea-4203-b466-7fb9711f3bb9';
-        $url = Url::fromNative('http://www.depot.be');
-
-        $this->editService->expects($this->once())
-            ->method('updateWebsite')
-            ->with(
-                $organizerId,
-                $url
-            );
-
-        $content = '{"url":"' . (string) $url . '"}';
-        $request = new Request([], [], [], [], [], [], $content);
-
-        $response = $this->controller->updateUrl(
-            $organizerId,
-            $request
-        );
-
-        $this->assertEquals(204, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_removes_address_of_an_organizer()
     {
         $organizerId = '5e1d6fec-d0ea-4203-b466-7fb9711f3bb9';

--- a/tests/Http/Organizer/UpdateUrlRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateUrlRequestHandlerTest.php
@@ -9,9 +9,9 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Web\Url;
 
 final class UpdateUrlRequestHandlerTest extends TestCase
 {
@@ -54,7 +54,7 @@ final class UpdateUrlRequestHandlerTest extends TestCase
             [
                 new UpdateWebsite(
                     'a088f396-ac96-45c4-b6b2-e2b6afe8af07',
-                    Url::fromNative('https://www.publiq.be'),
+                    new Url('https://www.publiq.be'),
                 ),
             ],
             $this->commandBus->getRecordedCommands()

--- a/tests/Http/Organizer/UpdateUrlRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateUrlRequestHandlerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
+use PHPUnit\Framework\TestCase;
+use ValueObjects\Web\Url;
+
+final class UpdateUrlRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+
+    private UpdateUrlRequestHandler $updateUrlRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->updateUrlRequestHandler = new UpdateUrlRequestHandler($this->commandBus);
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+
+        $this->commandBus->record();
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_updating_the_url(): void
+    {
+        $updateUrlRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('organizerId', 'a088f396-ac96-45c4-b6b2-e2b6afe8af07')
+            ->withBodyFromString(
+                '{
+                    "url": "https://www.publiq.be"
+                }'
+            )
+            ->build('PUT');
+
+        $this->updateUrlRequestHandler->handle($updateUrlRequest);
+
+        $this->assertEquals(
+            [
+                new UpdateWebsite(
+                    'a088f396-ac96-45c4-b6b2-e2b6afe8af07',
+                    Url::fromNative('https://www.publiq.be'),
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_a_url(): void
+    {
+        $updateUrlRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('organizerId', 'a088f396-ac96-45c4-b6b2-e2b6afe8af07')
+            ->withRouteParameter('language', 'fr')
+            ->withBodyFromString(
+                '{
+                    "missing": "https://www.publiq.be"
+                }'
+            )
+            ->build('PUT');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/', 'The required properties (url) are missing')
+            ),
+            fn () => $this->updateUrlRequestHandler->handle($updateUrlRequest)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_a_valid_url(): void
+    {
+        $updateUrlRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('organizerId', 'a088f396-ac96-45c4-b6b2-e2b6afe8af07')
+            ->withRouteParameter('language', 'fr')
+            ->withBodyFromString(
+                '{
+                    "url": "This is wrong"
+                }'
+            )
+            ->build('PUT');
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError('/url', 'The string should match pattern: ^http[s]?:\/\/')
+            ),
+            fn () => $this->updateUrlRequestHandler->handle($updateUrlRequest)
+        );
+    }
+}

--- a/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
+++ b/tests/Model/Import/Organizer/OrganizerDocumentImporterTest.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\ImportLabels;
 use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
@@ -33,7 +34,7 @@ use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\Title as LegacyTitle;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class OrganizerDocumentImporterTest extends TestCase
 {
@@ -97,7 +98,7 @@ class OrganizerDocumentImporterTest extends TestCase
             Organizer::create(
                 $id,
                 new LegacyLanguage('nl'),
-                Url::fromNative('https://www.publiq.be'),
+                LegacyUrl::fromNative('https://www.publiq.be'),
                 new LegacyTitle('Voorbeeld naam')
             )
         );
@@ -136,7 +137,7 @@ class OrganizerDocumentImporterTest extends TestCase
         $this->importer->import($document);
 
         $expectedCommands = [new UpdateTitle($id, new Title('Voorbeeld naam'), new Language('nl')),
-            new UpdateWebsite($id, Url::fromNative('https://www.publiq.be')),
+            new UpdateWebsite($id, new Url('https://www.publiq.be')),
             new UpdateContactPoint($id, new ContactPoint()),
             new RemoveAddress($id),
             new UpdateTitle($id, new Title('Nom example'), new Language('fr')),

--- a/tests/Organizer/CommandHandler/UpdateWebsiteHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateWebsiteHandlerTest.php
@@ -9,12 +9,13 @@ use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
 use Broadway\EventHandling\EventBus;
 use Broadway\EventStore\EventStore;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
 use CultuurNet\UDB3\Title;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class UpdateWebsiteHandlerTest extends CommandHandlerScenarioTestCase
 {
@@ -33,14 +34,14 @@ class UpdateWebsiteHandlerTest extends CommandHandlerScenarioTestCase
         $organizerCreated = new OrganizerCreatedWithUniqueWebsite(
             $id,
             new Language('nl'),
-            Url::fromNative('https://www.madewithlove.be'),
+            LegacyUrl::fromNative('https://www.madewithlove.be'),
             new Title('Organizer Title')
         );
 
         $this->scenario
             ->withAggregateId($id)
             ->given([$organizerCreated])
-            ->when(new UpdateWebsite($id, Url::fromNative('https://www.publiq.be')))
-            ->then([new WebsiteUpdated($id, Url::fromNative('https://www.publiq.be'))]);
+            ->when(new UpdateWebsite($id, new Url('https://www.publiq.be')))
+            ->then([new WebsiteUpdated($id, LegacyUrl::fromNative('https://www.publiq.be'))]);
     }
 }

--- a/tests/Organizer/CommandHandler/UpdateWebsiteHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateWebsiteHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+use CultuurNet\UDB3\Title;
+use ValueObjects\Web\Url;
+
+class UpdateWebsiteHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new UpdateWebsiteHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_updating_the_website(): void
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        $organizerCreated = new OrganizerCreatedWithUniqueWebsite(
+            $id,
+            new Language('nl'),
+            Url::fromNative('https://www.madewithlove.be'),
+            new Title('Organizer Title')
+        );
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([$organizerCreated])
+            ->when(new UpdateWebsite($id, Url::fromNative('https://www.publiq.be')))
+            ->then([new WebsiteUpdated($id, Url::fromNative('https://www.publiq.be'))]);
+    }
+}

--- a/tests/Organizer/Commands/UpdateWebsiteTest.php
+++ b/tests/Organizer/Commands/UpdateWebsiteTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Commands;
 
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\Web\Url;
 
 final class UpdateWebsiteTest extends TestCase
 {
@@ -19,7 +19,7 @@ final class UpdateWebsiteTest extends TestCase
     {
         $this->organizerId = '8f9f5180-1099-474e-804c-461fc3701e5c';
 
-        $this->website = Url::fromNative('http://www.company.be');
+        $this->website = new Url('http://www.company.be');
 
         $this->updateWebsite = new UpdateWebsite(
             $this->organizerId,

--- a/tests/Organizer/DefaultOrganizerEditingServiceTest.php
+++ b/tests/Organizer/DefaultOrganizerEditingServiceTest.php
@@ -19,7 +19,6 @@ use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Organizer\Commands\DeleteOrganizer;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;
-use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -156,23 +155,6 @@ class DefaultOrganizerEditingServiceTest extends TestCase
         );
 
         $this->assertEquals($expectedUuid, $organizerId);
-    }
-
-    /**
-     * @test
-     */
-    public function it_handles_update_website()
-    {
-        $organizerId = 'baee2963-e1ba-4777-a803-4c645c6fd31c';
-        $website = Url::fromNative('http://www.depot.be');
-
-        $expectedUpdateWebsite = new UpdateWebsite($organizerId, $website);
-
-        $this->commandBus->expects($this->once())
-            ->method('dispatch')
-            ->with($expectedUpdateWebsite);
-
-        $this->service->updateWebsite($organizerId, $website);
     }
 
     /**

--- a/tests/Organizer/OrganizerCommandHandlerTest.php
+++ b/tests/Organizer/OrganizerCommandHandlerTest.php
@@ -19,18 +19,15 @@ use CultuurNet\UDB3\Offer\Commands\AbstractDeleteOrganizer;
 use CultuurNet\UDB3\Organizer\Commands\DeleteOrganizer;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateContactPoint;
-use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerDeleted;
-use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use ValueObjects\Geography\Country;
 use ValueObjects\Identity\UUID;
-use ValueObjects\Web\Url;
 
 class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
@@ -120,36 +117,6 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
                 $eventBus
             )
         );
-    }
-
-    /**
-     * @test
-     */
-    public function it_handles_update_website()
-    {
-        $organizerId = $this->organizerCreated->getOrganizerId();
-
-        $this->scenario
-            ->withAggregateId($organizerId)
-            ->given(
-                [
-                    $this->organizerCreated,
-                ]
-            )
-            ->when(
-                new UpdateWebsite(
-                    $organizerId,
-                    Url::fromNative('http://www.depot.be')
-                )
-            )
-            ->then(
-                [
-                    new WebsiteUpdated(
-                        $organizerId,
-                        Url::fromNative('http://www.depot.be')
-                    ),
-                ]
-            );
     }
 
     /**

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
@@ -38,7 +39,7 @@ use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
 use CultuurNet\UDB3\Title as LegacyTitle;
 use ValueObjects\Geography\Country;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class OrganizerTest extends AggregateRootScenarioTestCase
 {
@@ -53,7 +54,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
     private $mainLanguage;
 
     /**
-     * @var Url
+     * @var LegacyUrl
      */
     private $website;
 
@@ -73,7 +74,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
 
         $this->id = '18eab5bf-09bf-4521-a8b4-c0f4a585c096';
         $this->mainLanguage = new LegacyLanguage('en');
-        $this->website = Url::fromNative('http://www.stuk.be');
+        $this->website = LegacyUrl::fromNative('http://www.stuk.be');
         $this->title = new LegacyTitle('STUK');
 
         $this->organizerCreatedWithUniqueWebsite = new OrganizerCreatedWithUniqueWebsite(
@@ -375,8 +376,8 @@ class OrganizerTest extends AggregateRootScenarioTestCase
             )
             ->when(
                 function (Organizer $organizer) {
-                    $organizer->updateWebsite(Url::fromNative('http://www.stuk.be'));
-                    $organizer->updateWebsite(Url::fromNative('http://www.hetdepot.be'));
+                    $organizer->updateWebsite(new Url('http://www.stuk.be'));
+                    $organizer->updateWebsite(new Url('http://www.hetdepot.be'));
                 }
             )
             ->then(
@@ -384,7 +385,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     // Organizer was created with website 'http://www.stuk.be'.
                     new WebsiteUpdated(
                         $this->id,
-                        Url::fromNative('http://www.hetdepot.be')
+                        LegacyUrl::fromNative('http://www.hetdepot.be')
                     ),
                 ]
             );
@@ -409,7 +410,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
             )
             ->when(
                 function (Organizer $organizer) {
-                    $organizer->updateWebsite(Url::fromNative('http://www.hetdepot.be'));
+                    $organizer->updateWebsite(new Url('http://www.hetdepot.be'));
                 }
             )
             ->then(
@@ -417,7 +418,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     // Organizer was created with an empty website.
                     new WebsiteUpdated(
                         '404EE8DE-E828-9C07-FE7D12DC4EB24480',
-                        Url::fromNative('http://www.hetdepot.be')
+                        LegacyUrl::fromNative('http://www.hetdepot.be')
                     ),
                 ]
             );


### PR DESCRIPTION
### Added
- Added new `UpdateWebsite` command handler
- Added new `UpdateWebsite` request handler

### Changed
- Refactor UpdateWebsite command to work with `Url` from Model namespace
- Refactor Organizer::updateWebsite method to work with `Url` from Model namespace

### Removed
- Removed obsolete code for handling updateWebsite

---
Ticket: https://jira.uitdatabank.be/browse/III-4287
