### PR TITLE
III-4428 Add endpoint to delete image from organizer

### DIFF
--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Organizer\CommandHandler\AddLabelHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\RemoveImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveLabelHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateContactPointHandler;
@@ -87,6 +88,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[AddImageHandler::class] = $app->share(
             fn (Application $application) => new AddImageHandler($app['organizer_repository'])
+        );
+
+        $app[RemoveImageHandler::class] = $app->share(
+            fn (Application $application) => new RemoveImageHandler($app['organizer_repository'])
         );
     }
 

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\Organizer\AddImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\AddLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\CreateOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteAddressRequestHandler;
+use CultuurNet\UDB3\Http\Organizer\DeleteImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\GetOrganizerRequestHandler;
@@ -49,6 +50,7 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
         $controllers->put('/{organizerId}/contact-point/', UpdateContactPointRequestHandler::class);
 
         $controllers->post('/{organizerId}/images/', AddImageRequestHandler::class);
+        $controllers->delete('/{organizerId}/images/{imageId}', DeleteImageRequestHandler::class);
 
         $controllers->put('/{organizerId}/labels/{labelName}/', AddLabelRequestHandler::class);
         $controllers->delete('/{organizerId}/labels/{labelName}/', DeleteLabelRequestHandler::class);
@@ -117,6 +119,10 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
                 $app['event_command_bus'],
                 $app['media_object_repository']
             )
+        );
+
+        $app[DeleteImageRequestHandler::class] = $app->share(
+            fn (Application $application) => new DeleteImageRequestHandler($app['event_command_bus'])
         );
 
         $app[AddLabelRequestHandler::class] = $app->share(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -40,6 +40,7 @@ use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\RemoveImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateContactPointHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateDescriptionHandler;
@@ -644,6 +645,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[UpdateWebsiteHandler::class]);
         $commandBus->subscribe($app[UpdateContactPointHandler::class]);
         $commandBus->subscribe($app[AddImageHandler::class]);
+        $commandBus->subscribe($app[RemoveImageHandler::class]);
 
         $commandBus->subscribe($app[LabelServiceProvider::COMMAND_HANDLER]);
     };

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4426-add-image-to-organizer",
+    "publiq/stoplight-docs-uitdatabank": "dev-unreleased",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",
     "sentry/sdk": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccf6948b04304e4b0d1397e2a2544b81",
+    "content-hash": "fb49093c71b0de845a9b565d741c4f1c",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5222,16 +5222,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-feature/III-4426-add-image-to-organizer",
+            "version": "dev-unreleased",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "7ec5f4798dbf2f9e097763629edc91944496773c"
+                "reference": "dcc63d64edb78a239102c9d7db85186bc3f2d60a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/7ec5f4798dbf2f9e097763629edc91944496773c",
-                "reference": "7ec5f4798dbf2f9e097763629edc91944496773c",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/dcc63d64edb78a239102c9d7db85186bc3f2d60a",
+                "reference": "dcc63d64edb78a239102c9d7db85186bc3f2d60a",
                 "shasum": ""
             },
             "type": "library",
@@ -5248,9 +5248,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4426-add-image-to-organizer"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/unreleased"
             },
-            "time": "2021-12-16T09:23:59+00:00"
+            "time": "2021-12-17T15:56:37+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Organizer/DeleteImageRequestHandler.php
+++ b/src/Http/Organizer/DeleteImageRequestHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Organizer\Commands\RemoveImage;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DeleteImageRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $organizerId = $routeParameters->getOrganizerId();
+        $imageId = $routeParameters->get('imageId');
+
+        $this->commandBus->dispatch(new RemoveImage($organizerId, new UUID($imageId)));
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Organizer/CommandHandler/RemoveImageHandler.php
+++ b/src/Organizer/CommandHandler/RemoveImageHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\RemoveImage;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class RemoveImageHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof RemoveImage) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getOrganizerId());
+
+        $organizer->removeImage($command->getImageId());
+
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/Commands/RemoveImage.php
+++ b/src/Organizer/Commands/RemoveImage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+
+final class RemoveImage
+{
+    private string $organizerId;
+
+    private UUID $imageId;
+
+    public function __construct(string $organizerId, UUID $imageId)
+    {
+        $this->organizerId = $organizerId;
+        $this->imageId = $imageId;
+    }
+
+    public function getOrganizerId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getImageId(): UUID
+    {
+        return $this->imageId;
+    }
+}

--- a/src/Organizer/Events/ImageRemoved.php
+++ b/src/Organizer/Events/ImageRemoved.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use Broadway\Serializer\Serializable;
+
+final class ImageRemoved implements Serializable
+{
+    private string $organizerId;
+
+    private string $imageId;
+
+    public function __construct(string $organizerId, string $imageId)
+    {
+        $this->organizerId = $organizerId;
+        $this->imageId = $imageId;
+    }
+
+    public function getOrganizerId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getImageId(): string
+    {
+        return $this->imageId;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'organizerId' => $this->organizerId,
+            'imageId' => $this->imageId,
+        ];
+    }
+
+    public static function deserialize(array $data): ImageRemoved
+    {
+        return new ImageRemoved(
+            $data['organizerId'],
+            $data['imageId']
+        );
+    }
+}

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -39,6 +39,7 @@ use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelAdded;
 use CultuurNet\UDB3\Organizer\Events\LabelRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelsImported;
@@ -284,6 +285,15 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         return !$this->images->filter(
             fn (Image $currentImage) => $currentImage->getId()->sameAs($imageId)
         )->isEmpty();
+    }
+
+    public function removeImage(UUID $imageId): void
+    {
+        if (!$this->hasImage($imageId)) {
+            return;
+        }
+
+        $this->apply(new ImageRemoved($this->actorId, $imageId->toString()));
     }
 
     public function updateGeoCoordinates(Coordinates $coordinate): void
@@ -532,6 +542,13 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
     protected function applyImageAdded(ImageAdded $imageAdded): void
     {
         $this->images = $this->images->with($imageAdded->getImage());
+    }
+
+    protected function applyImageRemoved(ImageRemoved $imageRemoved): void
+    {
+        $this->images = $this->images->filter(
+            fn (Image $image) => $image->getId()->toString() !== $imageRemoved->getImageId()
+        );
     }
 
     protected function applyLabelAdded(LabelAdded $labelAdded): void

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
 use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
@@ -259,7 +260,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
 
     public function addImage(Image $image): void
     {
-        if ($this->hasImage($image)) {
+        if ($this->hasImage($image->getId())) {
             return;
         }
 
@@ -274,14 +275,14 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         );
     }
 
-    public function hasImage(Image $image): bool
+    public function hasImage(UUID $imageId): bool
     {
         if ($this->images->isEmpty()) {
             return false;
         }
 
         return !$this->images->filter(
-            fn (Image $currentImage) => $currentImage->getId()->sameAs($image->getId())
+            fn (Image $currentImage) => $currentImage->getId()->sameAs($imageId)
         )->isEmpty();
     }
 

--- a/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
@@ -32,6 +32,9 @@ final class DeleteImageRequestHandlerTest extends TestCase
         $this->commandBus->record();
     }
 
+    /**
+     * @test
+     */
     public function it_handles_removing_an_image(): void
     {
         $request = (new Psr7RequestBuilder())

--- a/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Organizer\Commands\RemoveImage;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteImageRequestHandlerTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private TraceableCommandBus $commandBus;
+
+    private DeleteImageRequestHandler $deleteImageRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->deleteImageRequestHandler = new DeleteImageRequestHandler($this->commandBus);
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+
+        $this->commandBus->record();
+    }
+
+    public function it_handles_removing_an_image(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->withRouteParameter('imageId', '03789a2f-5063-4062-b7cb-95a0a2280d92')
+            ->build('DELETE');
+
+        $response = $this->deleteImageRequestHandler->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(
+            [
+                new RemoveImage(
+                    'c269632a-a887-4f21-8455-1631c31e4df5',
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92')
+                ),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+}

--- a/tests/Organizer/CommandHandler/RemoveImageHandlerTest.php
+++ b/tests/Organizer/CommandHandler/RemoveImageHandlerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Organizer\Commands\RemoveImage;
+use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class RemoveImageHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new RemoveImageHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     * @dataProvider removeImageProvider
+     */
+    public function it_handles_removing_an_image(
+        array $given,
+        RemoveImage $removeImage,
+        array $then
+    ): void {
+        $this->scenario
+            ->withAggregateId('5e360b25-fd85-4dac-acf4-0571e0b57dce')
+            ->given($given)
+            ->when($removeImage)
+            ->then($then);
+    }
+
+    public function removeImageProvider(): array
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        return [
+            'Remove an image' => [
+                [
+                    $this->organizerCreatedWithUniqueWebsite($id),
+                    new ImageAdded(
+                        $id,
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Description of the image',
+                        'publiq'
+                    ),
+                ],
+                new removeImage(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new UUID('cf539408-bba9-4e77-9f85-72019013db37')
+                ),
+                [
+                    new ImageRemoved(
+                        $id,
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                    ),
+                ],
+            ],
+            'Remove an image twice' => [
+                [
+                    $this->organizerCreatedWithUniqueWebsite($id),
+                    new ImageAdded(
+                        $id,
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Description of the image',
+                        'publiq'
+                    ),
+                    new ImageRemoved(
+                        $id,
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                    ),
+                ],
+                new removeImage(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new UUID('cf539408-bba9-4e77-9f85-72019013db37')
+                ),
+                [
+                ],
+            ],
+            'Removing when no image present' => [
+                [
+                    $this->organizerCreatedWithUniqueWebsite($id),
+                ],
+                new removeImage(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new UUID('cf539408-bba9-4e77-9f85-72019013db37')
+                ),
+                [
+                ],
+            ],
+        ];
+    }
+
+    private function organizerCreatedWithUniqueWebsite(string $id): OrganizerCreatedWithUniqueWebsite
+    {
+        return new OrganizerCreatedWithUniqueWebsite(
+            $id,
+            'nl',
+            'https://www.publiq.be',
+            'publiq'
+        );
+    }
+}

--- a/tests/Organizer/Commands/RemoveImageTest.php
+++ b/tests/Organizer/Commands/RemoveImageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use PHPUnit\Framework\TestCase;
+
+final class RemoveImageTest extends TestCase
+{
+    private RemoveImage $removeImage;
+
+    protected function setUp(): void
+    {
+        $this->removeImage = new RemoveImage(
+            '683739ce-f048-438d-8131-a674286c0b2f',
+            new UUID('ac4cd69f-c789-41c9-aa85-e21c8e481f58')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals(
+            '683739ce-f048-438d-8131-a674286c0b2f',
+            $this->removeImage->getOrganizerId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_image_id(): void
+    {
+        $this->assertEquals(
+            new UUID('ac4cd69f-c789-41c9-aa85-e21c8e481f58'),
+            $this->removeImage->getImageId()
+        );
+    }
+}

--- a/tests/Organizer/Events/ImageRemovedTest.php
+++ b/tests/Organizer/Events/ImageRemovedTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use PHPUnit\Framework\TestCase;
+
+final class ImageRemovedTest extends TestCase
+{
+    private ImageRemoved $imageRemoved;
+
+    protected function setUp(): void
+    {
+        $this->imageRemoved = new ImageRemoved(
+            '683739ce-f048-438d-8131-a674286c0b2f',
+            'ac4cd69f-c789-41c9-aa85-e21c8e481f58'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals(
+            '683739ce-f048-438d-8131-a674286c0b2f',
+            $this->imageRemoved->getOrganizerId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_image_id(): void
+    {
+        $this->assertEquals(
+            'ac4cd69f-c789-41c9-aa85-e21c8e481f58',
+            $this->imageRemoved->getImageId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_serialized(): void
+    {
+        $this->assertEquals(
+            [
+                'organizerId' => '683739ce-f048-438d-8131-a674286c0b2f',
+                'imageId' => 'ac4cd69f-c789-41c9-aa85-e21c8e481f58',
+            ],
+            $this->imageRemoved->serialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_deserialized(): void
+    {
+        $this->assertEquals(
+            new ImageRemoved(
+                '683739ce-f048-438d-8131-a674286c0b2f',
+                'ac4cd69f-c789-41c9-aa85-e21c8e481f58'
+            ),
+            ImageRemoved::deserialize(
+                [
+                    'organizerId' => '683739ce-f048-438d-8131-a674286c0b2f',
+                    'imageId' => 'ac4cd69f-c789-41c9-aa85-e21c8e481f58',
+                ]
+            )
+        );
+    }
+}

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -28,12 +28,12 @@ use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelAdded;
 use CultuurNet\UDB3\Organizer\Events\LabelRemoved;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Organizer\Events\OrganizerDeleted;
-use CultuurNet\UDB3\Organizer\Events\OrganizerEvent;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
@@ -465,6 +465,46 @@ final class OrganizerLDProjectorTest extends TestCase
         );
 
         $this->expectSave($organizerId, 'organizer_with_two_images.json');
+
+        $this->projector->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_removing_an_image(): void
+    {
+        $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
+        $this->mockGet($organizerId, 'organizer_with_two_images.json');
+
+        $domainMessage = $this->createDomainMessage(
+            new ImageRemoved(
+                $organizerId,
+                'dd45e5a1-f70c-48d7-83e5-dde9226c1dd6',
+            )
+        );
+
+        $this->expectSave($organizerId, 'organizer_with_image.json');
+
+        $this->projector->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_removing_last_image(): void
+    {
+        $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
+        $this->mockGet($organizerId, 'organizer_with_image.json');
+
+        $domainMessage = $this->createDomainMessage(
+            new ImageRemoved(
+                $organizerId,
+                '03789a2f-5063-4062-b7cb-95a0a2280d92',
+            )
+        );
+
+        $this->expectSave($organizerId, 'organizer_with_all_images_removed.json');
 
         $this->projector->handle($domainMessage);
     }
@@ -980,9 +1020,7 @@ final class OrganizerLDProjectorTest extends TestCase
             ->with(new JsonDocument($organizerId, $expectedOrganizerJson));
     }
 
-    /**
-     * @param ActorEvent|OrganizerEvent|ImageAdded $organizerEvent
-     */
+
     private function createDomainMessage($organizerEvent): DomainMessage
     {
         if ($organizerEvent instanceof ActorEvent) {

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -706,7 +706,6 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                 [
                 ],
             ],
-
             'Allow setting extra image' => [
                 [
                     $organizerCreated,

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -31,6 +31,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelAdded;
 use CultuurNet\UDB3\Organizer\Events\LabelRemoved;
 use CultuurNet\UDB3\Organizer\Events\LabelsImported;
@@ -735,6 +736,71 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                         'Description of the image',
                         'publiq'
                     ),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider addImageDataProvider
+     */
+    public function it_can_remove_an_image(array $given, callable $removeImage, array $then): void
+    {
+        $this->scenario
+            ->given($given)
+            ->when(fn (Organizer $organizer) => $removeImage($organizer))
+            ->then($then);
+    }
+
+    public function removeImageDataProvider(): array
+    {
+        $organizerCreated = new OrganizerCreatedWithUniqueWebsite(
+            'ae3aab28-6351-489e-a61c-c48aec0a77df',
+            'en',
+            'https://www.publiq.be',
+            'publiq'
+        );
+
+        return [
+            'Remove existing image' => [
+                [
+                    $organizerCreated,
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Beschrijving van de afbeelding',
+                        'publiq'
+                    ),
+                ],
+                fn (Organizer $organizer) =>
+                    $organizer->removeImage(new UUID('cf539408-bba9-4e77-9f85-72019013db37')),
+                [
+                    new ImageRemoved(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37'
+                    ),
+                ],
+            ],
+            'Remove image only once' => [
+                [
+                    $organizerCreated,
+                    new ImageAdded(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37',
+                        'nl',
+                        'Beschrijving van de afbeelding',
+                        'publiq'
+                    ),
+                    new ImageRemoved(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'cf539408-bba9-4e77-9f85-72019013db37'
+                    ),
+                ],
+                fn (Organizer $organizer) =>
+                    $organizer->removeImage(new UUID('cf539408-bba9-4e77-9f85-72019013db37')),
+                [
                 ],
             ],
         ];

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -743,7 +743,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
-     * @dataProvider addImageDataProvider
+     * @dataProvider removeImageDataProvider
      */
     public function it_can_remove_an_image(array $given, callable $removeImage, array $then): void
     {

--- a/tests/Organizer/Samples/organizer_with_all_images_removed.json
+++ b/tests/Organizer/Samples/organizer_with_all_images_removed.json
@@ -1,0 +1,23 @@
+{
+  "@id": "http:\/\/udb-silex.dev\/organizer\/586f596d-7e43-4ab9-b062-04db9436fca4",
+  "@context": "\/api\/1.0\/organizer.jsonld",
+  "name": {
+    "nl": "TestOrganisatie"
+  },
+  "address": {
+    "nl": {
+      "addressCountry": "BE",
+      "addressLocality": "Kessel-Lo (Leuven)",
+      "postalCode": "3010",
+      "streetAddress": "Straat"
+    }
+  },
+  "phone": [],
+  "email": [],
+  "url": [],
+  "created": "2016-09-28T10:01:28+00:00",
+  "creator": "20a72430-7e3e-4b75-ab59-043156b3169c (LucW)",
+  "languages": ["nl"],
+  "completedLanguages": ["nl"],
+  "modified": "2018-01-18T13:57:09+00:00"
+}


### PR DESCRIPTION
### Added
- Added `ImageRemoved` event
- Added `RemoveImage` command
- Implement `removeImage` on `Organizer` aggregate
- Implement `ImageRemoved` inside `OrganizerLDProjector`
- Added `RemoveImageHandler` to handle the `RemoveImage` command
- Added `DeleteImageRequestHandler` to handle the `DELETE` image request

---
Ticket: https://jira.uitdatabank.be/browse/III-4428
