### PR TITLE
Hot fix organizer events serialisation

### DIFF
--- a/src/Organizer/Events/AddressTranslated.php
+++ b/src/Organizer/Events/AddressTranslated.php
@@ -36,10 +36,10 @@ final class AddressTranslated extends AddressUpdated
     {
         return new self(
             $data['organizer_id'],
-            $data['streetAddress'],
-            $data['postalCode'],
-            $data['addressLocality'],
-            $data['addressCountry'],
+            $data['address']['streetAddress'],
+            $data['address']['postalCode'],
+            $data['address']['addressLocality'],
+            $data['address']['addressCountry'],
             $data['language']
         );
     }

--- a/src/Organizer/Events/AddressUpdated.php
+++ b/src/Organizer/Events/AddressUpdated.php
@@ -51,10 +51,12 @@ class AddressUpdated extends OrganizerEvent
     public function serialize(): array
     {
         return parent::serialize() + [
-            'streetAddress' => $this->streetAddress,
-            'postalCode' => $this->postalCode,
-            'addressLocality' => $this->locality,
-            'addressCountry' => $this->countryCode,
+            'address' => [
+                'streetAddress' => $this->streetAddress,
+                'postalCode' => $this->postalCode,
+                'addressLocality' => $this->locality,
+                'addressCountry' => $this->countryCode,
+            ],
         ];
     }
 
@@ -62,10 +64,10 @@ class AddressUpdated extends OrganizerEvent
     {
         return new self(
             $data['organizer_id'],
-            $data['streetAddress'],
-            $data['postalCode'],
-            $data['addressLocality'],
-            $data['addressCountry']
+            $data['address']['streetAddress'],
+            $data['address']['postalCode'],
+            $data['address']['addressLocality'],
+            $data['address']['addressCountry']
         );
     }
 }

--- a/src/Organizer/Events/ContactPointUpdated.php
+++ b/src/Organizer/Events/ContactPointUpdated.php
@@ -52,9 +52,9 @@ final class ContactPointUpdated extends OrganizerEvent
     {
         return parent::serialize() + [
             'contactPoint' => [
-                'phones' => $this->phones,
-                'emails' => $this->emails,
-                'urls' => $this->urls,
+                'phone' => $this->phones,
+                'email' => $this->emails,
+                'url' => $this->urls,
             ],
         ];
     }
@@ -63,9 +63,9 @@ final class ContactPointUpdated extends OrganizerEvent
     {
         return new static(
             $data['organizer_id'],
-            $data['contactPoint']['phones'],
-            $data['contactPoint']['emails'],
-            $data['contactPoint']['urls']
+            $data['contactPoint']['phone'],
+            $data['contactPoint']['email'],
+            $data['contactPoint']['url']
         );
     }
 }

--- a/src/Organizer/Events/ContactPointUpdated.php
+++ b/src/Organizer/Events/ContactPointUpdated.php
@@ -51,9 +51,11 @@ final class ContactPointUpdated extends OrganizerEvent
     public function serialize(): array
     {
         return parent::serialize() + [
-            'phones' => $this->phones,
-            'emails' => $this->emails,
-            'urls' => $this->urls,
+            'contactPoint' => [
+                'phones' => $this->phones,
+                'emails' => $this->emails,
+                'urls' => $this->urls,
+            ],
         ];
     }
 
@@ -61,9 +63,9 @@ final class ContactPointUpdated extends OrganizerEvent
     {
         return new static(
             $data['organizer_id'],
-            $data['phones'],
-            $data['emails'],
-            $data['urls']
+            $data['contactPoint']['phones'],
+            $data['contactPoint']['emails'],
+            $data['contactPoint']['urls']
         );
     }
 }


### PR DESCRIPTION
### Fixed
- Add `contactPoint` root property again to stay backwards compatible
- Add `address` root property again to stay backwards compatible
