### PR TITLE
III-4500 Add endpoint to delete organizer description

### DIFF
--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Silex\Organizer;
 use CultuurNet\UDB3\Event\EventOrganizerRelationService;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddLabelHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\DeleteDescriptionHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
@@ -70,6 +71,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[UpdateDescriptionHandler::class] = $app->share(
             fn (Application $application) => new UpdateDescriptionHandler($app['organizer_repository'])
+        );
+
+        $app[DeleteDescriptionHandler::class] = $app->share(
+            fn (Application $application) => new DeleteDescriptionHandler($app['organizer_repository'])
         );
 
         $app[UpdateAddressHandler::class] = $app->share(

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\Organizer\AddImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\AddLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\CreateOrganizerRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteAddressRequestHandler;
+use CultuurNet\UDB3\Http\Organizer\DeleteDescriptionRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteOrganizerRequestHandler;
@@ -42,6 +43,7 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
         $controllers->put('/{organizerId}/name/{language}/', UpdateTitleRequestHandler::class);
 
         $controllers->put('/{organizerId}/description/{language}/', UpdateDescriptionRequestHandler::class);
+        $controllers->delete('/{organizerId}/description/{language}/', DeleteDescriptionRequestHandler::class);
 
         $controllers->put('/{organizerId}/address/', UpdateAddressRequestHandler::class);
         $controllers->put('/{organizerId}/address/{language}/', UpdateAddressRequestHandler::class);
@@ -100,6 +102,10 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
 
         $app[UpdateDescriptionRequestHandler::class] = $app->share(
             fn (Application $application) => new UpdateDescriptionRequestHandler($app['event_command_bus'])
+        );
+
+        $app[DeleteDescriptionRequestHandler::class] = $app->share(
+            fn (Application $application) => new DeleteDescriptionRequestHandler($app['event_command_bus'])
         );
 
         $app[UpdateAddressRequestHandler::class] = $app->share(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,6 +38,7 @@ use CultuurNet\UDB3\Offer\OfferLocator;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\DeleteDescriptionHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveImageHandler;
@@ -642,6 +643,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[\CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler::class]);
         $commandBus->subscribe($app[UpdateTitleHandler::class]);
         $commandBus->subscribe($app[UpdateDescriptionHandler::class]);
+        $commandBus->subscribe($app[DeleteDescriptionHandler::class]);
         $commandBus->subscribe($app[UpdateAddressHandler::class]);
         $commandBus->subscribe($app[RemoveAddressHandler::class]);
         $commandBus->subscribe($app[UpdateWebsiteHandler::class]);

--- a/src/Http/Organizer/DeleteDescriptionRequestHandler.php
+++ b/src/Http/Organizer/DeleteDescriptionRequestHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DeleteDescriptionRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $organizerId = $routeParameters->getOrganizerId();
+        $language = $routeParameters->getLanguage();
+
+        $this->commandBus->dispatch(new DeleteDescription($organizerId, $language));
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Organizer/CommandHandler/DeleteDescriptionHandler.php
+++ b/src/Organizer/CommandHandler/DeleteDescriptionHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class DeleteDescriptionHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof DeleteDescription) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getItemId());
+
+        $organizer->deleteDescription($command->getLanguage());
+
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/Commands/DeleteDescription.php
+++ b/src/Organizer/Commands/DeleteDescription.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class DeleteDescription implements AuthorizableCommand
+{
+    private string $organizerId;
+
+    private Language $language;
+
+    public function __construct(string $organizerId, Language $language)
+    {
+        $this->organizerId = $organizerId;
+        $this->language = $language;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::ORGANISATIES_BEWERKEN();
+    }
+}

--- a/src/Organizer/Events/DescriptionDeleted.php
+++ b/src/Organizer/Events/DescriptionDeleted.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use Broadway\Serializer\Serializable;
+
+final class DescriptionDeleted implements Serializable
+{
+    private string $organizerId;
+
+    private string $language;
+
+    public function __construct(string $organizerId, string $language)
+    {
+        $this->organizerId = $organizerId;
+        $this->language = $language;
+    }
+
+    public function getOrganizerId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'organizerId' => $this->organizerId,
+            'language' => $this->language,
+        ];
+    }
+
+    public static function deserialize(array $data): DescriptionDeleted
+    {
+        return new DescriptionDeleted(
+            $data['organizerId'],
+            $data['language']
+        );
+    }
+}

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -187,7 +187,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
 
     public function updateDescription(Description $description, Language $language): void
     {
-        if ($this->needsDescriptionUpdate($description, $language)) {
+        if ($this->descriptionCanBeUpdated($description, $language)) {
             $this->apply(
                 new DescriptionUpdated(
                     $this->actorId,
@@ -198,7 +198,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         }
     }
 
-    public function needsDescriptionUpdate(Description $description, Language $language): bool
+    private function descriptionCanBeUpdated(Description $description, Language $language): bool
     {
         if ($this->translatedDescription === null) {
             return true;

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -37,6 +37,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
+use CultuurNet\UDB3\Organizer\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
@@ -208,6 +209,29 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
             return !$this->translatedDescription->getTranslation($language)->sameAs($description);
         } catch (OutOfBoundsException $outOfBoundsException) {
             return true;
+        }
+    }
+
+    public function deleteDescription(Language $language): void
+    {
+        if ($this->descriptionCanBeDeleted($language)) {
+            $this->apply(
+                new DescriptionDeleted($this->actorId, $language->toString())
+            );
+        }
+    }
+
+    private function descriptionCanBeDeleted(Language $language): bool
+    {
+        if ($this->translatedDescription === null) {
+            return false;
+        }
+
+        try {
+            $this->translatedDescription->getTranslation($language);
+            return true;
+        } catch (OutOfBoundsException $outOfBoundsException) {
+            return false;
         }
     }
 
@@ -554,7 +578,19 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
             return;
         }
 
-        $this->translatedDescription->withTranslation($language, $description);
+        $this->translatedDescription = $this->translatedDescription->withTranslation($language, $description);
+    }
+
+    protected function applyDescriptionDeleted(DescriptionDeleted $descriptionDeleted): void
+    {
+        if ($this->translatedDescription->getLanguages()->count() === 1) {
+            $this->translatedDescription = null;
+            return;
+        }
+
+        $this->translatedDescription = $this->translatedDescription->withoutTranslation(
+            new Language($descriptionDeleted->getLanguage())
+        );
     }
 
     protected function applyAddressUpdated(AddressUpdated $addressUpdated): void

--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -32,6 +32,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
+use CultuurNet\UDB3\Organizer\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
@@ -71,6 +72,7 @@ class OrganizerLDProjector implements EventListener
      * @uses applyTitleUpdated
      * @uses applyTitleTranslated
      * @uses applyDescriptionUpdated
+     * @uses applyDescriptionDeleted
      * @uses applyAddressUpdated
      * @uses applyAddressRemoved
      * @uses applyAddressTranslated
@@ -314,6 +316,20 @@ class OrganizerLDProjector implements EventListener
         }
 
         $jsonLD->description->{$descriptionUpdated->getLanguage()} = $descriptionUpdated->getDescription();
+
+        return $document->withBody($jsonLD);
+    }
+
+    private function applyDescriptionDeleted(DescriptionDeleted $descriptionDeleted): JsonDocument
+    {
+        $document = $this->repository->fetch($descriptionDeleted->getOrganizerId());
+        $jsonLD = $document->getBody();
+
+        unset($jsonLD->description->{$descriptionDeleted->getLanguage()});
+
+        if (empty((array) $jsonLD->description)) {
+            unset($jsonLD->description);
+        }
 
         return $document->withBody($jsonLD);
     }

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -34,8 +34,6 @@ final class AddImageRequestHandlerTest extends TestCase
 
     private AddImageRequestHandler $addImageRequestHandler;
 
-    private Psr7RequestBuilder $psr7RequestBuilder;
-
     /** @var Repository|MockObject */
     private $imageRepository;
 
@@ -46,8 +44,6 @@ final class AddImageRequestHandlerTest extends TestCase
         $this->imageRepository = $this->createMock(Repository::class);
 
         $this->addImageRequestHandler = new AddImageRequestHandler($this->commandBus, $this->imageRepository);
-
-        $this->psr7RequestBuilder = new Psr7RequestBuilder();
 
         $this->commandBus->record();
     }

--- a/tests/Http/Organizer/DeleteDescriptionRequestHandlerTest.php
+++ b/tests/Http/Organizer/DeleteDescriptionRequestHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Organizer;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteDescriptionRequestHandlerTest extends TestCase
+{
+    private TraceableCommandBus $commandBus;
+
+    private DeleteDescriptionRequestHandler $deleteDescriptionRequestHandler;
+
+    private Psr7RequestBuilder $psr7RequestBuilder;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->deleteDescriptionRequestHandler = new DeleteDescriptionRequestHandler($this->commandBus);
+
+        $this->psr7RequestBuilder = new Psr7RequestBuilder();
+
+        $this->commandBus->record();
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_deleting_a_description(): void
+    {
+        $request = $this->psr7RequestBuilder
+            ->withRouteParameter('organizerId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->withRouteParameter('language', 'nl')
+            ->build('DELETE');
+
+        $expectedCommand = new DeleteDescription(
+            'c269632a-a887-4f21-8455-1631c31e4df5',
+            new Language('nl')
+        );
+
+        $response = $this->deleteDescriptionRequestHandler->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals([$expectedCommand], $this->commandBus->getRecordedCommands());
+    }
+}

--- a/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/DeleteImageRequestHandlerTest.php
@@ -19,15 +19,11 @@ final class DeleteImageRequestHandlerTest extends TestCase
 
     private DeleteImageRequestHandler $deleteImageRequestHandler;
 
-    private Psr7RequestBuilder $psr7RequestBuilder;
-
     protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
 
         $this->deleteImageRequestHandler = new DeleteImageRequestHandler($this->commandBus);
-
-        $this->psr7RequestBuilder = new Psr7RequestBuilder();
 
         $this->commandBus->record();
     }

--- a/tests/Http/Organizer/UpdateDescriptionRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateDescriptionRequestHandlerTest.php
@@ -22,15 +22,11 @@ final class UpdateDescriptionRequestHandlerTest extends TestCase
 
     private UpdateDescriptionRequestHandler $updateDescriptionRequestHandler;
 
-    private Psr7RequestBuilder $psr7RequestBuilder;
-
     protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
 
         $this->updateDescriptionRequestHandler = new UpdateDescriptionRequestHandler($this->commandBus);
-
-        $this->psr7RequestBuilder = new Psr7RequestBuilder();
 
         $this->commandBus->record();
     }

--- a/tests/Http/Organizer/UpdateImagesRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateImagesRequestHandlerTest.php
@@ -24,15 +24,11 @@ final class UpdateImagesRequestHandlerTest extends TestCase
 
     private UpdateImagesRequestHandler $updateImagesRequestHandler;
 
-    private Psr7RequestBuilder $psr7RequestBuilder;
-
     protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
 
         $this->updateImagesRequestHandler = new UpdateImagesRequestHandler($this->commandBus);
-
-        $this->psr7RequestBuilder = new Psr7RequestBuilder();
 
         $this->commandBus->record();
     }

--- a/tests/Http/Organizer/UpdateMainImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/UpdateMainImageRequestHandlerTest.php
@@ -21,15 +21,11 @@ final class UpdateMainImageRequestHandlerTest extends TestCase
 
     private UpdateMainImageRequestHandler $updateMainImageRequestHandler;
 
-    private Psr7RequestBuilder $psr7RequestBuilder;
-
     protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
 
         $this->updateMainImageRequestHandler = new UpdateMainImageRequestHandler($this->commandBus);
-
-        $this->psr7RequestBuilder = new Psr7RequestBuilder();
 
         $this->commandBus->record();
     }

--- a/tests/Organizer/CommandHandler/DeleteDescriptionHandlerTest.php
+++ b/tests/Organizer/CommandHandler/DeleteDescriptionHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use CultuurNet\UDB3\Organizer\Events\DescriptionDeleted;
+use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class DeleteDescriptionHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new DeleteDescriptionHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     * @dataProvider deleteDescriptionProvider
+     */
+    public function it_handles_deleting_a_description(
+        array $given,
+        DeleteDescription $deleteDescription,
+        array $then
+    ): void {
+        $this->scenario
+            ->withAggregateId('5e360b25-fd85-4dac-acf4-0571e0b57dce')
+            ->given($given)
+            ->when($deleteDescription)
+            ->then($then);
+    }
+
+    public function deleteDescriptionProvider(): array
+    {
+        return [
+            'Delete an existing description' => [
+                [
+                    $this->organizerCreated(),
+                    new DescriptionUpdated(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'Description EN',
+                        'en'
+                    ),
+                    new DescriptionUpdated(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'Beschrijving NL',
+                        'nl'
+                    ),
+                ],
+                new DeleteDescription(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new Language('nl')
+                ),
+                [
+                    new DescriptionDeleted(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'nl'
+                    ),
+                ],
+            ],
+            'Delete the last description' => [
+                [
+                    $this->organizerCreated(),
+                    new DescriptionUpdated(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'Beschrijving NL',
+                        'nl'
+                    ),
+                ],
+                new DeleteDescription(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new Language('nl')
+                ),
+                [
+                    new DescriptionDeleted(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'nl'
+                    ),
+                ],
+            ],
+            'Try deleting a non-existing description' => [
+                [
+                    $this->organizerCreated(),
+                    new DescriptionUpdated(
+                        '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                        'Beschrijving NL',
+                        'nl'
+                    ),
+                ],
+                new DeleteDescription(
+                    '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+                    new Language('fr')
+                ),
+                [
+                ],
+            ],
+        ];
+    }
+
+    private function organizerCreated(): OrganizerCreatedWithUniqueWebsite
+    {
+        return new OrganizerCreatedWithUniqueWebsite(
+            '5e360b25-fd85-4dac-acf4-0571e0b57dce',
+            'en',
+            'https://www.publiq.be',
+            'publiq'
+        );
+    }
+}

--- a/tests/Organizer/Commands/DeleteDescriptionTest.php
+++ b/tests/Organizer/Commands/DeleteDescriptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteDescriptionTest extends TestCase
+{
+    private DeleteDescription $deleteDescription;
+
+    protected function setUp(): void
+    {
+        $this->deleteDescription = new DeleteDescription(
+            'f6549ff4-aafc-436e-8630-48cd05a01943',
+            new Language('en')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals('f6549ff4-aafc-436e-8630-48cd05a01943', $this->deleteDescription->getItemId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_language(): void
+    {
+        $this->assertEquals(new Language('en'), $this->deleteDescription->getLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_permission(): void
+    {
+        $this->assertEquals(Permission::ORGANISATIES_BEWERKEN(), $this->deleteDescription->getPermission());
+    }
+}

--- a/tests/Organizer/Events/DescriptionDeletedTest.php
+++ b/tests/Organizer/Events/DescriptionDeletedTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use PHPUnit\Framework\TestCase;
+
+final class DescriptionDeletedTest extends TestCase
+{
+    private DescriptionDeleted $descriptionDeleted;
+
+    protected function setUp(): void
+    {
+        $this->descriptionDeleted = new DescriptionDeleted(
+            'f6549ff4-aafc-436e-8630-48cd05a01943',
+            'nl'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals('f6549ff4-aafc-436e-8630-48cd05a01943', $this->descriptionDeleted->getOrganizerId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_language(): void
+    {
+        $this->assertEquals('nl', $this->descriptionDeleted->getLanguage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            [
+                'organizerId' => 'f6549ff4-aafc-436e-8630-48cd05a01943',
+                'language' => 'nl',
+            ],
+            $this->descriptionDeleted->serialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deserialize(): void
+    {
+        $this->assertEquals(
+            new DescriptionDeleted(
+                'f6549ff4-aafc-436e-8630-48cd05a01943',
+                'nl'
+            ),
+            DescriptionDeleted::deserialize(
+                [
+                    'organizerId' => 'f6549ff4-aafc-436e-8630-48cd05a01943',
+                    'language' => 'nl',
+                ]
+            )
+        );
+    }
+}

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
+use CultuurNet\UDB3\Organizer\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\GeoCoordinatesUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
@@ -333,6 +334,42 @@ final class OrganizerLDProjectorTest extends TestCase
         );
 
         $this->expectSave($organizerId, 'organizer_with_translated_description.json');
+
+        $this->projector->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_deleting_a_translated_description(): void
+    {
+        $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
+
+        $this->mockGet($organizerId, 'organizer_with_translated_description.json');
+
+        $domainMessage = $this->createDomainMessage(
+            new DescriptionDeleted($organizerId, 'fr')
+        );
+
+        $this->expectSave($organizerId, 'organizer_with_updated_description.json');
+
+        $this->projector->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_deleting_a_description(): void
+    {
+        $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
+
+        $this->mockGet($organizerId, 'organizer_with_updated_description.json');
+
+        $domainMessage = $this->createDomainMessage(
+            new DescriptionDeleted($organizerId, 'en')
+        );
+
+        $this->expectSave($organizerId, 'organizer_without_description.json');
 
         $this->projector->handle($domainMessage);
     }

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -29,6 +29,7 @@ use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
+use CultuurNet\UDB3\Organizer\Events\DescriptionDeleted;
 use CultuurNet\UDB3\Organizer\Events\DescriptionUpdated;
 use CultuurNet\UDB3\Organizer\Events\ImageAdded;
 use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
@@ -634,6 +635,72 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                         'Beschrijving van de organisatie',
                         'nl'
                     ),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider deleteDescriptionDataProvider
+     */
+    public function it_can_delete_a_description(array $given, callable $delete, array $then): void
+    {
+        $this->scenario
+            ->given($given)
+            ->when(fn (Organizer $organizer) => $delete($organizer))
+            ->then($then);
+    }
+
+    public function deleteDescriptionDataProvider(): array
+    {
+        $organizerCreated = new OrganizerCreatedWithUniqueWebsite(
+            'ae3aab28-6351-489e-a61c-c48aec0a77df',
+            'en',
+            'https://www.publiq.be',
+            'publiq'
+        );
+
+        return [
+            'Delete existing description' => [
+                [
+                    $organizerCreated,
+                    new DescriptionUpdated(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'Description of the organizer',
+                        'en'
+                    ),
+                ],
+                function (Organizer $organizer) {
+                    $organizer->deleteDescription(new Language('en'));
+                },
+                [
+                    new DescriptionDeleted('ae3aab28-6351-489e-a61c-c48aec0a77df', 'en'),
+                ],
+            ],
+            'Try deleting non-existing description' => [
+                [
+                    $organizerCreated,
+                    new DescriptionUpdated(
+                        'ae3aab28-6351-489e-a61c-c48aec0a77df',
+                        'Description of the organizer',
+                        'en'
+                    ),
+                ],
+                function (Organizer $organizer) {
+                    $organizer->deleteDescription(new Language('fr'));
+                },
+                [
+                ],
+            ],
+            'Try deleting when no description available' => [
+                [
+                    $organizerCreated,
+                ],
+                function (Organizer $organizer) {
+                    $organizer->deleteDescription(new Language('fr'));
+                },
+                [
                 ],
             ],
         ];

--- a/tests/Organizer/Samples/organizer_without_description.json
+++ b/tests/Organizer/Samples/organizer_without_description.json
@@ -1,0 +1,23 @@
+{
+  "@id": "http:\/\/udb-silex.dev\/organizer\/586f596d-7e43-4ab9-b062-04db9436fca4",
+  "@context": "\/api\/1.0\/organizer.jsonld",
+  "name": {
+    "nl": "TestOrganisatie"
+  },
+  "address": {
+    "nl": {
+      "addressCountry": "BE",
+      "addressLocality": "Kessel-Lo (Leuven)",
+      "postalCode": "3010",
+      "streetAddress": "Straat"
+    }
+  },
+  "phone": [],
+  "email": [],
+  "url": [],
+  "created": "2016-09-28T10:01:28+00:00",
+  "creator": "20a72430-7e3e-4b75-ab59-043156b3169c (LucW)",
+  "languages": ["nl"],
+  "completedLanguages": ["nl"],
+  "modified": "2018-01-18T13:57:09+00:00"
+}


### PR DESCRIPTION
### Added
- Added `DeleteDescription` command
- Added `DeleteDescriptionHandler` command handler
- Added `DescriptionDeleted` event
- Added method `deleteDescription` on the `Organizer` aggregate
- Handled `DescriptionDeleted` inside the organizer JSON-LD projector
- Added `DeleteDescriptionRequestHandler` HTTP handler

### Removed
- Removed some unused properties inside the Organizer HTTP tests.

---
Note: when doing the commits I mixed up the tests for the `DeleteDescriptionHandler` and `DeleteDescriptionRequestHandler`

Ticket: https://jira.uitdatabank.be/browse/III-4500
