### PR TITLE
III-4144 refactor organizer getters TitleTranslated

### DIFF
--- a/src/Organizer/Events/TitleTranslated.php
+++ b/src/Organizer/Events/TitleTranslated.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\Events;
 
-use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\Title;
-
 final class TitleTranslated extends OrganizerEvent
 {
     private string $title;

--- a/src/Organizer/Events/TitleTranslated.php
+++ b/src/Organizer/Events/TitleTranslated.php
@@ -23,14 +23,14 @@ final class TitleTranslated extends OrganizerEvent
         $this->language = $language;
     }
 
-    public function getTitle(): Title
+    public function getTitle(): string
     {
-        return new Title($this->title);
+        return $this->title;
     }
 
-    public function getLanguage(): Language
+    public function getLanguage(): string
     {
-        return new Language($this->language);
+        return $this->language;
     }
 
     public function serialize(): array

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -379,7 +379,11 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
 
     protected function applyTitleTranslated(TitleTranslated $titleTranslated): void
     {
-        $this->setTitle($titleTranslated->getTitle(), $titleTranslated->getLanguage());
+        $this->setTitle(
+            new LegacyTitle($titleTranslated->getTitle()),
+            new LegacyLanguage($titleTranslated->getLanguage())
+        )
+        ;
     }
 
     protected function applyAddressUpdated(AddressUpdated $addressUpdated): void

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -382,8 +382,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         $this->setTitle(
             new LegacyTitle($titleTranslated->getTitle()),
             new LegacyLanguage($titleTranslated->getLanguage())
-        )
-        ;
+        );
     }
 
     protected function applyAddressUpdated(AddressUpdated $addressUpdated): void

--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -240,8 +240,8 @@ class OrganizerLDProjector implements EventListener
     {
         return $this->applyTitle(
             $titleTranslated,
-            $titleTranslated->getTitle(),
-            $titleTranslated->getLanguage()
+            new Title($titleTranslated->getTitle()),
+            new Language($titleTranslated->getLanguage())
         );
     }
 


### PR DESCRIPTION
### Changed

- Remove `TitleTranslated` to return primitive types

---
Ticket: https://jira.uitdatabank.be/browse/III-4144
