### PR TITLE
III-4511 Add id to organizer images

### DIFF
--- a/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
@@ -32,6 +32,7 @@ final class ImageNormalizer implements NormalizerInterface
 
         return [
             '@id' => $this->mediaIriGenerator->iri($image->getId()->toString()),
+            'id' => $image->getId()->toString(),
             'contentUrl' => (string) $mediaObject->getSourceLocation(),
             'thumbnailUrl' => (string) $mediaObject->getSourceLocation(),
             'language' => $image->getLanguage()->toString(),

--- a/tests/Organizer/Samples/organizer_with_image.json
+++ b/tests/Organizer/Samples/organizer_with_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "language": "nl",

--- a/tests/Organizer/Samples/organizer_with_two_images.json
+++ b/tests/Organizer/Samples/organizer_with_two_images.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "language": "nl",
@@ -30,6 +31,7 @@
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
+      "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "language": "en",

--- a/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
+++ b/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "language": "nl",
@@ -30,6 +31,7 @@
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
+      "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "language": "en",

--- a/tests/Organizer/Samples/organizer_with_updated_image.json
+++ b/tests/Organizer/Samples/organizer_with_updated_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "language": "en",


### PR DESCRIPTION
### Added
- Added `id` to the images projection of an organizer.

---
Ticket: https://jira.uitdatabank.be/browse/III-4511
