### PR TITLE
III-4384 Use correct key media_url_mapping

### DIFF
--- a/app/Media/MediaControllerProvider.php
+++ b/app/Media/MediaControllerProvider.php
@@ -22,7 +22,7 @@ class MediaControllerProvider implements ControllerProviderInterface
                 return new ReadMediaRestController(
                     $app['media_manager'],
                     $app['media_object_serializer'],
-                    $app['media_mapping_url']
+                    $app['media_url_mapping']
                 );
             }
         );


### PR DESCRIPTION
### Fixed
- Use correct key `media_url_mapping` instead of `media_mapping_mapping`

---
Ticket: https://jira.uitdatabank.be/browse/III-4384
