### PR TITLE
III-4187 refactor command type

### DIFF
--- a/src/Http/Label/CommandType.php
+++ b/src/Http/Label/CommandType.php
@@ -4,36 +4,37 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Label;
 
-use ValueObjects\Enum\Enum;
+use CultuurNet\UDB3\Model\ValueObject\String\Enum;
 
-/**
- * Class CommandType
- * @package CultuurNet\UDB3\Http\Label\Helper
- */
 class CommandType extends Enum
 {
-    public const MAKE_VISIBLE = 'MakeVisible';
-    public const MAKE_INVISIBLE = 'MakeInvisible';
-    public const MAKE_PUBLIC = 'MakePublic';
-    public const MAKE_PRIVATE = 'MakePrivate';
+    public static function getAllowedValues(): array
+    {
+        return [
+            'MakeVisible',
+            'MakeInvisible',
+            'MakePublic',
+            'MakePrivate',
+        ];
+    }
 
     public static function makeVisible(): self
     {
-        return self::fromNative(self::MAKE_VISIBLE);
+        return new CommandType('MakeVisible');
     }
 
     public static function makeInvisible(): self
     {
-        return self::fromNative(self::MAKE_INVISIBLE);
+        return new CommandType('MakeInvisible');
     }
 
     public static function makePublic(): self
     {
-        return self::fromNative(self::MAKE_PUBLIC);
+        return new CommandType('MakePublic');
     }
 
     public static function makePrivate(): self
     {
-        return self::fromNative(self::MAKE_PRIVATE);
+        return new CommandType('MakePrivate');
     }
 }

--- a/src/Http/Label/EditRestController.php
+++ b/src/Http/Label/EditRestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Label;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\Services\WriteServiceInterface;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
@@ -16,10 +17,7 @@ use ValueObjects\Identity\UUID;
 
 class EditRestController
 {
-    /**
-     * @var WriteServiceInterface
-     */
-    private $writeService;
+    private WriteServiceInterface $writeService;
 
     /**
      * EditRestController constructor.
@@ -29,12 +27,9 @@ class EditRestController
         $this->writeService = $writeService;
     }
 
-    /**
-     * @return JsonResponse
-     */
-    public function create(Request $request)
+    public function create(Request $request): JsonResponse
     {
-        $bodyAsArray = json_decode($request->getContent(), true);
+        $bodyAsArray = Json::decodeAssociatively($request->getContent());
 
         $uuid = $this->writeService->create(
             new LabelName($bodyAsArray['name']),
@@ -47,23 +42,23 @@ class EditRestController
 
     public function patch(Request $request, string $id): Response
     {
-        $bodyAsArray = json_decode($request->getContent(), true);
+        $bodyAsArray = Json::decodeAssociatively($request->getContent());
         $commandType = new CommandType($bodyAsArray['command']);
 
-        $id = new UUID($id);
+        $uuid = new UUID($id);
 
         switch ($commandType) {
             case CommandType::makeVisible():
-                $this->writeService->makeVisible($id);
+                $this->writeService->makeVisible($uuid);
                 break;
             case CommandType::makeInvisible():
-                $this->writeService->makeInvisible($id);
+                $this->writeService->makeInvisible($uuid);
                 break;
             case CommandType::makePublic():
-                $this->writeService->makePublic($id);
+                $this->writeService->makePublic($uuid);
                 break;
             case CommandType::makePrivate():
-                $this->writeService->makePrivate($id);
+                $this->writeService->makePrivate($uuid);
                 break;
         }
 

--- a/src/Http/Label/EditRestController.php
+++ b/src/Http/Label/EditRestController.php
@@ -48,7 +48,7 @@ class EditRestController
     public function patch(Request $request, string $id): Response
     {
         $bodyAsArray = json_decode($request->getContent(), true);
-        $commandType = CommandType::fromNative($bodyAsArray['command']);
+        $commandType = new CommandType($bodyAsArray['command']);
 
         $id = new UUID($id);
 

--- a/tests/Http/Label/CommandTypeTest.php
+++ b/tests/Http/Label/CommandTypeTest.php
@@ -15,7 +15,7 @@ class CommandTypeTest extends TestCase
     {
         $commandType = CommandType::makeVisible();
 
-        $this->assertEquals($commandType, CommandType::MAKE_VISIBLE);
+        $this->assertEquals($commandType->toString(), 'MakeVisible');
     }
 
     /**
@@ -25,7 +25,7 @@ class CommandTypeTest extends TestCase
     {
         $commandType = CommandType::makeInvisible();
 
-        $this->assertEquals($commandType, CommandType::MAKE_INVISIBLE);
+        $this->assertEquals($commandType->toString(), 'MakeInvisible');
     }
 
     /**
@@ -35,7 +35,7 @@ class CommandTypeTest extends TestCase
     {
         $commandType = CommandType::makePublic();
 
-        $this->assertEquals($commandType, CommandType::MAKE_PUBLIC);
+        $this->assertEquals($commandType->toString(), 'MakePublic');
     }
 
     /**
@@ -45,7 +45,7 @@ class CommandTypeTest extends TestCase
     {
         $commandType = CommandType::makePrivate();
 
-        $this->assertEquals($commandType, CommandType::MAKE_PRIVATE);
+        $this->assertEquals($commandType->toString(), 'MakePrivate');
     }
 
     /**
@@ -53,14 +53,14 @@ class CommandTypeTest extends TestCase
      */
     public function it_has_only_four_specified_options()
     {
-        $options = CommandType::getConstants();
+        $options = CommandType::getAllowedValues();
 
         $this->assertEquals(
             [
-                CommandType::makeVisible()->getName() => CommandType::MAKE_VISIBLE,
-                CommandType::makeInvisible()->getName() => CommandType::MAKE_INVISIBLE,
-                CommandType::makePublic()->getName() => CommandType::MAKE_PUBLIC,
-                CommandType::makePrivate()->getName() => CommandType::MAKE_PRIVATE,
+                CommandType::makeVisible()->toString(),
+                CommandType::makeInvisible()->toString(),
+                CommandType::makePublic()->toString(),
+                CommandType::makePrivate()->toString(),
             ],
             $options
         );


### PR DESCRIPTION
### Changed
- Refactor `CommandType` to use `Enum` from Model namespace.

---
Ticket: https://jira.uitdatabank.be/browse/III-4187
