### PR TITLE
III-4380 Add extra history events

### DIFF
--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\ReadModel\History;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
+use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
 use CultuurNet\UDB3\Event\Events\ContactPointUpdated;
@@ -166,6 +167,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof Rejected:
                 $this->projectRejected($domainMessage);
+                break;
+            case $event instanceof AvailableFromUpdated:
+                $this->projectAvailableFromUpdated($domainMessage);
                 break;
             case $event instanceof ThemeUpdated:
                 $this->projectThemeUpdated($domainMessage);

--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
+use CultuurNet\UDB3\Event\Events\VideoDeleted;
 use CultuurNet\UDB3\History\BaseHistoryProjector;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Offer\ReadModel\History\OfferHistoryProjectorTrait;
@@ -125,6 +126,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof VideoAdded:
                 $this->projectVideoAdded($domainMessage);
+                break;
+            case $event instanceof VideoDeleted:
+                $this->projectVideoDeleted($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -46,6 +46,7 @@ use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\Event\Events\VideoDeleted;
+use CultuurNet\UDB3\Event\Events\VideoUpdated;
 use CultuurNet\UDB3\History\BaseHistoryProjector;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Offer\ReadModel\History\OfferHistoryProjectorTrait;
@@ -129,6 +130,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof VideoDeleted:
                 $this->projectVideoDeleted($domainMessage);
+                break;
+            case $event instanceof VideoUpdated:
+                $this->projectVideoUpdated($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -39,6 +39,7 @@ use CultuurNet\UDB3\Event\Events\Moderation\Rejected;
 use CultuurNet\UDB3\Event\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Event\Events\OrganizerUpdated;
 use CultuurNet\UDB3\Event\Events\PriceInfoUpdated;
+use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
 use CultuurNet\UDB3\Event\Events\TitleUpdated;
@@ -173,6 +174,12 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof ThemeUpdated:
                 $this->projectThemeUpdated($domainMessage);
+                break;
+            case $event instanceof ThemeRemoved:
+                $this->writeHistory(
+                    $event->getItemId(),
+                    Log::createFromDomainMessage($domainMessage, 'Thema verwijderd')
+                );
                 break;
             case $event instanceof TitleTranslated:
                 $this->projectTitleTranslated($domainMessage);

--- a/src/Event/ReadModel/History/HistoryProjector.php
+++ b/src/Event/ReadModel/History/HistoryProjector.php
@@ -44,6 +44,7 @@ use CultuurNet\UDB3\Event\Events\TitleUpdated;
 use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
+use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\History\BaseHistoryProjector;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Offer\ReadModel\History\OfferHistoryProjectorTrait;
@@ -121,6 +122,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof ImagesUpdatedFromUDB2:
                 $this->projectImagesUpdatedFromUDB2($domainMessage);
+                break;
+            case $event instanceof VideoAdded:
+                $this->projectVideoAdded($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\History;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Media\Image;
+use CultuurNet\UDB3\Offer\Events\AbstractVideoEvent;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImageEvent;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImagesImportedFromUDB2;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImageUpdated;
@@ -175,6 +176,17 @@ trait OfferHistoryProjectorTrait
                 )
             );
         }
+    }
+
+    private function projectVideoAdded(DomainMessage $domainMessage): void
+    {
+        /* @var AbstractVideoEvent $event */
+        $event = $domainMessage->getPayload();
+
+        $this->writeHistory(
+            $event->getItemId(),
+            Log::createFromDomainMessage($domainMessage, 'Video \'' . $event->getVideo()->getId() . '\' toegevoegd')
+        );
     }
 
     private function projectLabelAdded(DomainMessage $domainMessage): void

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -201,6 +201,17 @@ trait OfferHistoryProjectorTrait
         );
     }
 
+    private function projectVideoUpdated(DomainMessage $domainMessage): void
+    {
+        /* @var AbstractVideoEvent $event */
+        $event = $domainMessage->getPayload();
+
+        $this->writeHistory(
+            $event->getItemId(),
+            Log::createFromDomainMessage($domainMessage, 'Video \'' . $event->getVideo()->getId() . '\' aangepast')
+        );
+    }
+
     private function projectLabelAdded(DomainMessage $domainMessage): void
     {
         $event = $domainMessage->getPayload();

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\History;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Media\Image;
+use CultuurNet\UDB3\Offer\Events\AbstractAvailableFromUpdated;
 use CultuurNet\UDB3\Offer\Events\AbstractVideoDeleted;
 use CultuurNet\UDB3\Offer\Events\AbstractVideoEvent;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImageEvent;
@@ -313,6 +314,17 @@ trait OfferHistoryProjectorTrait
         $this->writeHistory(
             $domainMessage->getId(),
             Log::createFromDomainMessage($domainMessage, "Afgekeurd, reden: '{$reason}'")
+        );
+    }
+
+    private function projectAvailableFromUpdated(DomainMessage $domainMessage): void
+    {
+        /* @var AbstractAvailableFromUpdated $event */
+        $event = $domainMessage->getPayload();
+
+        $this->writeHistory(
+            $event->getItemId(),
+            Log::createFromDomainMessage($domainMessage, 'Publicatiedatum aangepast')
         );
     }
 

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\History;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Media\Image;
+use CultuurNet\UDB3\Offer\Events\AbstractVideoDeleted;
 use CultuurNet\UDB3\Offer\Events\AbstractVideoEvent;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImageEvent;
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImagesImportedFromUDB2;
@@ -186,6 +187,17 @@ trait OfferHistoryProjectorTrait
         $this->writeHistory(
             $event->getItemId(),
             Log::createFromDomainMessage($domainMessage, 'Video \'' . $event->getVideo()->getId() . '\' toegevoegd')
+        );
+    }
+
+    private function projectVideoDeleted(DomainMessage $domainMessage): void
+    {
+        /* @var AbstractVideoDeleted $event */
+        $event = $domainMessage->getPayload();
+
+        $this->writeHistory(
+            $event->getItemId(),
+            Log::createFromDomainMessage($domainMessage, 'Video \'' . $event->getVideoId() . '\' verwijderd')
         );
     }
 

--- a/src/Place/ReadModel/History/HistoryProjector.php
+++ b/src/Place/ReadModel/History/HistoryProjector.php
@@ -48,6 +48,7 @@ use CultuurNet\UDB3\Place\Events\TypeUpdated;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Place\Events\VideoAdded;
+use CultuurNet\UDB3\Place\Events\VideoDeleted;
 use DateTime;
 use DateTimeZone;
 
@@ -112,6 +113,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof VideoAdded:
                 $this->projectVideoAdded($domainMessage);
+                break;
+            case $event instanceof VideoDeleted:
+                $this->projectVideoDeleted($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Place/ReadModel/History/HistoryProjector.php
+++ b/src/Place/ReadModel/History/HistoryProjector.php
@@ -47,6 +47,7 @@ use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\Place\Events\TypeUpdated;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
+use CultuurNet\UDB3\Place\Events\VideoAdded;
 use DateTime;
 use DateTimeZone;
 
@@ -108,6 +109,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof ImagesUpdatedFromUDB2:
                 $this->projectImagesUpdatedFromUDB2($domainMessage);
+                break;
+            case $event instanceof VideoAdded:
+                $this->projectVideoAdded($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Place/ReadModel/History/HistoryProjector.php
+++ b/src/Place/ReadModel/History/HistoryProjector.php
@@ -49,6 +49,7 @@ use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Place\Events\VideoAdded;
 use CultuurNet\UDB3\Place\Events\VideoDeleted;
+use CultuurNet\UDB3\Place\Events\VideoUpdated;
 use DateTime;
 use DateTimeZone;
 
@@ -116,6 +117,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof VideoDeleted:
                 $this->projectVideoDeleted($domainMessage);
+                break;
+            case $event instanceof VideoUpdated:
+                $this->projectVideoUpdated($domainMessage);
                 break;
             case $event instanceof LabelAdded:
                 $this->projectLabelAdded($domainMessage);

--- a/src/Place/ReadModel/History/HistoryProjector.php
+++ b/src/Place/ReadModel/History/HistoryProjector.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\History\Log;
 use CultuurNet\UDB3\Offer\ReadModel\History\OfferHistoryProjectorTrait;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
+use CultuurNet\UDB3\Place\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Place\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Place\Events\CalendarUpdated;
 use CultuurNet\UDB3\Place\Events\ContactPointUpdated;
@@ -168,6 +169,9 @@ final class HistoryProjector extends BaseHistoryProjector
                 break;
             case $event instanceof Rejected:
                 $this->projectRejected($domainMessage);
+                break;
+            case $event instanceof AvailableFromUpdated:
+                $this->projectAvailableFromUpdated($domainMessage);
                 break;
             case $event instanceof TitleTranslated:
                 $this->projectTitleTranslated($domainMessage);

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
+use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\Event\Events\VideoDeleted;
 use CultuurNet\UDB3\Event\Events\VideoUpdated;
@@ -1492,6 +1493,35 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Thema aangepast',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_theme_removed(): void
+    {
+        $event = new ThemeRemoved(self::EVENT_ID_1);
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Thema verwijderd',
                 ],
             ]
         );

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\ReadModel\History;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -58,12 +59,15 @@ use CultuurNet\UDB3\Event\ValueObjects\Audience;
 use CultuurNet\UDB3\Event\ValueObjects\AudienceType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Label;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
@@ -78,7 +82,7 @@ use PHPUnit\Framework\TestCase;
 use ValueObjects\Identity\UUID;
 use ValueObjects\Money\Currency;
 use ValueObjects\StringLiteral\StringLiteral;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class HistoryProjectorTest extends TestCase
 {
@@ -270,7 +274,7 @@ class HistoryProjectorTest extends TestCase
 
         $eventCreated = new EventCreated(
             $eventId,
-            new Language('en'),
+            new LegacyLanguage('en'),
             new Title('Faith no More'),
             new EventType('0.50.4.0.0', 'Concert'),
             new LocationId('7a59de16-6111-4658-aa6e-958ff855d14e'),
@@ -349,7 +353,7 @@ class HistoryProjectorTest extends TestCase
     {
         $titleTranslated = new TitleTranslated(
             self::EVENT_ID_1,
-            new Language('fr'),
+            new LegacyLanguage('fr'),
             new Title('Titre en français')
         );
 
@@ -384,7 +388,7 @@ class HistoryProjectorTest extends TestCase
     {
         $descriptionTranslated = new DescriptionTranslated(
             self::EVENT_ID_1,
-            new Language('fr'),
+            new LegacyLanguage('fr'),
             new Description('Signalement en français')
         );
 
@@ -815,8 +819,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImageAdded(self::EVENT_ID_1, $image);
@@ -853,8 +857,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImageRemoved(self::EVENT_ID_1, $image);
@@ -925,8 +929,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
+            new LegacyLanguage('en')
         );
 
         $image2 = new Image(
@@ -934,8 +938,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImagesImportedFromUDB2(
@@ -982,8 +986,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
+            new LegacyLanguage('en')
         );
 
         $image2 = new Image(
@@ -991,8 +995,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImagesUpdatedFromUDB2(
@@ -1024,6 +1028,42 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Afbeelding \'f1926870-136c-4b06-b2a1-1fab01590847\' aangepast via UDB2',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_added(): void
+    {
+        $event = new VideoAdded(
+            self::EVENT_ID_1,
+            new Video(
+                '91c75325-3830-4000-b580-5778b2de4548',
+                new Url('https://www.youtube.com/watch?v=123'),
+                new Language('nl')
+            )
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
                 ],
             ]
         );
@@ -1097,8 +1137,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new MainImageSelected(self::EVENT_ID_1, $image);

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event\ReadModel\History;
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\Event\Events\VideoDeleted;
 use CultuurNet\UDB3\Event\Events\VideoUpdated;
@@ -1430,6 +1431,38 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => "Afgekeurd, reden: 'not good enough'",
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_available_from_updated(): void
+    {
+        $event = new AvailableFromUpdated(
+            self::EVENT_ID_1,
+            new DateTimeImmutable('2023-10-10T11:22:00+00:00')
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Publicatiedatum aangepast',
                 ],
             ]
         );

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
 use CultuurNet\UDB3\Event\Events\VideoDeleted;
+use CultuurNet\UDB3\Event\Events\VideoUpdated;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -1097,6 +1098,42 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_updated(): void
+    {
+        $event = new VideoUpdated(
+            self::EVENT_ID_1,
+            new Video(
+                '91c75325-3830-4000-b580-5778b2de4548',
+                new Url('https://www.youtube.com/watch?v=123'),
+                new Language('nl')
+            )
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' aangepast',
                 ],
             ]
         );

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
+use CultuurNet\UDB3\Event\Events\VideoDeleted;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -1064,6 +1065,38 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_deleted(): void
+    {
+        $event = new VideoDeleted(
+            self::EVENT_ID_1,
+            '91c75325-3830-4000-b580-5778b2de4548'
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            self::EVENT_ID_1,
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
                 ],
             ]
         );

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -70,6 +70,7 @@ use CultuurNet\UDB3\Place\Events\TypeUpdated;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Place\Events\VideoAdded;
+use CultuurNet\UDB3\Place\Events\VideoDeleted;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -635,6 +636,38 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_deleted(): void
+    {
+        $event = new VideoDeleted(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            '91c75325-3830-4000-b580-5778b2de4548'
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
                 ],
             ]
         );

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -71,6 +71,7 @@ use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Place\Events\VideoAdded;
 use CultuurNet\UDB3\Place\Events\VideoDeleted;
+use CultuurNet\UDB3\Place\Events\VideoUpdated;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -668,6 +669,42 @@ class HistoryProjectorTest extends TestCase
                     'date' => '2015-03-27T10:17:19+02:00',
                     'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
                     'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' verwijderd',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_updated(): void
+    {
+        $event = new VideoUpdated(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            new Video(
+                '91c75325-3830-4000-b580-5778b2de4548',
+                new Url('https://www.youtube.com/watch?v=123'),
+                new Language('nl')
+            )
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' aangepast',
                 ],
             ]
         );

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -33,6 +33,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
+use CultuurNet\UDB3\Place\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Place\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Place\Events\CalendarUpdated;
 use CultuurNet\UDB3\Place\Events\ContactPointUpdated;
@@ -916,6 +917,38 @@ class HistoryProjectorTest extends TestCase
         $this->assertHistoryContainsLogWithDescription(
             $event->getItemId(),
             "Afgekeurd, reden: 'not good enough'"
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_available_from_updated(): void
+    {
+        $event = new AvailableFromUpdated(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            new DateTimeImmutable('2023-10-10T11:22:00+00:00')
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Publicatiedatum aangepast',
+                ],
+            ]
         );
     }
 

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -21,12 +21,15 @@ use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Label;
-use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Media\ImageCollection;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Video;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\Place\Events\AddressTranslated;
 use CultuurNet\UDB3\Place\Events\AddressUpdated;
@@ -66,6 +69,7 @@ use CultuurNet\UDB3\Place\Events\TitleUpdated;
 use CultuurNet\UDB3\Place\Events\TypeUpdated;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Place\Events\TypicalAgeRangeUpdated;
+use CultuurNet\UDB3\Place\Events\VideoAdded;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
 use CultuurNet\UDB3\PriceInfo\Price;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
@@ -79,7 +83,7 @@ use ValueObjects\Geography\Country;
 use ValueObjects\Identity\UUID;
 use ValueObjects\Money\Currency;
 use ValueObjects\StringLiteral\StringLiteral;
-use ValueObjects\Web\Url;
+use ValueObjects\Web\Url as LegacyUrl;
 
 class HistoryProjectorTest extends TestCase
 {
@@ -449,8 +453,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImageAdded('a0ee7b1c-a9c1-4da1-af7e-d15496014656', $image);
@@ -474,8 +478,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImageRemoved('a0ee7b1c-a9c1-4da1-af7e-d15496014656', $image);
@@ -520,8 +524,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
+            new LegacyLanguage('en')
         );
 
         $image2 = new Image(
@@ -529,8 +533,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImagesImportedFromUDB2(
@@ -565,8 +569,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test1.jpg'),
+            new LegacyLanguage('en')
         );
 
         $image2 = new Image(
@@ -574,8 +578,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test2.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new ImagesUpdatedFromUDB2(
@@ -597,6 +601,42 @@ class HistoryProjectorTest extends TestCase
         $this->assertHistoryContainsLogWithDescription(
             (string) $event->getItemId(),
             'Afbeelding \'f1926870-136c-4b06-b2a1-1fab01590847\' aangepast via UDB2'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_video_added(): void
+    {
+        $event = new VideoAdded(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            new Video(
+                '91c75325-3830-4000-b580-5778b2de4548',
+                new Url('https://www.youtube.com/watch?v=123'),
+                new Language('nl')
+            )
+        );
+
+        $domainMessage = new DomainMessage(
+            $event->getItemId(),
+            3,
+            new Metadata(['user_id' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7']),
+            $event,
+            DateTime::fromString('2015-03-27T10:17:19.176169+02:00')
+        );
+
+        $this->historyProjector->handle($domainMessage);
+
+        $this->assertHistoryContainsLogs(
+            'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
+            [
+                (object) [
+                    'date' => '2015-03-27T10:17:19+02:00',
+                    'author' => 'fc54f5c1-aa5a-45d1-837e-919b742ca6c7',
+                    'description' => 'Video \'91c75325-3830-4000-b580-5778b2de4548\' toegevoegd',
+                ],
+            ]
         );
     }
 
@@ -626,8 +666,8 @@ class HistoryProjectorTest extends TestCase
             MIMEType::fromSubtype('jpeg'),
             new \CultuurNet\UDB3\Media\Properties\Description('description'),
             new CopyrightHolder('copyright holder'),
-            Url::fromNative('https://io.uitdatabank.be/media/test.jpg'),
-            new Language('en')
+            LegacyUrl::fromNative('https://io.uitdatabank.be/media/test.jpg'),
+            new LegacyLanguage('en')
         );
 
         $event = new MainImageSelected('a0ee7b1c-a9c1-4da1-af7e-d15496014656', $image);
@@ -898,7 +938,7 @@ class HistoryProjectorTest extends TestCase
     {
         return new PlaceCreated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            new Language('en'),
+            new LegacyLanguage('en'),
             new Title('Foo'),
             new EventType('1.8.2', 'PARTY!'),
             new Address(
@@ -954,7 +994,7 @@ class HistoryProjectorTest extends TestCase
     {
         return new DescriptionTranslated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            new Language('en'),
+            new LegacyLanguage('en'),
             new Description('description')
         );
     }
@@ -963,7 +1003,7 @@ class HistoryProjectorTest extends TestCase
     {
         return new TitleTranslated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            new Language('en'),
+            new LegacyLanguage('en'),
             new Title('Title')
         );
     }
@@ -1009,7 +1049,7 @@ class HistoryProjectorTest extends TestCase
                 new Locality('Leuven'),
                 Country::fromNative('BE')
             ),
-            new Language('en')
+            new LegacyLanguage('en')
         );
     }
 


### PR DESCRIPTION
### Added
- Project `VideoAdded` inside the history of a **place** or **event**
- Project `VideoDeleted` inside the history of a **place** or **event**
- Project `VideoUpdated` inside the history of a **place** or **event**
- Project `AvailableFromUpdated` inside the history of a **place** or **event**
- Project `ThemeRemoved` inside the history of an **event**

---
Ticket: https://jira.uitdatabank.be/browse/III-4380
