### PR TITLE
III-4426 Add endpoint to add an image to an organizer

### DIFF
--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Organizer;
 
 use CultuurNet\UDB3\Event\EventOrganizerRelationService;
+use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddLabelHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler;
@@ -82,6 +83,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[UpdateContactPointHandler::class] = $app->share(
             fn (Application $application) => new UpdateContactPointHandler($app['organizer_repository'])
+        );
+
+        $app[AddImageHandler::class] = $app->share(
+            fn (Application $application) => new AddImageHandler($app['organizer_repository'])
         );
     }
 

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Organizer;
 
+use CultuurNet\UDB3\Http\Organizer\AddImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\AddLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\CreateOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteAddressRequestHandler;
@@ -46,6 +47,8 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
         $controllers->put('/{organizerId}/url/', UpdateUrlRequestHandler::class);
 
         $controllers->put('/{organizerId}/contact-point/', UpdateContactPointRequestHandler::class);
+
+        $controllers->post('/{organizerId}/images/', AddImageRequestHandler::class);
 
         $controllers->put('/{organizerId}/labels/{labelName}/', AddLabelRequestHandler::class);
         $controllers->delete('/{organizerId}/labels/{labelName}/', DeleteLabelRequestHandler::class);
@@ -107,6 +110,13 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
 
         $app[UpdateContactPointRequestHandler::class] = $app->share(
             fn (Application $application) => new UpdateContactPointRequestHandler($app['event_command_bus'])
+        );
+
+        $app[AddImageRequestHandler::class] = $app->share(
+            fn (Application $application) => new AddImageRequestHandler(
+                $app['event_command_bus'],
+                $app['media_object_repository']
+            )
         );
 
         $app[AddLabelRequestHandler::class] = $app->share(

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Organizer;
 
+use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\EventFactory;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
@@ -18,7 +20,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
 
     public const JSONLD_PROJECTED_EVENT_FACTORY = 'organizer_jsonld_projected_event_factory';
 
-    public function register(Application $app)
+    public function register(Application $app): void
     {
         $app[self::PROJECTOR] = $app->share(
             function ($app) {
@@ -38,7 +40,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
 
         $app['real_organizer_jsonld_repository'] = $app->share(
             function ($app) {
-                return new \CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository(
+                return new CacheDocumentRepository(
                     $app['organizer_jsonld_cache']
                 );
             }
@@ -69,7 +71,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
         );
     }
 
-    public function boot(Application $app)
+    public function boot(Application $app): void
     {
     }
 }

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Organizer;
 
+use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\EventFactory;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
@@ -21,11 +22,15 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
     {
         $app[self::PROJECTOR] = $app->share(
             function ($app) {
-                return new \CultuurNet\UDB3\Organizer\OrganizerLDProjector(
+                return new OrganizerLDProjector(
                     $app['organizer_jsonld_repository'],
                     $app['organizer_iri_generator'],
                     new JsonDocumentLanguageEnricher(
                         new OrganizerJsonDocumentLanguageAnalyzer()
+                    ),
+                    new ImageNormalizer(
+                        $app['media_object_repository'],
+                        $app['media_object_iri_generator']
                     )
                 );
             }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -37,6 +37,7 @@ use CultuurNet\UDB3\Offer\CommandHandlers\UpdateVideoHandler;
 use CultuurNet\UDB3\Offer\OfferLocator;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
+use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
@@ -642,6 +643,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[RemoveAddressHandler::class]);
         $commandBus->subscribe($app[UpdateWebsiteHandler::class]);
         $commandBus->subscribe($app[UpdateContactPointHandler::class]);
+        $commandBus->subscribe($app[AddImageHandler::class]);
 
         $commandBus->subscribe($app[LabelServiceProvider::COMMAND_HANDLER]);
     };

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4425-add-description-to-organizer",
+    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4426-add-image-to-organizer",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",
     "sentry/sdk": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41a4533d931f31566b28e9431aa948a6",
+    "content-hash": "ccf6948b04304e4b0d1397e2a2544b81",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5222,16 +5222,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-feature/III-4425-add-description-to-organizer",
+            "version": "dev-feature/III-4426-add-image-to-organizer",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "1fb4509f40e72a605b2f214360b462de0d0f8c7a"
+                "reference": "7ec5f4798dbf2f9e097763629edc91944496773c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/1fb4509f40e72a605b2f214360b462de0d0f8c7a",
-                "reference": "1fb4509f40e72a605b2f214360b462de0d0f8c7a",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/7ec5f4798dbf2f9e097763629edc91944496773c",
+                "reference": "7ec5f4798dbf2f9e097763629edc91944496773c",
                 "shasum": ""
             },
             "type": "library",
@@ -5248,9 +5248,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4425-add-description-to-organizer"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4426-add-image-to-organizer"
             },
-            "time": "2021-12-14T12:47:58+00:00"
+            "time": "2021-12-16T09:23:59+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -236,6 +236,11 @@ final class ApiProblem extends Exception
         return self::resourceNotFound('News Article', $articleId);
     }
 
+    public static function imageNotFound(string $imageId): self
+    {
+        return self::resourceNotFound('Image', $imageId);
+    }
+
     public static function tokenNotSupported(string $detail): self
     {
         return self::create(

--- a/src/Http/Organizer/AddImageRequestHandler.php
+++ b/src/Http/Organizer/AddImageRequestHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\CommandBus;
+use Broadway\Repository\AggregateNotFoundException;
+use Broadway\Repository\Repository;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
+use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParserFactory;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Organizer\Commands\AddImage;
+use CultuurNet\UDB3\Organizer\Serializers\AddImageDenormalizer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AddImageRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    private Repository $mediaRepository;
+
+    public function __construct(CommandBus $commandBus, Repository $mediaRepository)
+    {
+        $this->commandBus = $commandBus;
+        $this->mediaRepository = $mediaRepository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $organizerId = $routeParameters->getOrganizerId();
+
+        $requestBodyParser = RequestBodyParserFactory::createBaseParser(
+            new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::ORGANIZER_IMAGE_POST),
+            new DenormalizingRequestBodyParser(new AddImageDenormalizer($organizerId), AddImage::class)
+        );
+
+        /** @var AddImage $addImage */
+        $addImage = $requestBodyParser->parse($request)->getParsedBody();
+        $imageId = $addImage->getImage()->getId()->toString();
+
+        try {
+            $this->mediaRepository->load($imageId);
+        } catch (AggregateNotFoundException $exception) {
+            throw ApiProblem::imageNotFound($imageId);
+        }
+
+        $this->commandBus->dispatch($addImage);
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Http/Request/Body/JsonSchemaLocator.php
+++ b/src/Http/Request/Body/JsonSchemaLocator.php
@@ -39,6 +39,7 @@ final class JsonSchemaLocator
     public const ORGANIZER_ADDRESS_PUT = 'organizer-address-put.json';
     public const ORGANIZER_URL_PUT = 'organizer-url-put.json';
     public const ORGANIZER_CONTACT_POINT_PUT = 'organizer-contactPoint-put.json';
+    public const ORGANIZER_IMAGE_POST = 'organizer-image-post.json';
 
     public const NEWS_ARTICLE_POST = 'newsArticle-post.json';
 

--- a/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject;
+
+use Broadway\Repository\Repository;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ImageNormalizer implements NormalizerInterface
+{
+    private Repository $mediaRepository;
+
+    private IriGeneratorInterface $mediaIriGenerator;
+
+    public function __construct(Repository $mediaRepository, IriGeneratorInterface $mediaIriGenerator)
+    {
+        $this->mediaRepository = $mediaRepository;
+        $this->mediaIriGenerator = $mediaIriGenerator;
+    }
+
+    /**
+     * @param Image $image
+     */
+    public function normalize($image, $format = null, array $context = []): array
+    {
+        /** @var MediaObject $mediaObject */
+        $mediaObject = $this->mediaRepository->load($image->getId()->toString());
+
+        return [
+            '@id' => $this->mediaIriGenerator->iri($image->getId()->toString()),
+            'contentUrl' => (string) $mediaObject->getSourceLocation(),
+            'thumbnailUrl' => (string) $mediaObject->getSourceLocation(),
+            'language' => $image->getLanguage()->toString(),
+            'description' => $image->getDescription()->toString(),
+            'copyrightHolder' => $image->getCopyrightHolder()->toString(),
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data === Image::class;
+    }
+}

--- a/src/Model/ValueObject/MediaObject/Image.php
+++ b/src/Model/ValueObject/MediaObject/Image.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\MediaObject;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+
+final class Image
+{
+    private UUID $id;
+
+    private Language $language;
+
+    private Description $description;
+
+    private CopyrightHolder $copyrightHolder;
+
+    public function __construct(
+        UUID $id,
+        Language $language,
+        Description $description,
+        CopyrightHolder $copyrightHolder
+    ) {
+        $this->id = $id;
+        $this->language = $language;
+        $this->description = $description;
+        $this->copyrightHolder = $copyrightHolder;
+    }
+
+    public function getId(): UUID
+    {
+        return $this->id;
+    }
+
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+
+    public function getDescription(): Description
+    {
+        return $this->description;
+    }
+
+    public function getCopyrightHolder(): CopyrightHolder
+    {
+        return $this->copyrightHolder;
+    }
+}

--- a/src/Model/ValueObject/MediaObject/Images.php
+++ b/src/Model/ValueObject/MediaObject/Images.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\MediaObject;
+
+use CultuurNet\UDB3\Model\ValueObject\Collection\Collection;
+
+final class Images extends Collection
+{
+    public function __construct(Image ...$images)
+    {
+        parent::__construct(...$images);
+    }
+}

--- a/src/Organizer/CommandHandler/AddImageHandler.php
+++ b/src/Organizer/CommandHandler/AddImageHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\AddImage;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class AddImageHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof AddImage) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getOrganizerId());
+
+        $organizer->addImage($command->getImage());
+
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/Commands/AddImage.php
+++ b/src/Organizer/Commands/AddImage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+
+final class AddImage
+{
+    private string $organizerId;
+
+    private Image $image;
+
+    public function __construct(string $organizerId, Image $image)
+    {
+        $this->organizerId = $organizerId;
+        $this->image = $image;
+    }
+
+    public function getOrganizerId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getImage(): Image
+    {
+        return $this->image;
+    }
+}

--- a/src/Organizer/Events/ImageAdded.php
+++ b/src/Organizer/Events/ImageAdded.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use Broadway\Serializer\Serializable;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+
+final class ImageAdded implements Serializable
+{
+    private string $organizerId;
+
+    private string $imageId;
+
+    private string $language;
+
+    private string $description;
+
+    private string $copyrightHolder;
+
+    public function __construct(
+        string $organizerId,
+        string $imageId,
+        string $language,
+        string $description,
+        string $copyrightHolder
+    ) {
+        $this->organizerId = $organizerId;
+        $this->imageId = $imageId;
+        $this->language = $language;
+        $this->description = $description;
+        $this->copyrightHolder = $copyrightHolder;
+    }
+
+    public function getOrganizerId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getImageId(): string
+    {
+        return $this->imageId;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getCopyrightHolder(): string
+    {
+        return $this->copyrightHolder;
+    }
+
+    public function getImage(): Image
+    {
+        return new Image(
+            new UUID($this->imageId),
+            new Language($this->language),
+            new Description($this->description),
+            new CopyrightHolder($this->copyrightHolder)
+        );
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'organizerId' => $this->organizerId,
+            'imageId' => $this->imageId,
+            'language' => $this->language,
+            'description' => $this->description,
+            'copyrightHolder' => $this->copyrightHolder,
+        ];
+    }
+
+    public static function deserialize(array $data): ImageAdded
+    {
+        return new ImageAdded(
+            $data['organizerId'],
+            $data['imageId'],
+            $data['language'],
+            $data['description'],
+            $data['copyrightHolder'],
+        );
+    }
+}

--- a/src/Organizer/Serializers/AddImageDenormalizer.php
+++ b/src/Organizer/Serializers/AddImageDenormalizer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Serializers;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\AddImage;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class AddImageDenormalizer implements DenormalizerInterface
+{
+    private string $organizerId;
+
+    public function __construct(string $organizerId)
+    {
+        $this->organizerId = $organizerId;
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = []): AddImage
+    {
+        return new AddImage(
+            $this->organizerId,
+            new Image(
+                new UUID($data['id']),
+                new Language($data['language']),
+                new Description($data['description']),
+                new CopyrightHolder($data['copyrightHolder'])
+            )
+        );
+    }
+
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        return $type === AddImage::class;
+    }
+}

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -120,7 +120,7 @@ final class AddImageRequestHandlerTest extends TestCase
             fn () => $this->addImageRequestHandler->handle($request)
         );
     }
-    
+
     /**
      * @test
      * @dataProvider invalidBodyDataProvider

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use Broadway\Repository\AggregateNotFoundException;
+use Broadway\Repository\Repository;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Language as LegacyLanguage;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\Properties\MIMEType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\AddImage;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ValueObjects\Identity\UUID as LegacyUUID;
+use ValueObjects\StringLiteral\StringLiteral;
+use ValueObjects\Web\Url;
+
+final class AddImageRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+
+    private AddImageRequestHandler $addImageRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    /** @var Repository|MockObject */
+    private $imageRepository;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->imageRepository = $this->createMock(Repository::class);
+
+        $this->addImageRequestHandler = new AddImageRequestHandler($this->commandBus, $this->imageRepository);
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+
+        $this->commandBus->record();
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_adding_an_image(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->withBodyFromArray([
+                'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                'language' => 'en',
+                'description' => 'A nice image',
+                'copyrightHolder' => 'publiq',
+            ])
+            ->build('POST');
+
+        $this->imageRepository->method('load')
+            ->with('03789a2f-5063-4062-b7cb-95a0a2280d92')
+            ->willReturn(
+                MediaObject::create(
+                    new LegacyUUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    MIMEType::fromSubtype('jpeg'),
+                    new StringLiteral('Uploaded image'),
+                    new CopyrightHolder('publiq'),
+                    Url::fromNative('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
+                    new LegacyLanguage('nl')
+                )
+            );
+
+        $expectedCommand = new AddImage(
+            'c269632a-a887-4f21-8455-1631c31e4df5',
+            new Image(
+                new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                new Language('en'),
+                new Description('A nice image'),
+                new CopyrightHolder('publiq')
+            )
+        );
+
+        $response = $this->addImageRequestHandler->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals([$expectedCommand], $this->commandBus->getRecordedCommands());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_api_problem_when_image_not_found(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->withBodyFromArray([
+                'id' => '08805a3c-ffe0-4c94-a1bc-453a6dd9d01f',
+                'language' => 'en',
+                'description' => 'A nice image',
+                'copyrightHolder' => 'publiq',
+            ])
+            ->build('POST');
+
+        $this->imageRepository->method('load')
+            ->with('08805a3c-ffe0-4c94-a1bc-453a6dd9d01f')
+            ->willThrowException(new AggregateNotFoundException());
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::imageNotFound('08805a3c-ffe0-4c94-a1bc-453a6dd9d01f'),
+            fn () => $this->addImageRequestHandler->handle($request)
+        );
+    }
+    
+    /**
+     * @test
+     * @dataProvider invalidBodyDataProvider
+     */
+    public function it_throws_an_api_problem_for_an_invalid_body(string $body, ApiProblem $expectedApiProblem): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->withBodyFromString($body)
+            ->build('POST');
+
+        $this->assertCallableThrowsApiProblem(
+            $expectedApiProblem,
+            fn () => $this->addImageRequestHandler->handle($request)
+        );
+    }
+
+    public function invalidBodyDataProvider(): array
+    {
+        return [
+            [
+                '',
+                ApiProblem::bodyMissing(),
+            ],
+            [
+                '{{}',
+                ApiProblem::bodyInvalidSyntax('JSON'),
+            ],
+            [
+                '{}',
+                ApiProblem::bodyInvalidData(
+                    new SchemaError('/', 'The required properties (id, language, copyrightHolder, description) are missing')
+                ),
+            ],
+            [
+                '{
+                    "id":"not a uuid",
+                    "language":"en",
+                    "description":"A nice image",
+                    "copyrightHolder":"publiq"
+                }',
+                ApiProblem::bodyInvalidData(
+                    new SchemaError('/id', 'The data must match the \'uuid\' format')
+                ),
+            ],
+            [
+                '{
+                    "id":"08805a3c-ffe0-4c94-a1bc-453a6dd9d01f",
+                    "language":"sw",
+                    "description":"A nice image",
+                    "copyrightHolder":"publiq"
+                }',
+                ApiProblem::bodyInvalidData(
+                    new SchemaError('/language', 'The data should match one item from enum')
+                ),
+            ],
+            [
+                '{
+                    "id":"08805a3c-ffe0-4c94-a1bc-453a6dd9d01f",
+                    "language":"en",
+                    "description":"",
+                    "copyrightHolder":"publiq"
+                }',
+                ApiProblem::bodyInvalidData(
+                    new SchemaError('/description', 'Minimum string length is 1, found 0')
+                ),
+            ],
+            [
+                '{
+                    "id":"08805a3c-ffe0-4c94-a1bc-453a6dd9d01f",
+                    "language":"en",
+                    "description":"A nice image",
+                    "copyrightHolder":""
+                }',
+                ApiProblem::bodyInvalidData(
+                    new SchemaError('/copyrightHolder', 'Minimum string length is 3, found 0')
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/Model/ValueObject/MediaObject/ImageTest.php
+++ b/tests/Model/ValueObject/MediaObject/ImageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\MediaObject;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use PHPUnit\Framework\TestCase;
+
+final class ImageTest extends TestCase
+{
+    private Image $image;
+
+    protected function setUp(): void
+    {
+        $this->image = new Image(
+            new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+            new Language('nl'),
+            new Description('Description of the image'),
+            new CopyrightHolder('publiq')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_id(): void
+    {
+        $this->assertEquals(new UUID('cf539408-bba9-4e77-9f85-72019013db37'), $this->image->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_language(): void
+    {
+        $this->assertEquals(new Language('nl'), $this->image->getLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_description(): void
+    {
+        $this->assertEquals(new Description('Description of the image'), $this->image->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_copyright_holder(): void
+    {
+        $this->assertEquals(new CopyrightHolder('publiq'), $this->image->getCopyrightHolder());
+    }
+}

--- a/tests/Organizer/CommandHandler/AddImageHandlerTest.php
+++ b/tests/Organizer/CommandHandler/AddImageHandlerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\AddImage;
+use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class AddImageHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new AddImageHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_adding_an_image(): void
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([$this->organizerCreatedWithUniqueWebsite($id)])
+            ->when(new AddImage(
+                $id,
+                new Image(
+                    new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                    new Language('nl'),
+                    new Description('Description of the image'),
+                    new CopyrightHolder('publiq')
+                )
+            ))
+            ->then([
+                new ImageAdded(
+                    $id,
+                    'cf539408-bba9-4e77-9f85-72019013db37',
+                    'nl',
+                    'Description of the image',
+                    'publiq'
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prevents_adding_the_same_image_twice(): void
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                $this->organizerCreatedWithUniqueWebsite($id),
+                new ImageAdded(
+                    $id,
+                    'cf539408-bba9-4e77-9f85-72019013db37',
+                    'nl',
+                    'Description of the image',
+                    'publiq'
+                ),
+            ])
+            ->when(new AddImage(
+                $id,
+                new Image(
+                    new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                    new Language('nl'),
+                    new Description('Description of the image'),
+                    new CopyrightHolder('publiq')
+                )
+            ))
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_multiple_images(): void
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                $this->organizerCreatedWithUniqueWebsite($id),
+                new ImageAdded(
+                    $id,
+                    'cf539408-bba9-4e77-9f85-72019013db37',
+                    'nl',
+                    'Description of the image',
+                    'publiq'
+                ),
+            ])
+            ->when(new AddImage(
+                $id,
+                new Image(
+                    new UUID('0b02240d-5fc0-4efa-8a6f-4281f695dd5f'),
+                    new Language('en'),
+                    new Description('Another image'),
+                    new CopyrightHolder('publiq')
+                )
+            ))
+            ->then([
+                new ImageAdded(
+                    $id,
+                    '0b02240d-5fc0-4efa-8a6f-4281f695dd5f',
+                    'en',
+                    'Another image',
+                    'publiq'
+                ),
+            ]);
+    }
+
+    private function organizerCreatedWithUniqueWebsite(string $id): OrganizerCreatedWithUniqueWebsite
+    {
+        return new OrganizerCreatedWithUniqueWebsite(
+            $id,
+            'nl',
+            'https://www.publiq.be',
+            'publiq'
+        );
+    }
+}

--- a/tests/Organizer/Commands/AddImageTest.php
+++ b/tests/Organizer/Commands/AddImageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use PHPUnit\Framework\TestCase;
+
+final class AddImageTest extends TestCase
+{
+    private AddImage $addImage;
+
+    protected function setUp(): void
+    {
+        $this->addImage = new AddImage(
+            '437604d2-5cb6-44ed-bb10-92ce33b6e7bd',
+            new Image(
+                new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                new Language('nl'),
+                new Description('Description of the image'),
+                new CopyrightHolder('publiq')
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals('437604d2-5cb6-44ed-bb10-92ce33b6e7bd', $this->addImage->getOrganizerId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_image(): void
+    {
+        $this->assertEquals(
+            new Image(
+                new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                new Language('nl'),
+                new Description('Description of the image'),
+                new CopyrightHolder('publiq')
+            ),
+            $this->addImage->getImage()
+        );
+    }
+}

--- a/tests/Organizer/Events/ImageAddedTest.php
+++ b/tests/Organizer/Events/ImageAddedTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use PHPUnit\Framework\TestCase;
+
+final class ImageAddedTest extends TestCase
+{
+    private ImageAdded $imageAdded;
+
+    protected function setUp(): void
+    {
+        $this->imageAdded = new ImageAdded(
+            '688cc29c-6662-4fc0-b832-71adf5282130',
+            '78957a0a-74ad-415d-ab6b-f49b865957fd',
+            'en',
+            'Description of the image',
+            'Copyright holder of the image'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_an_organizer_id(): void
+    {
+        $this->assertEquals('688cc29c-6662-4fc0-b832-71adf5282130', $this->imageAdded->getOrganizerId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_an_image_id(): void
+    {
+        $this->assertEquals('78957a0a-74ad-415d-ab6b-f49b865957fd', $this->imageAdded->getImageId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_language(): void
+    {
+        $this->assertEquals('en', $this->imageAdded->getLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_description(): void
+    {
+        $this->assertEquals('Description of the image', $this->imageAdded->getDescription());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_copyright_holder(): void
+    {
+        $this->assertEquals('Copyright holder of the image', $this->imageAdded->getCopyrightHolder());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            [
+                'organizerId' => '688cc29c-6662-4fc0-b832-71adf5282130',
+                'imageId' => '78957a0a-74ad-415d-ab6b-f49b865957fd',
+                'language' => 'en',
+                'description' => 'Description of the image',
+                'copyrightHolder' => 'Copyright holder of the image',
+            ],
+            $this->imageAdded->serialize()
+        );
+    }
+}

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -13,6 +13,9 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
 use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
@@ -27,6 +30,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
+use CultuurNet\UDB3\Organizer\Events\ImageAdded;
 use CultuurNet\UDB3\Organizer\Events\LabelAdded;
 use CultuurNet\UDB3\Organizer\Events\LabelRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelsImported;
@@ -626,6 +630,111 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                         'ae3aab28-6351-489e-a61c-c48aec0a77df',
                         'Beschrijving van de organisatie',
                         'nl'
+                    ),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider addImageDataProvider
+     */
+    public function it_can_add_an_image(array $given, callable $addImage, array $then): void
+    {
+        $this->scenario
+            ->given($given)
+            ->when(fn (Organizer $organizer) => $addImage($organizer))
+            ->then($then);
+    }
+
+    public function addImageDataProvider(): array
+    {
+        $organizerCreated = new OrganizerCreatedWithUniqueWebsite(
+            'ae3aab28-6351-489e-a61c-c48aec0a77df',
+            'en',
+            'https://www.publiq.be',
+            'publiq'
+        );
+
+        return [
+            'Set initial image' => [
+                [
+                    $organizerCreated,
+                ],
+                function (Organizer $organizer) {
+                    $organizer->addImage(
+                        new Image(
+                            new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                            new Language('nl'),
+                            new Description('Beschrijving van de afbeelding'),
+                            new CopyrightHolder('publiq')
+                        )
+                    );
+                },
+                [
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Beschrijving van de afbeelding',
+                        'publiq'
+                    ),
+                ],
+            ],
+            'Prevent setting same image' => [
+                [
+                    $organizerCreated,
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Beschrijving van de afbeelding',
+                        'publiq'
+                    ),
+                ],
+                function (Organizer $organizer) {
+                    $organizer->addImage(
+                        new Image(
+                            new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                            new Language('nl'),
+                            new Description('Beschrijving van de afbeelding'),
+                            new CopyrightHolder('publiq')
+                        )
+                    );
+                },
+                [
+                ],
+            ],
+
+            'Allow setting extra image' => [
+                [
+                    $organizerCreated,
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Beschrijving van de afbeelding',
+                        'publiq'
+                    ),
+                ],
+                function (Organizer $organizer) {
+                    $organizer->addImage(
+                        new Image(
+                            new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                            new Language('en'),
+                            new Description('Description of the image'),
+                            new CopyrightHolder('publiq')
+                        )
+                    );
+                },
+                [
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                        'en',
+                        'Description of the image',
+                        'publiq'
                     ),
                 ],
             ],

--- a/tests/Organizer/Samples/organizer_with_image.json
+++ b/tests/Organizer/Samples/organizer_with_image.json
@@ -1,0 +1,33 @@
+{
+  "@id": "http:\/\/udb-silex.dev\/organizer\/586f596d-7e43-4ab9-b062-04db9436fca4",
+  "@context": "\/api\/1.0\/organizer.jsonld",
+  "name": {
+    "nl": "TestOrganisatie"
+  },
+  "address": {
+    "nl": {
+      "addressCountry": "BE",
+      "addressLocality": "Kessel-Lo (Leuven)",
+      "postalCode": "3010",
+      "streetAddress": "Straat"
+    }
+  },
+  "phone": [],
+  "email": [],
+  "url": [],
+  "created": "2016-09-28T10:01:28+00:00",
+  "creator": "20a72430-7e3e-4b75-ab59-043156b3169c (LucW)",
+  "languages": ["nl"],
+  "completedLanguages": ["nl"],
+  "images": [
+    {
+      "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
+      "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
+      "language": "nl",
+      "description": "Beschrijving van de afbeelding",
+      "copyrightHolder": "publiq"
+    }
+  ],
+  "modified": "2018-01-18T13:57:09+00:00"
+}

--- a/tests/Organizer/Samples/organizer_with_two_images.json
+++ b/tests/Organizer/Samples/organizer_with_two_images.json
@@ -1,0 +1,41 @@
+{
+  "@id": "http:\/\/udb-silex.dev\/organizer\/586f596d-7e43-4ab9-b062-04db9436fca4",
+  "@context": "\/api\/1.0\/organizer.jsonld",
+  "name": {
+    "nl": "TestOrganisatie"
+  },
+  "address": {
+    "nl": {
+      "addressCountry": "BE",
+      "addressLocality": "Kessel-Lo (Leuven)",
+      "postalCode": "3010",
+      "streetAddress": "Straat"
+    }
+  },
+  "phone": [],
+  "email": [],
+  "url": [],
+  "created": "2016-09-28T10:01:28+00:00",
+  "creator": "20a72430-7e3e-4b75-ab59-043156b3169c (LucW)",
+  "languages": ["nl"],
+  "completedLanguages": ["nl"],
+  "images": [
+    {
+      "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
+      "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
+      "language": "nl",
+      "description": "Beschrijving van de afbeelding",
+      "copyrightHolder": "publiq"
+    },
+    {
+      "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
+      "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
+      "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
+      "language": "en",
+      "description": "Extra image",
+      "copyrightHolder": "madewithlove"
+    }
+  ],
+  "modified": "2018-01-18T13:57:09+00:00"
+}


### PR DESCRIPTION
### Added
- Added `Image` value object
- Added `Images` collection
- Added `ImageAdded` event
- Added `AddImage` command
- Added method `addImage` on `Organizer` aggregate
- Added method to handle `ImageAdded` inside the `OrganizerLDProjector`
- Added normalizer `ImageNormalizer` which can get the URLs from a media object (unfortunate the media object does not have a projection so the aggregate is used to get the URLs)
- Added `AddImageHandler` to handle `AddImage` command
- Added `AddImageDenormalizer` to create `AddImage` command from request bodies
- Added `AddImageRequestHandler` to handle POST image requests

---
Ticket: https://jira.uitdatabank.be/browse/III-4426 
