### PR TITLE
III-4393 Refactor TitleTranslated constructor to use primitive types

### DIFF
--- a/src/Organizer/Events/TitleUpdated.php
+++ b/src/Organizer/Events/TitleUpdated.php
@@ -8,14 +8,11 @@ use CultuurNet\UDB3\Title;
 
 final class TitleUpdated extends OrganizerEvent
 {
-    /**
-     * @var Title
-     */
-    private $title;
+    private string $title;
 
     public function __construct(
         string $organizerId,
-        Title $title
+        string $title
     ) {
         parent::__construct($organizerId);
         $this->title = $title;
@@ -23,13 +20,13 @@ final class TitleUpdated extends OrganizerEvent
 
     public function getTitle(): Title
     {
-        return $this->title;
+        return new Title($this->title);
     }
 
     public function serialize(): array
     {
         return parent::serialize() + [
-            'title' => $this->getTitle()->toNative(),
+            'title' => $this->title,
         ];
     }
 
@@ -37,7 +34,7 @@ final class TitleUpdated extends OrganizerEvent
     {
         return new static(
             $data['organizer_id'],
-            new Title($data['title'])
+            $data['title']
         );
     }
 }

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -150,7 +150,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
             } else {
                 $event = new TitleUpdated(
                     $this->actorId,
-                    LegacyTitle::fromUdb3ModelTitle($title)
+                    $title->toString()
                 );
             }
 

--- a/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
+++ b/tests/Organizer/CommandHandler/UpdateTitleHandlerTest.php
@@ -40,7 +40,7 @@ final class UpdateTitleHandlerTest extends CommandHandlerScenarioTestCase
             ->withAggregateId($id)
             ->given([$this->organizerCreated($id)])
             ->when(new UpdateTitle($id, new Title('Nieuwe Titel'), new Language('nl')))
-            ->then([new TitleUpdated($id, new LegacyTitle('Nieuwe Titel'))]);
+            ->then([new TitleUpdated($id, 'Nieuwe Titel')]);
     }
 
     /**

--- a/tests/Organizer/Events/TitleUpdatedTest.php
+++ b/tests/Organizer/Events/TitleUpdatedTest.php
@@ -29,7 +29,7 @@ class TitleUpdatedTest extends TestCase
      */
     private $titleUpdatedAsArray;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->organizerId = '3ad6c135-9b2d-4360-8886-3a58aaf66039';
 
@@ -49,7 +49,7 @@ class TitleUpdatedTest extends TestCase
     /**
      * @test
      */
-    public function it_can_serialize_to_an_array()
+    public function it_can_serialize_to_an_array(): void
     {
         $this->assertEquals(
             $this->titleUpdatedAsArray,
@@ -60,7 +60,7 @@ class TitleUpdatedTest extends TestCase
     /**
      * @test
      */
-    public function it_can_deserialize_from_an_array()
+    public function it_can_deserialize_from_an_array(): void
     {
         $this->assertEquals(
             TitleUpdated::deserialize($this->titleUpdatedAsArray),

--- a/tests/Organizer/Events/TitleUpdatedTest.php
+++ b/tests/Organizer/Events/TitleUpdatedTest.php
@@ -4,45 +4,28 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Events;
 
-use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\TestCase;
 
 class TitleUpdatedTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $organizerId;
+    private TitleUpdated $titleUpdated;
 
-    /**
-     * @var Title
-     */
-    private $title;
-
-    /**
-     * @var TitleUpdated
-     */
-    private $titleUpdated;
-
-    /**
-     * @var array
-     */
-    private $titleUpdatedAsArray;
+    private array $titleUpdatedAsArray;
 
     protected function setUp(): void
     {
-        $this->organizerId = '3ad6c135-9b2d-4360-8886-3a58aaf66039';
+        $organizerId = '3ad6c135-9b2d-4360-8886-3a58aaf66039';
 
-        $this->title = new Title('Het Depot');
+        $title = 'Het Depot';
 
         $this->titleUpdated = new TitleUpdated(
-            $this->organizerId,
-            $this->title
+            $organizerId,
+            $title
         );
 
         $this->titleUpdatedAsArray = [
-            'organizer_id' =>  $this->organizerId,
-            'title' => $this->title->toNative(),
+            'organizer_id' =>  $organizerId,
+            'title' => $title,
         ];
     }
 

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -283,7 +283,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_title_update()
+    public function it_handles_title_update(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
         $title = 'Het Depot';

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -18,7 +18,6 @@ use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
-use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
@@ -50,38 +49,22 @@ use ValueObjects\Web\Url;
 
 class OrganizerLDProjectorTest extends TestCase
 {
-    /**
-     * @var OrganizerLDProjector
-     */
-    protected $projector;
+    protected OrganizerLDProjector $projector;
 
     /**
      * @var DocumentRepository|MockObject
      */
     protected $documentRepository;
 
-    /**
-     * @var EventBus|MockObject
-     */
-    private $eventBus;
+    private RecordedOn $recordedOn;
 
-    /**
-     * @var IriGeneratorInterface
-     */
-    private $iriGenerator;
-
-    /**
-     * @var RecordedOn
-     */
-    private $recordedOn;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->documentRepository = $this->createMock(DocumentRepository::class);
 
-        $this->eventBus = $this->createMock(EventBus::class);
+        $eventBus = $this->createMock(EventBus::class);
 
-        $this->iriGenerator = new CallableIriGenerator(
+        $iriGenerator = new CallableIriGenerator(
             function ($id) {
                 return 'http://example.com/entity/' . $id;
             }
@@ -89,8 +72,8 @@ class OrganizerLDProjectorTest extends TestCase
 
         $this->projector = new OrganizerLDProjector(
             $this->documentRepository,
-            $this->iriGenerator,
-            $this->eventBus,
+            $iriGenerator,
+            $eventBus,
             new JsonDocumentLanguageEnricher(
                 new OrganizerJsonDocumentLanguageAnalyzer()
             )
@@ -101,11 +84,7 @@ class OrganizerLDProjectorTest extends TestCase
         );
     }
 
-    /**
-     * @param string $fileName
-     * @return OrganizerImportedFromUDB2
-     */
-    private function organizerImportedFromUDB2($fileName)
+    private function organizerImportedFromUDB2(string $fileName): OrganizerImportedFromUDB2
     {
         $cdbXml = file_get_contents(
             __DIR__ . '/Samples/' . $fileName
@@ -120,29 +99,23 @@ class OrganizerLDProjectorTest extends TestCase
         return $event;
     }
 
-    /**
-     * @param string $fileName
-     * @return OrganizerUpdatedFromUDB2
-     */
-    private function organizerUpdatedFromUDB2($fileName)
+    private function organizerUpdatedFromUDB2(string $fileName): OrganizerUpdatedFromUDB2
     {
         $cdbXml = file_get_contents(
             __DIR__ . '/Samples/' . $fileName
         );
 
-        $event = new OrganizerUpdatedFromUDB2(
+        return new OrganizerUpdatedFromUDB2(
             'someId',
             $cdbXml,
             'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
         );
-
-        return $event;
     }
 
     /**
      * @test
      */
-    public function it_handles_new_organizers()
+    public function it_handles_new_organizers(): void
     {
         $uuidGenerator = new Version4Generator();
         $id = $uuidGenerator->generate();
@@ -211,7 +184,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_new_organizers_with_unique_website()
+    public function it_handles_new_organizers_with_unique_website(): void
     {
         $uuidGenerator = new Version4Generator();
         $id = $uuidGenerator->generate();
@@ -261,7 +234,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_website_update()
+    public function it_handles_website_update(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
         $website = Url::fromNative('http://www.depot.be');
@@ -302,10 +275,7 @@ class OrganizerLDProjectorTest extends TestCase
         $this->projector->handle($domainMessage);
     }
 
-    /**
-     * Data provider for it_handles_address_updated()
-     */
-    public function addressUpdatesDataProvider()
+    public function addressUpdatesDataProvider(): array
     {
         return [
             'organizer with former address' => [
@@ -323,7 +293,7 @@ class OrganizerLDProjectorTest extends TestCase
      * @test
      * @dataProvider addressUpdatesDataProvider
      */
-    public function it_handles_address_updated($currentJson, $expectedJson)
+    public function it_handles_address_updated($currentJson, $expectedJson): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -349,7 +319,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_address_removed()
+    public function it_handles_address_removed(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -369,7 +339,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_set_name_when_importing_from_udb2()
+    public function it_should_set_name_when_importing_from_udb2(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_email.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -391,7 +361,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_update_name_when_updating_from_udb2_and_keep_missing_translations()
+    public function it_should_update_name_when_updating_from_udb2_and_keep_missing_translations(): void
     {
         // First make sure there is an already created organizer.
         $organizerId = 'someId';
@@ -431,7 +401,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_set_main_language_when_importing_from_udb2()
+    public function it_should_set_main_language_when_importing_from_udb2(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_email.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -449,7 +419,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_should_set_main_language_when_updating_from_udb2()
+    public function it_should_set_main_language_when_updating_from_udb2(): void
     {
         // First make sure there is an already created organizer.
         $organizerId = 'someId';
@@ -471,7 +441,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_title_translated()
+    public function it_handles_title_translated(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -493,7 +463,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_address_translated()
+    public function it_handles_address_translated(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -520,7 +490,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_translation_of_organizer_with_untranslated_name()
+    public function it_handles_translation_of_organizer_with_untranslated_name(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -542,7 +512,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_adds_an_email_property_when_cdbxml_has_an_email()
+    public function it_adds_an_email_property_when_cdbxml_has_an_email(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_email.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -567,7 +537,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_add_an_email_property_when_cdbxml_has_no_email()
+    public function it_does_not_add_an_email_property_when_cdbxml_has_no_email(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_without_email.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -586,7 +556,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_adds_an_email_property_when_cdbxml_has_multiple_emails()
+    public function it_adds_an_email_property_when_cdbxml_has_multiple_emails(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_emails.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -612,7 +582,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_adds_a_phone_property_when_cdbxml_has_a_phone_number()
+    public function it_adds_a_phone_property_when_cdbxml_has_a_phone_number(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_phone_number.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -636,7 +606,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_adds_a_phone_property_when_cdbxml_has_multiple_phone_numbers()
+    public function it_adds_a_phone_property_when_cdbxml_has_multiple_phone_numbers(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_with_phone_numbers.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -661,7 +631,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_add_a_phone_property_when_cdbxml_has_no_phone()
+    public function it_does_not_add_a_phone_property_when_cdbxml_has_no_phone(): void
     {
         $event = $this->organizerImportedFromUDB2('organizer_without_phone_number.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($event);
@@ -680,7 +650,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_updates_workflow_status_on_delete()
+    public function it_updates_workflow_status_on_delete(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -698,7 +668,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_update_an_organizer_from_udb2_even_if_it_has_been_deleted()
+    public function it_can_update_an_organizer_from_udb2_even_if_it_has_been_deleted(): void
     {
         $organizerUpdatedFromUdb2 = $this->organizerUpdatedFromUDB2('organizer_with_email.cdbxml.xml');
         $domainMessage = $this->createDomainMessage($organizerUpdatedFromUdb2);
@@ -725,7 +695,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_label_added()
+    public function it_handles_label_added(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
         $label = new Label('labelName', true);
@@ -743,7 +713,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_invisible_label_added()
+    public function it_handles_invisible_label_added(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
         $label = new Label('labelName', false);
@@ -761,14 +731,12 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      * @dataProvider labelRemovedDataProvider
-     * @param string $originalFile
-     * @param string $finalFile
      */
     public function it_handles_label_removed(
         Label $label,
-        $originalFile,
-        $finalFile
-    ) {
+        string $originalFile,
+        string $finalFile
+    ): void {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
         $this->mockGet($organizerId, $originalFile);
@@ -781,10 +749,7 @@ class OrganizerLDProjectorTest extends TestCase
         $this->projector->handle($domainMessage);
     }
 
-    /**
-     * @return array
-     */
-    public function labelRemovedDataProvider()
+    public function labelRemovedDataProvider(): array
     {
         return [
             [
@@ -808,7 +773,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_invisible_label_removed()
+    public function it_handles_invisible_label_removed(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
         $label = new Label('labelName', false);
@@ -826,7 +791,7 @@ class OrganizerLDProjectorTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_geo_coordinates_updated()
+    public function it_handles_geo_coordinates_updated(): void
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
 
@@ -847,11 +812,7 @@ class OrganizerLDProjectorTest extends TestCase
         $this->projector->handle($domainMessage);
     }
 
-    /**
-     * @param string $organizerId
-     * @param string $fileName
-     */
-    private function mockGet($organizerId, $fileName)
+    private function mockGet(string $organizerId, string $fileName): void
     {
         $organizerJson = file_get_contents(__DIR__ . '/Samples/' . $fileName);
         $this->documentRepository->method('fetch')
@@ -859,11 +820,7 @@ class OrganizerLDProjectorTest extends TestCase
             ->willReturn(new JsonDocument($organizerId, $organizerJson));
     }
 
-    /**
-     * @param string $organizerId
-     * @param string $fileName
-     */
-    private function expectSave($organizerId, $fileName)
+    private function expectSave(string $organizerId, string $fileName): void
     {
         $expectedOrganizerJson = file_get_contents(__DIR__ . '/Samples/' . $fileName);
         // The expected organizer json still has newline formatting.
@@ -879,9 +836,8 @@ class OrganizerLDProjectorTest extends TestCase
 
     /**
      * @param ActorEvent|OrganizerEvent $organizerEvent
-     * @return DomainMessage
      */
-    private function createDomainMessage($organizerEvent)
+    private function createDomainMessage($organizerEvent): DomainMessage
     {
         if ($organizerEvent instanceof ActorEvent) {
             $id = $organizerEvent->getActorId();

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -286,7 +286,7 @@ class OrganizerLDProjectorTest extends TestCase
     public function it_handles_title_update()
     {
         $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
-        $title = new Title('Het Depot');
+        $title = 'Het Depot';
 
         $this->mockGet($organizerId, 'organizer.json');
 

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -453,7 +453,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     // Organizer was created with 'nl' title STUK.
                     new TitleUpdated(
                         $this->id,
-                        new LegacyTitle('Het Depot')
+                        'Het Depot'
                     ),
                     new TitleTranslated(
                         $this->id,
@@ -595,7 +595,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     // Organizer was imported with title 'DE Studio'.
                     new TitleUpdated(
                         '404EE8DE-E828-9C07-FE7D12DC4EB24480',
-                        new LegacyTitle('STUK')
+                        'STUK'
                     ),
                 ]
             );
@@ -641,7 +641,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     ),
                     new TitleUpdated(
                         $this->id,
-                        new LegacyTitle('Het Depot')
+                        'Het Depot'
                     ),
                 ]
             );


### PR DESCRIPTION
### Changed
- Refactor `TitleTranslated` constructor to use primitive types

---
Ticket: https://jira.uitdatabank.be/browse/III-4393
