### PR TITLE
III-4410 news article put request

### DIFF
--- a/app/Curators/CuratorsControllerProvider.php
+++ b/app/Curators/CuratorsControllerProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Http\Curators\CreateNewsArticleRequestHandler;
 use CultuurNet\UDB3\Http\Curators\DeleteNewsArticleRequestHandler;
 use CultuurNet\UDB3\Http\Curators\GetNewsArticleRequestHandler;
 use CultuurNet\UDB3\Http\Curators\GetNewsArticlesRequestHandler;
+use CultuurNet\UDB3\Http\Curators\UpdateNewsArticleRequestHandler;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
@@ -26,6 +27,7 @@ class CuratorsControllerProvider implements ControllerProviderInterface, Service
         $controllers->get('/{articleId}/', GetNewsArticleRequestHandler::class);
 
         $controllers->post('/', CreateNewsArticleRequestHandler::class);
+        $controllers->put('/{articleId}', UpdateNewsArticleRequestHandler::class);
 
         $controllers->delete('/{articleId}/', DeleteNewsArticleRequestHandler::class);
 
@@ -52,6 +54,12 @@ class CuratorsControllerProvider implements ControllerProviderInterface, Service
             fn (Application $application) => new CreateNewsArticleRequestHandler(
                 $app[NewsArticleRepository::class],
                 $app['uuid_generator'],
+            )
+        );
+
+        $app[UpdateNewsArticleRequestHandler::class] = $app->share(
+            fn (Application $application) => new UpdateNewsArticleRequestHandler(
+                $app[NewsArticleRepository::class],
             )
         );
 

--- a/src/Curators/Serializer/NewsArticleDenormalizer.php
+++ b/src/Curators/Serializer/NewsArticleDenormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Curators\Serializer;
 
-use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Curators\NewsArticle;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
@@ -13,21 +12,17 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class NewsArticleDenormalizer implements DenormalizerInterface
 {
-    private UuidGeneratorInterface $uuidGenerator;
+    private UUID $uuid;
 
-    public function __construct(UuidGeneratorInterface $uuidGenerator)
+    public function __construct(UUID $uuid)
     {
-        $this->uuidGenerator = $uuidGenerator;
+        $this->uuid = $uuid;
     }
 
     public function denormalize($data, $type, $format = null, array $context = []): NewsArticle
     {
-        if (!isset($data['id'])) {
-            $data['id'] = $this->uuidGenerator->generate();
-        }
-
         return new NewsArticle(
-            new UUID($data['id']),
+            $this->uuid,
             $data['headline'],
             new Language($data['inLanguage']),
             $data['text'],

--- a/src/Http/Curators/CreateNewsArticleRequestHandler.php
+++ b/src/Http/Curators/CreateNewsArticleRequestHandler.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -32,10 +33,12 @@ final class CreateNewsArticleRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $uuid = new UUID($this->uuidGenerator->generate());
+
         $requestBodyParser = RequestBodyParserFactory::createBaseParser(
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::NEWS_ARTICLE_POST),
             new DenormalizingRequestBodyParser(
-                new NewsArticleDenormalizer($this->uuidGenerator),
+                new NewsArticleDenormalizer($uuid),
                 NewsArticle::class
             )
         );

--- a/src/Http/Curators/UpdateNewsArticleRequestHandler.php
+++ b/src/Http/Curators/UpdateNewsArticleRequestHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Curators;
+
+use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleRepository;
+use CultuurNet\UDB3\Curators\Serializer\NewsArticleDenormalizer;
+use CultuurNet\UDB3\Curators\Serializer\NewsArticleNormalizer;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\JsonResponse;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UpdateNewsArticleRequestHandler implements RequestHandlerInterface
+{
+    private NewsArticleRepository $newsArticleRepository;
+
+    public function __construct(NewsArticleRepository $newsArticleRepository)
+    {
+        $this->newsArticleRepository = $newsArticleRepository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $articleId = $routeParameters->get('articleId');
+
+        $requestBodyParser = RequestBodyParserFactory::createBaseParser(
+            new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::NEWS_ARTICLE_POST),
+            new DenormalizingRequestBodyParser(
+                new NewsArticleDenormalizer(new UUID($articleId)),
+                NewsArticle::class
+            )
+        );
+
+        /** @var NewsArticle $newsArticle */
+        $newsArticle = $requestBodyParser->parse($request)->getParsedBody();
+
+        $this->newsArticleRepository->update($newsArticle);
+
+        return new JsonResponse((new NewsArticleNormalizer())->normalize($newsArticle));
+    }
+}

--- a/src/Http/Curators/UpdateNewsArticleRequestHandler.php
+++ b/src/Http/Curators/UpdateNewsArticleRequestHandler.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Curators;
 
 use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleNotFound;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
 use CultuurNet\UDB3\Curators\Serializer\NewsArticleDenormalizer;
 use CultuurNet\UDB3\Curators\Serializer\NewsArticleNormalizer;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
@@ -32,6 +34,12 @@ final class UpdateNewsArticleRequestHandler implements RequestHandlerInterface
     {
         $routeParameters = new RouteParameters($request);
         $articleId = $routeParameters->get('articleId');
+
+        try {
+            $this->newsArticleRepository->getById(new UUID($articleId));
+        } catch (NewsArticleNotFound $exception) {
+            throw ApiProblem::newsArticleNotFound($articleId);
+        }
 
         $requestBodyParser = RequestBodyParserFactory::createBaseParser(
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::NEWS_ARTICLE_POST),

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Curators;
+
+use CultuurNet\UDB3\Curators\NewsArticle;
+use CultuurNet\UDB3\Curators\NewsArticleRepository;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UpdateNewsArticleRequestHandlerTest extends TestCase
+{
+    /** @var NewsArticleRepository|MockObject */
+    private $newsArticleRepository;
+
+    private UpdateNewsArticleRequestHandler $updateNewsArticleRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    protected function setUp(): void
+    {
+        $this->newsArticleRepository = $this->createMock(NewsArticleRepository::class);
+
+        $this->updateNewsArticleRequestHandler = new UpdateNewsArticleRequestHandler(
+            $this->newsArticleRepository,
+        );
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_news_article(): void
+    {
+        $createOrganizerRequest = $this->psr7RequestBuilder
+            ->withRouteParameter('articleId', '6c583739-a848-41ab-b8a3-8f7dab6f8ee1')
+            ->withBodyFromArray([
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+            ])
+            ->build('POST');
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('update')
+            ->with(new NewsArticle(
+                new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
+                'publiq wint API award',
+                new Language('nl'),
+                'Op 10 januari 2020 wint publiq de API award',
+                '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'BILL',
+                new Url('https://www.publiq.be/blog/api-reward'),
+                new Url('https://www.bill.be/img/favicon.png')
+            ));
+
+        $response = $this->updateNewsArticleRequestHandler->handle($createOrganizerRequest);
+
+        $this->assertEquals(
+            Json::encode([
+                'id' => '6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
+                'headline' => 'publiq wint API award',
+                'inLanguage' => 'nl',
+                'text' => 'Op 10 januari 2020 wint publiq de API award',
+                'about' => '17284745-7bcf-461a-aad0-d3ad54880e75',
+                'publisher' => 'BILL',
+                'url' => 'https://www.publiq.be/blog/api-reward',
+                'publisherLogo' => 'https://www.bill.be/img/favicon.png',
+            ]),
+            $response->getBody()->getContents()
+        );
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -89,7 +89,7 @@ $app['security.firewalls'] = array(
             ->with(new RequestMatcher('^/organizers/suggest/.*', null, 'GET'))
             ->with(new RequestMatcher('^/jobs/', null, 'GET'))
             ->with(new RequestMatcher('^/uitpas/.*', null, 'GET'))
-            ->with(new RequestMatcher('^/news_articles', null, ['GET', 'DELETE', 'POST']))
+            ->with(new RequestMatcher('^/news_articles', null, ['GET', 'DELETE', 'POST', 'PUT']))
     ],
     'cors-preflight' => array(
         'pattern' => $app['cors_preflight_request_matcher'],


### PR DESCRIPTION
### Added
- Added new handler `UpdateNewsArticleRequestHandler` to update a news article

### Changed
- Refactor `NewsArticleDenormalizer` to work with `UUID` instead of `UuidGeneratorInterface`. By changing this the denormalizer works for both update and create.

---
Ticket: https://jira.uitdatabank.be/browse/III-4410
