### PR TITLE
III-4426 Make properties when adding an image on an organizer optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4510-update-main-image",
+    "publiq/stoplight-docs-uitdatabank": "dev-feature/III-4426-optional-properties-when-adding-image",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",
     "sentry/sdk": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "573175381a4afe130e985c2310f97e69",
+    "content-hash": "2d2d09bfb667d5d53f32e4c1bc6cafa8",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5222,16 +5222,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-feature/III-4510-update-main-image",
+            "version": "dev-feature/III-4426-optional-properties-when-adding-image",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "2119ae4592aee00f09b92aab2b770a33fbaa6116"
+                "reference": "d471f1f22baf622d152de1525790fa05e5ead903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/2119ae4592aee00f09b92aab2b770a33fbaa6116",
-                "reference": "2119ae4592aee00f09b92aab2b770a33fbaa6116",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/d471f1f22baf622d152de1525790fa05e5ead903",
+                "reference": "d471f1f22baf622d152de1525790fa05e5ead903",
                 "shasum": ""
             },
             "type": "library",
@@ -5248,9 +5248,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4510-update-main-image"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/feature/III-4426-optional-properties-when-adding-image"
             },
-            "time": "2022-01-11T16:29:52+00:00"
+            "time": "2022-01-12T10:27:35+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Organizer/AddImageRequestHandler.php
+++ b/src/Http/Organizer/AddImageRequestHandler.php
@@ -39,6 +39,7 @@ final class AddImageRequestHandler implements RequestHandlerInterface
 
         $requestBodyParser = RequestBodyParserFactory::createBaseParser(
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::ORGANIZER_IMAGE_POST),
+            new AddMediaObjectPropertiesRequestBodyParser($this->mediaRepository),
             new DenormalizingRequestBodyParser(new AddImageDenormalizer($organizerId), AddImage::class)
         );
 

--- a/src/Http/Organizer/AddImageRequestHandler.php
+++ b/src/Http/Organizer/AddImageRequestHandler.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Organizer;
 
 use Broadway\CommandHandling\CommandBus;
-use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
@@ -45,13 +43,6 @@ final class AddImageRequestHandler implements RequestHandlerInterface
 
         /** @var AddImage $addImage */
         $addImage = $requestBodyParser->parse($request)->getParsedBody();
-        $imageId = $addImage->getImage()->getId()->toString();
-
-        try {
-            $this->mediaRepository->load($imageId);
-        } catch (AggregateNotFoundException $exception) {
-            throw ApiProblem::imageNotFound($imageId);
-        }
 
         $this->commandBus->dispatch($addImage);
 

--- a/src/Http/Organizer/AddMediaObjectPropertiesRequestBodyParser.php
+++ b/src/Http/Organizer/AddMediaObjectPropertiesRequestBodyParser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\Repository\AggregateNotFoundException;
+use Broadway\Repository\Repository;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Media\MediaObject;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AddMediaObjectPropertiesRequestBodyParser implements RequestBodyParser
+{
+    private Repository $mediaRepository;
+
+    public function __construct(Repository $mediaRepository)
+    {
+        $this->mediaRepository = $mediaRepository;
+    }
+
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $data = (array) $request->getParsedBody();
+
+        $imageId = $data['id'];
+
+        try {
+            /** @var MediaObject $mediaObject */
+            $mediaObject = $this->mediaRepository->load($imageId);
+        } catch (AggregateNotFoundException $exception) {
+            throw ApiProblem::imageNotFound($imageId);
+        }
+
+        $convertedData = [];
+        $convertedData['id'] = $imageId;
+        $convertedData['language'] = $data['language'] ?? $mediaObject->getLanguage()->getCode();
+        $convertedData['description'] = $data['description'] ?? $mediaObject->getDescription()->toNative();
+        $convertedData['copyrightHolder'] = $data['copyrightHolder'] ?? $mediaObject->getCopyrightHolder()->toString();
+
+        return $request->withParsedBody((object)$convertedData);
+    }
+}

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -102,7 +102,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new Language('en'),
                     new Description('A nice image'),
                     new CopyrightHolder('publiq')
-                )
+                ),
             ],
             'Only id provided' => [
                 [
@@ -113,7 +113,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new Description('Uploaded image'),
                     new CopyrightHolder('madewithlove')
-                )
+                ),
             ],
             'Only id and language provided' => [
                 [
@@ -125,7 +125,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new Language('fr'),
                     new Description('Uploaded image'),
                     new CopyrightHolder('madewithlove')
-                )
+                ),
             ],
             'Only id and description provided' => [
                 [
@@ -137,7 +137,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new Description('A nice image'),
                     new CopyrightHolder('madewithlove')
-                )
+                ),
             ],
             'Only id and copyrigght holder provided' => [
                 [
@@ -149,7 +149,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new Description('Uploaded image'),
                     new CopyrightHolder('publiq')
-                )
+                ),
             ],
         ];
     }

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -54,17 +54,13 @@ final class AddImageRequestHandlerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider addImageDataProvider
      */
-    public function it_handles_adding_an_image(): void
+    public function it_handles_adding_an_image(array $body, Image $image): void
     {
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
-            ->withBodyFromArray([
-                'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
-                'language' => 'en',
-                'description' => 'A nice image',
-                'copyrightHolder' => 'publiq',
-            ])
+            ->withBodyFromArray($body)
             ->build('POST');
 
         $this->imageRepository->method('load')
@@ -74,7 +70,7 @@ final class AddImageRequestHandlerTest extends TestCase
                     new LegacyUUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
                     MIMEType::fromSubtype('jpeg'),
                     new StringLiteral('Uploaded image'),
-                    new CopyrightHolder('publiq'),
+                    new CopyrightHolder('madewithlove'),
                     Url::fromNative('https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg'),
                     new LegacyLanguage('nl')
                 )
@@ -82,18 +78,80 @@ final class AddImageRequestHandlerTest extends TestCase
 
         $expectedCommand = new AddImage(
             'c269632a-a887-4f21-8455-1631c31e4df5',
-            new Image(
-                new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
-                new Language('en'),
-                new Description('A nice image'),
-                new CopyrightHolder('publiq')
-            )
+            $image
         );
 
         $response = $this->addImageRequestHandler->handle($request);
 
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals([$expectedCommand], $this->commandBus->getRecordedCommands());
+    }
+
+    public function addImageDataProvider(): array
+    {
+        return [
+            'All properties' => [
+                [
+                    'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                    'language' => 'en',
+                    'description' => 'A nice image',
+                    'copyrightHolder' => 'publiq',
+                ],
+                new Image(
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    new Language('en'),
+                    new Description('A nice image'),
+                    new CopyrightHolder('publiq')
+                )
+            ],
+            'Only id provided' => [
+                [
+                    'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                ],
+                new Image(
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    new Language('nl'),
+                    new Description('Uploaded image'),
+                    new CopyrightHolder('madewithlove')
+                )
+            ],
+            'Only id and language provided' => [
+                [
+                    'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                    'language' => 'fr',
+                ],
+                new Image(
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    new Language('fr'),
+                    new Description('Uploaded image'),
+                    new CopyrightHolder('madewithlove')
+                )
+            ],
+            'Only id and description provided' => [
+                [
+                    'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                    'description' => 'A nice image',
+                ],
+                new Image(
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    new Language('nl'),
+                    new Description('A nice image'),
+                    new CopyrightHolder('madewithlove')
+                )
+            ],
+            'Only id and copyrigght holder provided' => [
+                [
+                    'id' => '03789a2f-5063-4062-b7cb-95a0a2280d92',
+                    'copyrightHolder' => 'publiq',
+                ],
+                new Image(
+                    new UUID('03789a2f-5063-4062-b7cb-95a0a2280d92'),
+                    new Language('nl'),
+                    new Description('Uploaded image'),
+                    new CopyrightHolder('publiq')
+                )
+            ],
+        ];
     }
 
     /**
@@ -152,7 +210,7 @@ final class AddImageRequestHandlerTest extends TestCase
             [
                 '{}',
                 ApiProblem::bodyInvalidData(
-                    new SchemaError('/', 'The required properties (id, language, copyrightHolder, description) are missing')
+                    new SchemaError('/', 'The required properties (id) are missing')
                 ),
             ],
             [


### PR DESCRIPTION
### Changed
- Made properties when adding an image on an organizer optional

---
Note: I left the `composer.json` conflict so I can set it do dev-unreleased when reviewed.

Ticket: https://jira.uitdatabank.be/browse/III-4426
