### PR TITLE
III-4392 Refactor organizer TitleTranslated value objects in constructor

### DIFF
--- a/src/Organizer/Events/TitleTranslated.php
+++ b/src/Organizer/Events/TitleTranslated.php
@@ -9,15 +9,8 @@ use CultuurNet\UDB3\Title;
 
 final class TitleTranslated extends OrganizerEvent
 {
-    /**
-     * @var Title
-     */
-    private $title;
-
-    /**
-     * @var Language
-     */
-    private $language;
+    private string $title;
+    private string $language;
 
     public function __construct(
         string $organizerId,
@@ -26,25 +19,25 @@ final class TitleTranslated extends OrganizerEvent
     ) {
         parent::__construct($organizerId);
 
-        $this->title = $title;
-        $this->language = $language;
+        $this->title = $title->toNative();
+        $this->language = $language->getCode();
     }
 
     public function getTitle(): Title
     {
-        return $this->title;
+        return new Title($this->title);
     }
 
     public function getLanguage(): Language
     {
-        return $this->language;
+        return new Language($this->language);
     }
 
     public function serialize(): array
     {
         return parent::serialize() + [
-            'title' => $this->getTitle()->toNative(),
-            'language' => $this->getLanguage()->getCode(),
+            'title' => $this->title,
+            'language' => $this->language,
         ];
     }
 

--- a/src/Organizer/Events/TitleTranslated.php
+++ b/src/Organizer/Events/TitleTranslated.php
@@ -14,13 +14,13 @@ final class TitleTranslated extends OrganizerEvent
 
     public function __construct(
         string $organizerId,
-        Title $title,
-        Language $language
+        string $title,
+        string $language
     ) {
         parent::__construct($organizerId);
 
-        $this->title = $title->toNative();
-        $this->language = $language->getCode();
+        $this->title = $title;
+        $this->language = $language;
     }
 
     public function getTitle(): Title

--- a/src/Organizer/Events/TitleTranslated.php
+++ b/src/Organizer/Events/TitleTranslated.php
@@ -45,8 +45,8 @@ final class TitleTranslated extends OrganizerEvent
     {
         return new static(
             $data['organizer_id'],
-            new Title($data['title']),
-            new Language($data['language'])
+            $data['title'],
+            $data['language']
         );
     }
 }

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -144,8 +144,8 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
             if ($language->getCode() !== $this->mainLanguage->getCode()) {
                 $event = new TitleTranslated(
                     $this->actorId,
-                    LegacyTitle::fromUdb3ModelTitle($title),
-                    LegacyLanguage::fromUdb3ModelLanguage($language)
+                    $title->toString(),
+                    $language->toString()
                 );
             } else {
                 $event = new TitleUpdated(

--- a/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
@@ -55,7 +55,7 @@ final class UpdateTitleHandlerTest extends CommandHandlerScenarioTestCase
             ->withAggregateId($id)
             ->given([$this->organizerCreated($id)])
             ->when(new UpdateTitle($id, new Title('New Title'), new Language('fr')))
-            ->then([new TitleTranslated($id, new LegacyTitle('New Title'), new LegacyLanguage('fr'))]);
+            ->then([new TitleTranslated($id, 'New Title', 'fr')]);
     }
 
     private function organizerCreated(string $id): OrganizerCreated

--- a/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
@@ -12,7 +12,6 @@ use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
-use CultuurNet\UDB3\Language as LegacyLanguage;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Organizer\Commands\UpdateTitle;

--- a/tests/Organizer/Events/TitleTranslatedTest.php
+++ b/tests/Organizer/Events/TitleTranslatedTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Events;
 
-use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\TestCase;
 
 class TitleTranslatedTest extends TestCase

--- a/tests/Organizer/Events/TitleTranslatedTest.php
+++ b/tests/Organizer/Events/TitleTranslatedTest.php
@@ -15,15 +15,9 @@ class TitleTranslatedTest extends TestCase
      */
     private $organizerId;
 
-    /**
-     * @var Title
-     */
-    private $title;
+    private string $title;
 
-    /**
-     * @var Language
-     */
-    private $language;
+    private string $language;
 
     /**
      * @var TitleTranslated
@@ -39,9 +33,9 @@ class TitleTranslatedTest extends TestCase
     {
         $this->organizerId = '3ad6c135-9b2d-4360-8886-3a58aaf66039';
 
-        $this->title = new Title('Het Depot');
+        $this->title = 'Het Depot';
 
-        $this->language = new Language('nl');
+        $this->language = 'nl';
 
         $this->titleTranslated = new TitleTranslated(
             $this->organizerId,
@@ -51,8 +45,8 @@ class TitleTranslatedTest extends TestCase
 
         $this->titleTranslatedAsArray = [
             'organizer_id' =>  $this->organizerId,
-            'title' => $this->title->toNative(),
-            'language' => $this->language->getCode(),
+            'title' => $this->title,
+            'language' => $this->language,
         ];
     }
 

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -474,15 +474,14 @@ class OrganizerLDProjectorTest extends TestCase
     public function it_handles_title_translated()
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
-        $title = new Title('EssaiOrganisation');
 
         $this->mockGet($organizerId, 'organizer.json');
 
         $domainMessage = $this->createDomainMessage(
             new TitleTranslated(
                 $organizerId,
-                $title,
-                new Language('fr')
+                'EssaiOrganisation',
+                'fr'
             )
         );
 
@@ -524,15 +523,14 @@ class OrganizerLDProjectorTest extends TestCase
     public function it_handles_translation_of_organizer_with_untranslated_name()
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
-        $title = new Title('EssaiOrganisation');
 
         $this->mockGet($organizerId, 'organizer_untranslated_name.json');
 
         $domainMessage = $this->createDomainMessage(
             new TitleTranslated(
                 $organizerId,
-                $title,
-                new Language('fr')
+                'EssaiOrganisation',
+                'fr'
             )
         );
 

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -457,13 +457,13 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     ),
                     new TitleTranslated(
                         $this->id,
-                        new LegacyTitle('Le Depot'),
-                        new LegacyLanguage('fr')
+                        'Le Depot',
+                        'fr'
                     ),
                     new TitleTranslated(
                         $this->id,
-                        new LegacyTitle('STUK'),
-                        new LegacyLanguage('fr')
+                        'STUK',
+                        'fr'
                     ),
                 ]
             );
@@ -492,8 +492,8 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                 [
                     new TitleTranslated(
                         $this->id,
-                        new LegacyTitle('Pièce'),
-                        new LegacyLanguage('fr')
+                        'Pièce',
+                        'fr'
                     ),
                 ]
             );


### PR DESCRIPTION
### Changed

- Changed `CultuurNet\UDB3\Organizer\Events\TitleTranslated` to use scalar types in constructor and internally

---
Ticket: https://jira.uitdatabank.be/browse/III-4392
