### PR TITLE
III-4507 Use hyphens in news articles paths

### DIFF
--- a/app/LegacyRoutesServiceProvider.php
+++ b/app/LegacyRoutesServiceProvider.php
@@ -54,6 +54,9 @@ final class LegacyRoutesServiceProvider implements ServiceProviderInterface
                     // Convert old "calsum" path to "calendar-summary"
                     '/\/calsum/' => '/calendar-summary',
 
+                    // Convert old "news_articles" path to "news-articles"
+                    '/news_articles/' => 'news-articles',
+
                     // Add trailing slash if missing
                     '/^(.*)(?<!\/)$/' => '${1}/',
                 ];

--- a/src/Curators/Serializer/NewsArticleNormalizer.php
+++ b/src/Curators/Serializer/NewsArticleNormalizer.php
@@ -16,7 +16,7 @@ final class NewsArticleNormalizer implements NormalizerInterface
     {
         return [
             '@context' => '/contexts/NewsArticle',
-            '@id' => '/news_articles/' . $newsArticle->getId()->toString(),
+            '@id' => '/news-articles/' . $newsArticle->getId()->toString(),
             '@type' => 'https://schema.org/NewsArticle',
             'id' => $newsArticle->getId()->toString(),
             'headline' => $newsArticle->getHeadline(),

--- a/tests/Http/Curators/GetNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/GetNewsArticleRequestHandlerTest.php
@@ -72,7 +72,7 @@ class GetNewsArticleRequestHandlerTest extends TestCase
         $this->assertEquals(
             Json::encode([
                 '@context' => '/contexts/NewsArticle',
-                '@id' => '/news_articles/' . $articleId->toString(),
+                '@id' => '/news-articles/' . $articleId->toString(),
                 '@type' => 'https://schema.org/NewsArticle',
                 'id' => $articleId->toString(),
                 'headline' => 'publiq wint API award',

--- a/tests/Http/Curators/GetNewsArticlesRequestHandlerTest.php
+++ b/tests/Http/Curators/GetNewsArticlesRequestHandlerTest.php
@@ -78,7 +78,7 @@ class GetNewsArticlesRequestHandlerTest extends TestCase
                 'hydra:member' => [
                     [
                         '@context' => '/contexts/NewsArticle',
-                        '@id' => '/news_articles/ec00bcd0-41e9-47a0-8364-71aad7e537c5',
+                        '@id' => '/news-articles/ec00bcd0-41e9-47a0-8364-71aad7e537c5',
                         '@type' => 'https://schema.org/NewsArticle',
                         'id' => 'ec00bcd0-41e9-47a0-8364-71aad7e537c5',
                         'headline' => 'publiq wint API award',
@@ -91,7 +91,7 @@ class GetNewsArticlesRequestHandlerTest extends TestCase
                     ],
                     [
                         '@context' => '/contexts/NewsArticle',
-                        '@id' => '/news_articles/9bf7f5fa-4a0b-4475-9ebb-f776e33510f5',
+                        '@id' => '/news-articles/9bf7f5fa-4a0b-4475-9ebb-f776e33510f5',
                         '@type' => 'https://schema.org/NewsArticle',
                         'id' => '9bf7f5fa-4a0b-4475-9ebb-f776e33510f5',
                         'headline' => 'madewithlove creates API',

--- a/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/UpdateNewsArticleRequestHandlerTest.php
@@ -82,7 +82,7 @@ class UpdateNewsArticleRequestHandlerTest extends TestCase
         $this->assertEquals(
             Json::encode([
                 '@context' => '/contexts/NewsArticle',
-                '@id' => '/news_articles/6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
+                '@id' => '/news-articles/6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
                 '@type' => 'https://schema.org/NewsArticle',
                 'id' => '6c583739-a848-41ab-b8a3-8f7dab6f8ee1',
                 'headline' => 'publiq wint API award',

--- a/web/index.php
+++ b/web/index.php
@@ -89,7 +89,7 @@ $app['security.firewalls'] = array(
             ->with(new RequestMatcher('^/organizers/suggest/.*', null, 'GET'))
             ->with(new RequestMatcher('^/jobs/', null, 'GET'))
             ->with(new RequestMatcher('^/uitpas/.*', null, 'GET'))
-            ->with(new RequestMatcher('^/news_articles', null, ['GET', 'DELETE', 'POST', 'PUT']))
+            ->with(new RequestMatcher('^/(news_articles|news-articles)', null, ['GET', 'DELETE', 'POST', 'PUT']))
     ],
     'cors-preflight' => array(
         'pattern' => $app['cors_preflight_request_matcher'],

--- a/web/index.php
+++ b/web/index.php
@@ -238,7 +238,7 @@ $app->mount('/productions', new \CultuurNet\UDB3\Silex\Event\ProductionControlle
 $app->mount('/uitpas/labels', new UiTPASServiceLabelsControllerProvider());
 $app->mount('/uitpas/events', new UiTPASServiceEventControllerProvider());
 $app->mount('/uitpas/organizers', new UiTPASServiceOrganizerControllerProvider());
-$app->mount('/news_articles', new CuratorsControllerProvider());
+$app->mount('/news-articles', new CuratorsControllerProvider());
 
 $app->mount(ImportControllerProvider::PATH, new ImportControllerProvider());
 


### PR DESCRIPTION
### Changed

- `news_articles` routes are now registered as `news-articles`, but `news_articles` also still works

---
Ticket: https://jira.uitdatabank.be/browse/III-4507

(Note: This ticket also still requires some documentation changes and acceptance test changes)
