### PR TITLE
III-4384 Replace urls for media object

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -73,7 +73,7 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 
-                $repository = new MediaUrlOfferRepositoryDecorator($repository, $app['media_url_repository']);
+                $repository = new MediaUrlOfferRepositoryDecorator($repository, $app['media_url_mapping']);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/app/Media/MediaControllerProvider.php
+++ b/app/Media/MediaControllerProvider.php
@@ -21,7 +21,8 @@ class MediaControllerProvider implements ControllerProviderInterface
             function (Application $app) {
                 return new ReadMediaRestController(
                     $app['media_manager'],
-                    $app['media_object_serializer']
+                    $app['media_object_serializer'],
+                    $app['media_mapping_url']
                 );
             }
         );

--- a/app/Media/MediaServiceProvider.php
+++ b/app/Media/MediaServiceProvider.php
@@ -102,7 +102,7 @@ class MediaServiceProvider implements ServiceProviderInterface
             }
         );
 
-        $app['media_url_repository'] = $app->share(
+        $app['media_url_mapping'] = $app->share(
             function (Application $app) {
                 return new MediaUrlMapping($app['config']['media']['media_url_mapping']);
             }

--- a/app/Media/MediaServiceProvider.php
+++ b/app/Media/MediaServiceProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Silex\Media;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Media\ImageUploaderService;
-use CultuurNet\UDB3\Media\MediaUrlRepository;
+use CultuurNet\UDB3\Media\MediaUrlMapping;
 use CultuurNet\UDB3\Media\MediaManager;
 use CultuurNet\UDB3\Media\MediaObjectRepository;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
@@ -104,7 +104,7 @@ class MediaServiceProvider implements ServiceProviderInterface
 
         $app['media_url_repository'] = $app->share(
             function (Application $app) {
-                return new MediaUrlRepository($app['config']['media']['media_url_mapping']);
+                return new MediaUrlMapping($app['config']['media']['media_url_mapping']);
             }
         );
     }

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -105,7 +105,7 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 
-                $repository = new MediaUrlOfferRepositoryDecorator($repository, $app['media_url_repository']);
+                $repository = new MediaUrlOfferRepositoryDecorator($repository, $app['media_url_mapping']);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/src/Http/Media/ReadMediaRestController.php
+++ b/src/Http/Media/ReadMediaRestController.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Http\Media;
 use Broadway\Repository\AggregateNotFoundException;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Media\MediaManager;
+use CultuurNet\UDB3\Media\MediaUrlMapping;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use ValueObjects\Identity\UUID;
@@ -17,12 +18,16 @@ final class ReadMediaRestController
 
     private MediaObjectSerializer $serializer;
 
+    private MediaUrlMapping $mediaUrlMapping;
+
     public function __construct(
         MediaManager $mediaManager,
-        MediaObjectSerializer $serializer
+        MediaObjectSerializer $serializer,
+        MediaUrlMapping $mediaUrlMapping
     ) {
         $this->mediaManager = $mediaManager;
         $this->serializer = $serializer;
+        $this->mediaUrlMapping = $mediaUrlMapping;
     }
 
     public function get($id): JsonResponse
@@ -36,6 +41,9 @@ final class ReadMediaRestController
         }
 
         $serializedMediaObject = $this->serializer->serialize($mediaObject);
+
+        $serializedMediaObject['contentUrl'] = $this->mediaUrlMapping->getUpdatedUrl($serializedMediaObject['contentUrl']);
+        $serializedMediaObject['thumbnailUrl'] = $this->mediaUrlMapping->getUpdatedUrl($serializedMediaObject['thumbnailUrl']);
 
         return JsonResponse::create($serializedMediaObject);
     }

--- a/src/Http/Media/ReadMediaRestController.php
+++ b/src/Http/Media/ReadMediaRestController.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use ValueObjects\Identity\UUID;
 
-class ReadMediaRestController
+final class ReadMediaRestController
 {
     private MediaManager $mediaManager;
 

--- a/src/Http/Media/ReadMediaRestController.php
+++ b/src/Http/Media/ReadMediaRestController.php
@@ -13,15 +13,9 @@ use ValueObjects\Identity\UUID;
 
 class ReadMediaRestController
 {
-    /**
-     * @var MediaManager;
-     */
-    protected $mediaManager;
+    protected MediaManager $mediaManager;
 
-    /**
-     * @var MediaObjectSerializer
-     */
-    protected $serializer;
+    protected MediaObjectSerializer $serializer;
 
     public function __construct(
         MediaManager $mediaManager,
@@ -31,7 +25,7 @@ class ReadMediaRestController
         $this->serializer = $serializer;
     }
 
-    public function get($id)
+    public function get($id): JsonResponse
     {
         try {
             $mediaObject = $this->mediaManager->get(new UUID($id));

--- a/src/Http/Media/ReadMediaRestController.php
+++ b/src/Http/Media/ReadMediaRestController.php
@@ -13,9 +13,9 @@ use ValueObjects\Identity\UUID;
 
 class ReadMediaRestController
 {
-    protected MediaManager $mediaManager;
+    private MediaManager $mediaManager;
 
-    protected MediaObjectSerializer $serializer;
+    private MediaObjectSerializer $serializer;
 
     public function __construct(
         MediaManager $mediaManager,

--- a/src/Media/MediaUrlMapping.php
+++ b/src/Media/MediaUrlMapping.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media;
 
-final class MediaUrlRepository
+final class MediaUrlMapping
 {
     private array $mediaUrlMappings;
 

--- a/src/Media/MediaUrlMapping.php
+++ b/src/Media/MediaUrlMapping.php
@@ -15,7 +15,7 @@ final class MediaUrlMapping
 
     public function getUpdatedUrl(string $oldUrl): string
     {
-        foreach ($this->mediaUrlMappings as $udbVariant => $mediaUrlMapping) {
+        foreach ($this->mediaUrlMappings as $mediaUrlMapping) {
             if ($mediaUrlMapping['enabled'] && strpos($oldUrl, $mediaUrlMapping['legacy_url']) === 0) {
                 return str_replace($mediaUrlMapping['legacy_url'], $mediaUrlMapping['url'], $oldUrl);
             }

--- a/src/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecorator.php
+++ b/src/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecorator.php
@@ -11,12 +11,12 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 
 final class MediaUrlOfferRepositoryDecorator extends DocumentRepositoryDecorator
 {
-    private MediaUrlMapping $mediaUrlRepository;
+    private MediaUrlMapping $mediaUrlMapping;
 
-    public function __construct(DocumentRepository $repository, MediaUrlMapping $mediaUrlRepository)
+    public function __construct(DocumentRepository $repository, MediaUrlMapping $mediaUrlMapping)
     {
         parent::__construct($repository);
-        $this->mediaUrlRepository = $mediaUrlRepository;
+        $this->mediaUrlMapping = $mediaUrlMapping;
     }
 
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
@@ -36,8 +36,8 @@ final class MediaUrlOfferRepositoryDecorator extends DocumentRepositoryDecorator
                             return $mediaObject;
                         }
 
-                        $mediaObject['contentUrl'] = $this->mediaUrlRepository->getUpdatedUrl($mediaObject['contentUrl']);
-                        $mediaObject['thumbnailUrl'] = $this->mediaUrlRepository->getUpdatedUrl($mediaObject['thumbnailUrl']);
+                        $mediaObject['contentUrl'] = $this->mediaUrlMapping->getUpdatedUrl($mediaObject['contentUrl']);
+                        $mediaObject['thumbnailUrl'] = $this->mediaUrlMapping->getUpdatedUrl($mediaObject['thumbnailUrl']);
 
                         return $mediaObject;
                     },
@@ -47,7 +47,7 @@ final class MediaUrlOfferRepositoryDecorator extends DocumentRepositoryDecorator
                 if (!isset($json['image']) || !is_string($json['image'])) {
                     return $json;
                 }
-                $json['image'] = $this->mediaUrlRepository->getUpdatedUrl($json['image']);
+                $json['image'] = $this->mediaUrlMapping->getUpdatedUrl($json['image']);
 
                 return $json;
             }

--- a/src/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecorator.php
+++ b/src/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecorator.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
-use CultuurNet\UDB3\Media\MediaUrlRepository;
+use CultuurNet\UDB3\Media\MediaUrlMapping;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 
 final class MediaUrlOfferRepositoryDecorator extends DocumentRepositoryDecorator
 {
-    private MediaUrlRepository $mediaUrlRepository;
+    private MediaUrlMapping $mediaUrlRepository;
 
-    public function __construct(DocumentRepository $repository, MediaUrlRepository $mediaUrlRepository)
+    public function __construct(DocumentRepository $repository, MediaUrlMapping $mediaUrlRepository)
     {
         parent::__construct($repository);
         $this->mediaUrlRepository = $mediaUrlRepository;

--- a/tests/Http/Media/ReadMediaRestControllerTest.php
+++ b/tests/Http/Media/ReadMediaRestControllerTest.php
@@ -76,7 +76,7 @@ class ReadMediaRestControllerTest extends TestCase
                 'thumbnailUrl' => 'https://images.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg',
                 'description' => 'UDB2 image',
                 'copyrightHolder' => 'publiq',
-                'inLanguage' => 'nl'
+                'inLanguage' => 'nl',
             ]),
             $response->getContent()
         );

--- a/tests/Http/Media/ReadMediaRestControllerTest.php
+++ b/tests/Http/Media/ReadMediaRestControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Media;
+
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Media\MediaManager;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\MediaUrlMapping;
+use CultuurNet\UDB3\Media\Properties\MIMEType;
+use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use PHPUnit\Framework\TestCase;
+use ValueObjects\Identity\UUID;
+use ValueObjects\StringLiteral\StringLiteral;
+use ValueObjects\Web\Url;
+
+class ReadMediaRestControllerTest extends TestCase
+{
+    private ReadMediaRestController $readMediaRestController;
+
+    protected function setUp(): void
+    {
+        $id = '5624b810-c340-40a4-8f38-0393eca59bfe';
+        $mapping = [
+            'udb2' => [
+                'enabled' => true,
+                'legacy_url' => 'https://media.uitdatabank.be/',
+                'url' => 'https://images.uitdatabank.be/',
+            ],
+        ];
+
+        $mediaManager = $this->createMock(MediaManager::class);
+        $mediaManager->expects($this->once())
+            ->method('get')
+            ->with($id)
+            ->willReturn(
+                MediaObject::create(
+                    new UUID($id),
+                    MIMEType::fromSubtype('jpeg'),
+                    new StringLiteral('UDB2 image'),
+                    new CopyrightHolder('publiq'),
+                    Url::fromNative('https://media.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg'),
+                    new Language('nl')
+                )
+            );
+
+        $iriGenerator = $this->createMock(IriGeneratorInterface::class);
+        $iriGenerator->expects($this->once())
+            ->method('iri')
+            ->with($id)
+            ->willReturn('https://io.uitdatabank.be/images/5624b810-c340-40a4-8f38-0393eca59bfe');
+
+        $this->readMediaRestController = new ReadMediaRestController(
+            $mediaManager,
+            new MediaObjectSerializer($iriGenerator),
+            new MediaUrlMapping($mapping)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_a_media_object(): void
+    {
+        $response = $this->readMediaRestController->get('5624b810-c340-40a4-8f38-0393eca59bfe');
+
+        $this->assertEquals(
+            Json::encode([
+                '@id' => 'https://io.uitdatabank.be/images/5624b810-c340-40a4-8f38-0393eca59bfe',
+                '@type' => 'schema:ImageObject',
+                'contentUrl' => 'https://images.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg',
+                'thumbnailUrl' => 'https://images.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg',
+                'description' => 'UDB2 image',
+                'copyrightHolder' => 'publiq',
+                'inLanguage' => 'nl'
+            ]),
+            $response->getContent()
+        );
+    }
+}

--- a/tests/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecoratorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/MediaUrlOfferRepositoryDecoratorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\Media\MediaUrlRepository;
+use CultuurNet\UDB3\Media\MediaUrlMapping;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
@@ -99,7 +99,7 @@ final class MediaUrlOfferRepositoryDecoratorTest extends TestCase
 
         $mediaUrlOfferRepositoryDecoratorDecorator = new MediaUrlOfferRepositoryDecorator(
             new InMemoryDocumentRepository(),
-            new MediaUrlRepository($mapping)
+            new MediaUrlMapping($mapping)
         );
         $givenDocument = new JsonDocument($id, Json::encode(self::GIVEN_JSON));
 
@@ -131,7 +131,7 @@ final class MediaUrlOfferRepositoryDecoratorTest extends TestCase
 
         $mediaUrlOfferRepositoryDecorator = new MediaUrlOfferRepositoryDecorator(
             new InMemoryDocumentRepository(),
-            new MediaUrlRepository($mapping)
+            new MediaUrlMapping($mapping)
         );
         $givenDocument = new JsonDocument($id, Json::encode(self::GIVEN_JSON));
 


### PR DESCRIPTION
### Changed
- Rename `MediaUrlRepository` to `MediaUrlMapping`
- Map the contentUrl and thumbnailUrl from `mediaObject`

---
Ticket: https://jira.uitdatabank.be/browse/III-4384
