### PR TITLE
III-4509 Block new news article with existing url and about

### DIFF
--- a/src/Http/Curators/CreateNewsArticleRequestHandler.php
+++ b/src/Http/Curators/CreateNewsArticleRequestHandler.php
@@ -7,7 +7,9 @@ namespace CultuurNet\UDB3\Http\Curators;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Curators\NewsArticle;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
+use CultuurNet\UDB3\Curators\NewsArticleSearch;
 use CultuurNet\UDB3\Curators\Serializer\NewsArticleDenormalizer;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
@@ -44,6 +46,25 @@ final class CreateNewsArticleRequestHandler implements RequestHandlerInterface
 
         /** @var NewsArticle $newsArticle */
         $newsArticle = $requestBodyParser->parse($request)->getParsedBody();
+
+        $existingNewsArticles = $this->newsArticleRepository->search(
+            new NewsArticleSearch(
+                null,
+                $newsArticle->getAbout(),
+                $newsArticle->getUrl()->toString()
+            )
+        );
+
+        if (!$existingNewsArticles->isEmpty()) {
+            /** @var NewsArticle $first */
+            $first = $existingNewsArticles->getFirst();
+            $id = $first->getId()->toString();
+
+            throw ApiProblem::bodyInvalidDataWithDetail(
+                'A news article with the given url and about already exists. (' . $id . ') '
+                    . 'Do a GET /news-articles request with `url` and `about` parameters to find it programmatically.'
+            );
+        }
 
         $this->newsArticleRepository->create($newsArticle);
 

--- a/src/Http/Curators/CreateNewsArticleRequestHandler.php
+++ b/src/Http/Curators/CreateNewsArticleRequestHandler.php
@@ -47,6 +47,7 @@ final class CreateNewsArticleRequestHandler implements RequestHandlerInterface
         /** @var NewsArticle $newsArticle */
         $newsArticle = $requestBodyParser->parse($request)->getParsedBody();
 
+        // Do not include publisher to search for duplicates, because each publisher already has its own URL anyway.
         $existingNewsArticles = $this->newsArticleRepository->search(
             new NewsArticleSearch(
                 null,

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -280,7 +280,7 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
                 'A news article with the given url and about already exists. (d684fc46-b0ba-4b64-9584-5f61fb5c4963) '
                 . 'Do a GET /news-articles request with `url` and `about` parameters to find it programmatically.'
             ),
-            fn() => $this->createNewsArticleRequestHandler->handle($createOrganizerRequest)
+            fn () => $this->createNewsArticleRequestHandler->handle($createOrganizerRequest)
         );
     }
 

--- a/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
+++ b/tests/Http/Curators/CreateNewsArticleRequestHandlerTest.php
@@ -7,6 +7,8 @@ namespace CultuurNet\UDB3\Http\Curators;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Curators\NewsArticle;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
+use CultuurNet\UDB3\Curators\NewsArticles;
+use CultuurNet\UDB3\Curators\NewsArticleSearch;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
@@ -64,6 +66,17 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
             ->build('POST');
 
         $this->newsArticleRepository->expects($this->once())
+            ->method('search')
+            ->with(
+                new NewsArticleSearch(
+                    null,
+                    '17284745-7bcf-461a-aad0-d3ad54880e75',
+                    'https://www.publiq.be/blog/api-reward'
+                )
+            )
+            ->willReturn(new NewsArticles());
+
+        $this->newsArticleRepository->expects($this->once())
             ->method('create')
             ->with(new NewsArticle(
                 new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
@@ -115,6 +128,17 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
             ->build('POST');
 
         $this->newsArticleRepository->expects($this->once())
+            ->method('search')
+            ->with(
+                new NewsArticleSearch(
+                    null,
+                    '17284745-7bcf-461a-aad0-d3ad54880e75',
+                    'https://www.publiq.be/blog/api-reward'
+                )
+            )
+            ->willReturn(new NewsArticles());
+
+        $this->newsArticleRepository->expects($this->once())
             ->method('create')
             ->with(new NewsArticle(
                 new UUID('6c583739-a848-41ab-b8a3-8f7dab6f8ee1'),
@@ -164,6 +188,17 @@ class CreateNewsArticleRequestHandlerTest extends TestCase
                 'publisherLogo' => 'https://www.bill.be/img/favicon.png',
             ])
             ->build('POST');
+
+        $this->newsArticleRepository->expects($this->once())
+            ->method('search')
+            ->with(
+                new NewsArticleSearch(
+                    null,
+                    '17284745-7bcf-461a-aad0-d3ad54880e75',
+                    'https://www.publiq.be/blog/api-reward'
+                )
+            )
+            ->willReturn(new NewsArticles());
 
         $this->newsArticleRepository->expects($this->once())
             ->method('create')


### PR DESCRIPTION
### Added

- Added check that no news article(s) already exist with the same `url` and `about` when creating a new news article

---
Ticket: https://jira.uitdatabank.be/browse/III-4509
