### PR TITLE
III-4438 Add CLI command to geocode organizers

### DIFF
--- a/app/Console/AbstractGeocodeCommand.php
+++ b/app/Console/AbstractGeocodeCommand.php
@@ -18,15 +18,9 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractGeocodeCommand extends AbstractCommand
 {
-    /**
-     * @var ResultsGeneratorInterface
-     */
-    private $searchResultsGenerator;
+    private ResultsGeneratorInterface $searchResultsGenerator;
 
-    /**
-     * @var DocumentRepository
-     */
-    private $documentRepository;
+    private DocumentRepository $documentRepository;
 
     public function __construct(
         CommandBus $commandBus,
@@ -42,14 +36,14 @@ abstract class AbstractGeocodeCommand extends AbstractCommand
         $this->documentRepository = $documentRepository;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(
                 'id',
                 null,
                 InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL,
-                'Fixed list of ids of the places to geocode.'
+                'Fixed list of ids of the items to geocode.'
             )
             ->addOption(
                 'force',

--- a/app/Console/GeocodeOrganizerCommand.php
+++ b/app/Console/GeocodeOrganizerCommand.php
@@ -58,6 +58,6 @@ class GeocodeOrganizerCommand extends AbstractGeocodeCommand
             new UpdateGeoCoordinatesFromAddress($organizerId, $address)
         );
 
-        $output->writeln("Dispatched geocode command for place {$organizerId}.");
+        $output->writeln("Dispatched geocode command for organizer {$organizerId}.");
     }
 }

--- a/app/Console/GeocodeOrganizerCommand.php
+++ b/app/Console/GeocodeOrganizerCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use CultuurNet\UDB3\Address\Address;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Organizer\Commands\UpdateGeoCoordinatesFromAddress;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GeocodeOrganizerCommand extends AbstractGeocodeCommand
+{
+    public function configure(): void
+    {
+        parent::configure();
+        $this
+            ->setName('organizer:geocode')
+            ->setDescription('Geocode organizers with missing or outdated coordinates.');
+    }
+
+    protected function getQueryForMissingCoordinates(): string
+    {
+        return 'NOT(_exists_:geo OR workflowStatus:DELETED OR workflowStatus:REJECTED)';
+    }
+
+    protected function dispatchGeocodingCommand(string $organizerId, OutputInterface $output): void
+    {
+        $document = $this->getDocument($organizerId);
+
+        if (is_null($document)) {
+            $output->writeln("Skipping {$organizerId}. (Could not find JSON-LD in local repository.)");
+            return;
+        }
+
+        $jsonLd = Json::decodeAssociatively($document->getRawBody());
+
+        $mainLanguage = $jsonLd->mainLanguage ?? 'nl';
+
+        if (!isset($jsonLd['address'])) {
+            $output->writeln("Skipping {$organizerId}. (JSON-LD does not contain an address.)");
+            return;
+        }
+
+        if (!isset($jsonLd['address'][$mainLanguage])) {
+            $output->writeln("Skipping {$organizerId}. (JSON-LD does not contain an address for {$mainLanguage}.)");
+            return;
+        }
+
+        try {
+            $address = Address::deserialize($jsonLd['address'][$mainLanguage]);
+        } catch (\Exception $e) {
+            $output->writeln("Skipping {$organizerId}. (JSON-LD address for {$mainLanguage} could not be parsed.)");
+            return;
+        }
+
+        $this->commandBus->dispatch(
+            new UpdateGeoCoordinatesFromAddress($organizerId, $address)
+        );
+
+        $output->writeln("Dispatched geocode command for place {$organizerId}.");
+    }
+}

--- a/app/Search/Sapi3SearchServiceProvider.php
+++ b/app/Search/Sapi3SearchServiceProvider.php
@@ -52,6 +52,17 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
                 );
             }
         );
+
+        $app[self::SEARCH_SERVICE_ORGANIZERS] = $app->share(
+            function ($app) {
+                return new Sapi3SearchService(
+                    new Uri($app['config']['search']['v3']['base_url'] . '/organizers/'),
+                    new Client(new \GuzzleHttp\Client()),
+                    new ItemIdentifierFactory($app['config']['item_url_regex']),
+                    $app['config']['export']['search']['api_key'] ?? null
+                );
+            }
+        );
     }
 
     public function boot(Application $app)

--- a/app/Search/Sapi3SearchServiceProvider.php
+++ b/app/Search/Sapi3SearchServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Search;
 
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifierFactory;
 use CultuurNet\UDB3\Search\Sapi3SearchService;
 use GuzzleHttp\Psr7\Uri;
 use Http\Adapter\Guzzle6\Client;
@@ -15,6 +16,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
     public const SEARCH_SERVICE_OFFERS = 'sapi3_search_service_offers';
     public const SEARCH_SERVICE_EVENTS = 'sapi3_search_service_events';
     public const SEARCH_SERVICE_PLACES = 'sapi3_search_service_places';
+    public const SEARCH_SERVICE_ORGANIZERS = 'sapi3_search_service_organizers';
 
     public function register(Application $app)
     {
@@ -23,7 +25,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
                 return new Sapi3SearchService(
                     new Uri($app['config']['search']['v3']['base_url'] . '/offers/'),
                     new Client(new \GuzzleHttp\Client()),
-                    $app['iri_offer_identifier_factory'],
+                    new ItemIdentifierFactory($app['config']['item_url_regex']),
                     $app['config']['export']['search']['api_key'] ?? null
                 );
             }
@@ -34,7 +36,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
                 return new Sapi3SearchService(
                     new Uri($app['config']['search']['v3']['base_url'] . '/events/'),
                     new Client(new \GuzzleHttp\Client()),
-                    $app['iri_offer_identifier_factory'],
+                    new ItemIdentifierFactory($app['config']['item_url_regex']),
                     $app['config']['export']['search']['api_key'] ?? null
                 );
             }
@@ -45,7 +47,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
                 return new Sapi3SearchService(
                     new Uri($app['config']['search']['v3']['base_url'] . '/places/'),
                     new Client(new \GuzzleHttp\Client()),
-                    $app['iri_offer_identifier_factory'],
+                    new ItemIdentifierFactory($app['config']['item_url_regex']),
                     $app['config']['export']['search']['api_key'] ?? null
                 );
             }

--- a/app/Search/Sapi3SearchServiceProvider.php
+++ b/app/Search/Sapi3SearchServiceProvider.php
@@ -18,7 +18,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
     public const SEARCH_SERVICE_PLACES = 'sapi3_search_service_places';
     public const SEARCH_SERVICE_ORGANIZERS = 'sapi3_search_service_organizers';
 
-    public function register(Application $app)
+    public function register(Application $app): void
     {
         $app[self::SEARCH_SERVICE_OFFERS] = $app->share(
             function ($app) {
@@ -65,7 +65,7 @@ class Sapi3SearchServiceProvider implements ServiceProviderInterface
         );
     }
 
-    public function boot(Application $app)
+    public function boot(Application $app): void
     {
     }
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -15,6 +15,7 @@ use CultuurNet\UDB3\Silex\Console\EventAncestorsCommand;
 use CultuurNet\UDB3\Silex\Console\FireProjectedToJSONLDCommand;
 use CultuurNet\UDB3\Silex\Console\FireProjectedToJSONLDForRelationsCommand;
 use CultuurNet\UDB3\Silex\Console\GeocodeEventCommand;
+use CultuurNet\UDB3\Silex\Console\GeocodeOrganizerCommand;
 use CultuurNet\UDB3\Silex\Console\GeocodePlaceCommand;
 use CultuurNet\UDB3\Silex\Console\ImportOfferAutoClassificationLabels;
 use CultuurNet\UDB3\Silex\Console\ImportEventCdbXmlCommand;
@@ -96,6 +97,7 @@ $consoleApp->add(new EventAncestorsCommand($app['event_command_bus'], $app['even
 $consoleApp->add(new PurgeModelCommand($app['dbal_connection']));
 $consoleApp->add(new GeocodePlaceCommand($app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_PLACES], $app['place_jsonld_repository']));
 $consoleApp->add(new GeocodeEventCommand($app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_EVENTS], $app['event_jsonld_repository']));
+$consoleApp->add(new GeocodeOrganizerCommand($app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_ORGANIZERS], $app['organizer_jsonld_repository']));
 $consoleApp->add(new FireProjectedToJSONLDForRelationsCommand($app['event_bus'], $app['dbal_connection'], $app[OrganizerJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY], $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY]));
 $consoleApp->add(new FireProjectedToJSONLDCommand($app['event_bus'], $app[OrganizerJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY], $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY]));
 $consoleApp->add(new ImportEventCdbXmlCommand($app['event_command_bus'], $app['event_bus'], $app['system_user_id']));

--- a/src/EventExport/EventExportService.php
+++ b/src/EventExport/EventExportService.php
@@ -20,49 +20,23 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use ValueObjects\Web\EmailAddress;
 
-class EventExportService implements EventExportServiceInterface
+final class EventExportService implements EventExportServiceInterface
 {
-    /**
-     * @var EventServiceInterface
-     */
-    protected $eventService;
+    private EventServiceInterface $eventService;
 
-    /**
-     * @var SearchServiceInterface
-     */
-    protected $searchService;
+    private SearchServiceInterface $searchService;
 
-    /**
-     * @var UuidGeneratorInterface
-     */
-    protected $uuidGenerator;
+    private UuidGeneratorInterface $uuidGenerator;
 
-    /**
-     * Publicly accessible directory where exports will be stored.
-     *
-     * @var string
-     */
-    protected $publicDirectory;
+    private string $publicDirectory;
 
-    /**
-     * @var NotificationMailerInterface
-     */
-    protected $mailer;
+    private NotificationMailerInterface $mailer;
 
-    /**
-     * @var IriGeneratorInterface
-     */
-    protected $iriGenerator;
+    private IriGeneratorInterface $iriGenerator;
 
-    /**
-     * @var ResultsGeneratorInterface
-     */
-    protected $resultsGenerator;
+    private ResultsGeneratorInterface $resultsGenerator;
 
-    /**
-     * @var int
-     */
-    private $maxAmountOfItems;
+    private int $maxAmountOfItems;
 
     public function __construct(
         EventServiceInterface $eventService,
@@ -84,6 +58,9 @@ class EventExportService implements EventExportServiceInterface
         $this->maxAmountOfItems = $maxAmountOfItems;
     }
 
+    /**
+     * @return bool|string
+     */
     public function exportEvents(
         FileFormatInterface $fileFormat,
         EventExportQuery $query,
@@ -118,11 +95,7 @@ class EventExportService implements EventExportServiceInterface
         } else {
             // do a pre query to test if the query is valid and check the item count
             try {
-                $preQueryResult = $this->searchService->search(
-                    (string) $query,
-                    1,
-                    0
-                );
+                $preQueryResult = $this->searchService->search((string) $query, 1);
                 $totalItemCount = $preQueryResult->getTotalItems();
             } catch (Exception $e) {
                 $logger->error(
@@ -275,10 +248,7 @@ class EventExportService implements EventExportServiceInterface
         return $this->publicDirectory . '/' . $finalFileName;
     }
 
-    /**
-     * @param string $url
-     */
-    private function notifyByMail(EmailAddress $address, $url): void
+    private function notifyByMail(EmailAddress $address, string $url): void
     {
         $this->mailer->sendNotificationMail(
             $address,

--- a/src/EventExport/EventExportService.php
+++ b/src/EventExport/EventExportService.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\EventExport;
 
 use Broadway\UuidGenerator\UuidGeneratorInterface;
-use CultuurNet\UDB3\EventExport\Exception\MaximumNumberOfExportItemsExceeded;
-use CultuurNet\UDB3\EventExport\Notification\NotificationMailerInterface;
 use CultuurNet\UDB3\Event\EventNotFoundException;
 use CultuurNet\UDB3\Event\EventServiceInterface;
+use CultuurNet\UDB3\EventExport\Exception\MaximumNumberOfExportItemsExceeded;
+use CultuurNet\UDB3\EventExport\Notification\NotificationMailerInterface;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use CultuurNet\UDB3\Search\SearchServiceInterface;
 use Generator;
@@ -252,7 +253,8 @@ class EventExportService implements EventExportServiceInterface
 
         $count = 0;
         foreach ($events as $eventIdentifier) {
-            $event = $this->getEventAsJSONLD((string) $eventIdentifier->getIri(), $logger);
+            /** @var ItemIdentifier $eventIdentifier */
+            $event = $this->getEventAsJSONLD($eventIdentifier->getUrl()->toString(), $logger);
 
             if ($event) {
                 $count++;

--- a/src/EventExport/EventExportService.php
+++ b/src/EventExport/EventExportService.php
@@ -122,7 +122,7 @@ class EventExportService implements EventExportServiceInterface
                     1,
                     0
                 );
-                $totalItemCount = $preQueryResult->getTotalItems()->toNative();
+                $totalItemCount = $preQueryResult->getTotalItems();
             } catch (Exception $e) {
                 $logger->error(
                     'not_exported',

--- a/src/Model/ValueObject/Identity/ItemIdentifier.php
+++ b/src/Model/ValueObject/Identity/ItemIdentifier.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+
+final class ItemIdentifier
+{
+    private Url $url;
+
+    private string $id;
+
+    private ItemType $itemType;
+
+    public function __construct(Url $url, string $id, ItemType $itemType)
+    {
+        $this->url = $url;
+        $this->id = $id;
+        $this->itemType = $itemType;
+    }
+
+    public function getUrl(): Url
+    {
+        return $this->url;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getItemType(): ItemType
+    {
+        return $this->itemType;
+    }
+}

--- a/src/Model/ValueObject/Identity/ItemIdentifierFactory.php
+++ b/src/Model/ValueObject/Identity/ItemIdentifierFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use InvalidArgumentException;
+
+final class ItemIdentifierFactory
+{
+    private string $regex;
+
+    public function __construct(string $regex)
+    {
+        $this->regex = '@^' . $regex . '$@';
+    }
+
+    public function fromUrl(Url $url): ItemIdentifier
+    {
+        preg_match(
+            $this->regex,
+            $url->toString(),
+            $matches
+        );
+
+        if (count($matches) === 0) {
+            throw new InvalidArgumentException(
+                'The given URL does not match the pattern for an event, place or organizer.'
+            );
+        }
+
+        if (!array_key_exists('itemType', $matches)) {
+            throw new InvalidArgumentException(
+                'Regular expression pattern should capture group named "itemType"'
+            );
+        }
+
+        if (!array_key_exists('itemId', $matches)) {
+            throw new InvalidArgumentException(
+                'Regular expression pattern should capture group named "itemId"'
+            );
+        }
+
+        return new ItemIdentifier(
+            $url,
+            $matches['itemId'],
+            new ItemType($matches['itemType'])
+        );
+    }
+}

--- a/src/Model/ValueObject/Identity/ItemIdentifiers.php
+++ b/src/Model/ValueObject/Identity/ItemIdentifiers.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Collection\Collection;
+
+final class ItemIdentifiers extends Collection
+{
+    public function __construct(ItemIdentifier ...$itemIdentifiers)
+    {
+        parent::__construct(...$itemIdentifiers);
+    }
+}

--- a/src/Model/ValueObject/Identity/ItemType.php
+++ b/src/Model/ValueObject/Identity/ItemType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\String\Enum;
+
+/**
+ * @method static ItemType event()
+ * @method static ItemType place()
+ * @method static ItemType organizer()
+ */
+final class ItemType extends Enum
+{
+    public static function getAllowedValues(): array
+    {
+        return [
+            'event',
+            'place',
+            'organizer',
+        ];
+    }
+}

--- a/src/Search/Results.php
+++ b/src/Search/Results.php
@@ -6,15 +6,14 @@ namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use ValueObjects\Number\Integer as IntegerLiteral;
 
 class Results
 {
     private OfferIdentifierCollection $items;
 
-    private IntegerLiteral $totalItems;
+    private int $totalItems;
 
-    public function __construct(OfferIdentifierCollection $items, IntegerLiteral $totalItems)
+    public function __construct(OfferIdentifierCollection $items, int $totalItems)
     {
         $this->items = $items;
         $this->totalItems = $totalItems;
@@ -28,7 +27,7 @@ class Results
         return $this->items->toArray();
     }
 
-    public function getTotalItems(): IntegerLiteral
+    public function getTotalItems(): int
     {
         return $this->totalItems;
     }

--- a/src/Search/Results.php
+++ b/src/Search/Results.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
 
 class Results
 {
-    private OfferIdentifierCollection $items;
+    private ItemIdentifiers $items;
 
     private int $totalItems;
 
-    public function __construct(OfferIdentifierCollection $items, int $totalItems)
+    public function __construct(ItemIdentifiers $items, int $totalItems)
     {
         $this->items = $items;
         $this->totalItems = $totalItems;
     }
 
     /**
-     * @return IriOfferIdentifier[]
+     * @return ItemIdentifier[]
      */
     public function getItems(): array
     {

--- a/src/Search/Results.php
+++ b/src/Search/Results.php
@@ -10,15 +10,9 @@ use ValueObjects\Number\Integer as IntegerLiteral;
 
 class Results
 {
-    /**
-     * @var OfferIdentifierCollection
-     */
-    private $items;
+    private OfferIdentifierCollection $items;
 
-    /**
-     * @var IntegerLiteral
-     */
-    private $totalItems;
+    private IntegerLiteral $totalItems;
 
     public function __construct(OfferIdentifierCollection $items, IntegerLiteral $totalItems)
     {

--- a/src/Search/ResultsGenerator.php
+++ b/src/Search/ResultsGenerator.php
@@ -14,28 +14,18 @@ class ResultsGenerator implements LoggerAwareInterface, ResultsGeneratorInterfac
     use LoggerAwareTrait;
 
     /**
-     * Default sorting method because it's ideal for getting consistent paging
-     * results.
+     * Default sorting method because it's ideal for getting consistent paging results.
      */
     private const SORT_CREATED_ASC = ['created' => 'asc'];
 
     private const COUNT_PAGE_LIMIT = 1;
     private const COUNT_PAGE_START = 0;
 
-    /**
-     * @var SearchServiceInterface
-     */
-    private $searchService;
+    private SearchServiceInterface $searchService;
 
-    /**
-     * @var array
-     */
-    private $sorting;
+    private ?array $sorting;
 
-    /**
-     * @var int
-     */
-    private $pageSize;
+    private int $pageSize;
 
     public function __construct(
         SearchServiceInterface $searchService,

--- a/src/Search/ResultsGenerator.php
+++ b/src/Search/ResultsGenerator.php
@@ -74,8 +74,7 @@ class ResultsGenerator implements LoggerAwareInterface, ResultsGeneratorInterfac
     {
         return $this->searchService
             ->search($query, self::COUNT_PAGE_LIMIT, self::COUNT_PAGE_START)
-            ->getTotalItems()
-            ->toNative();
+            ->getTotalItems();
     }
 
     public function search(string $query): Generator
@@ -95,7 +94,7 @@ class ResultsGenerator implements LoggerAwareInterface, ResultsGeneratorInterfac
                 $this->sorting
             );
 
-            $total = $results->getTotalItems()->toNative();
+            $total = $results->getTotalItems();
 
             $this->logger->info('Search API reported ' . $total . ' results');
 

--- a/src/Search/Sapi3SearchService.php
+++ b/src/Search/Sapi3SearchService.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use ValueObjects\Number\Integer;
 use ValueObjects\Web\Url;
 use function http_build_query;
 
@@ -91,6 +90,6 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
             new OfferIdentifierCollection()
         );
 
-        return new Results($offerIds, new Integer($searchResponseData->{'totalItems'}));
+        return new Results($offerIds, (int) $searchResponseData->{'totalItems'});
     }
 }

--- a/src/Search/Sapi3SearchService.php
+++ b/src/Search/Sapi3SearchService.php
@@ -42,7 +42,7 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
-    public function search(string $query, $limit = 30, $start = 0, array $sort = null): Results
+    public function search(string $query, int $limit = 30, int $start = 0, ?array $sort = null): Results
     {
         $queryParameters = [
             'q' => $query,

--- a/src/Search/Sapi3SearchService.php
+++ b/src/Search/Sapi3SearchService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use GuzzleHttp\Psr7\Request;
@@ -20,26 +21,13 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    /**
-     * @var UriInterface
-     */
-    private $searchLocation;
+    private UriInterface $searchLocation;
 
-    /**
-     * @var HttpClient
-     */
-    private $httpClient;
+    private HttpClient $httpClient;
 
-    /**
-     * @var IriOfferIdentifierFactoryInterface
-     */
-    private $offerIdentifier;
+    private IriOfferIdentifierFactoryInterface $offerIdentifier;
 
-    /**
-     * @var string|null
-     */
-    private $apiKey;
-
+    private ?string $apiKey;
 
     public function __construct(
         UriInterface $searchLocation,
@@ -54,7 +42,7 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
-    public function search(string $query, $limit = 30, $start = 0, array $sort = null)
+    public function search(string $query, $limit = 30, $start = 0, array $sort = null): Results
     {
         $queryParameters = [
             'q' => $query,
@@ -88,10 +76,10 @@ class Sapi3SearchService implements SearchServiceInterface, LoggerAwareInterface
             ->getBody()
             ->getContents();
 
-        $this->logger->debug('Sent SAPI3 request with the following parameters: ' . json_encode($queryParameters));
+        $this->logger->debug('Sent SAPI3 request with the following parameters: ' . Json::encode($queryParameters));
         $this->logger->debug('Response data: ' . $searchResponseData);
 
-        $searchResponseData = json_decode($searchResponseData);
+        $searchResponseData = Json::decode($searchResponseData);
 
         $offerIds = array_reduce(
             $searchResponseData->{'member'},

--- a/src/Search/SearchServiceInterface.php
+++ b/src/Search/SearchServiceInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-/**
- * Interface for a service responsible for search-related tasks.
- */
 interface SearchServiceInterface
 {
     /**
@@ -18,10 +15,8 @@ interface SearchServiceInterface
      *   How many items to retrieve.
      * @param int $start
      *   Offset to start from.
-     * @param array $sort
+     * @param ?array $sort
      *   Sort by fields. Eg. ['created' => 'asc']
-     *
-     * @return Results
      */
-    public function search(string $query, $limit = 30, $start = 0, array $sort = null);
+    public function search(string $query, int $limit = 30, int $start = 0, ?array $sort = null): Results;
 }

--- a/tests/EventExport/EventExportServiceTest.php
+++ b/tests/EventExport/EventExportServiceTest.php
@@ -23,7 +23,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Traversable;
-use ValueObjects\Number\Integer;
 use ValueObjects\Web\EmailAddress;
 use ValueObjects\Web\Url;
 
@@ -142,19 +141,19 @@ class EventExportServiceTest extends TestCase
                     OfferIdentifierCollection::fromArray(
                         array_slice($this->searchResults, 0, 1)
                     ),
-                    new Integer(self::AMOUNT)
+                    self::AMOUNT
                 ),
                 new Results(
                     OfferIdentifierCollection::fromArray(
                         array_slice($this->searchResults, 0, 10)
                     ),
-                    new Integer(self::AMOUNT)
+                    self::AMOUNT
                 ),
                 new Results(
                     OfferIdentifierCollection::fromArray(
                         array_slice($this->searchResults, 10)
                     ),
-                    new Integer(self::AMOUNT)
+                    self::AMOUNT
                 )
             );
     }

--- a/tests/Model/ValueObject/Identity/ItemIdentifierFactoryTest.php
+++ b/tests/Model/ValueObject/Identity/ItemIdentifierFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use PHPUnit\Framework\TestCase;
+
+final class ItemIdentifierFactoryTest extends TestCase
+{
+    private ItemIdentifierFactory $itemIdentifierFactory;
+
+    protected function setUp(): void
+    {
+        $this->itemIdentifierFactory = new ItemIdentifierFactory(
+            'https://io\.uitdatabank\.dev/(?<itemType>[event|place|organizer]+)s?/(?<itemId>[a-zA-Z0-9\-]+)'
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider itemIdentifierDataProvider
+     */
+    public function it_generates_item_identifier_from_a_url(Url $url, ItemIdentifier $itemIdentifier): void
+    {
+        $this->assertEquals(
+            $itemIdentifier,
+            $this->itemIdentifierFactory->fromUrl($url)
+        );
+    }
+
+    public function itemIdentifierDataProvider(): array
+    {
+        return [
+            'An event with event path' => [
+                new Url('https://io.uitdatabank.dev/event/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/event/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::event()
+                ),
+            ],
+            'An event with plural path' => [
+                new Url('https://io.uitdatabank.dev/events/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/events/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::event()
+                ),
+            ],
+            'A place' => [
+                new Url('https://io.uitdatabank.dev/place/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/place/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::place()
+                ),
+            ],
+            'A place with plural path' => [
+                new Url('https://io.uitdatabank.dev/places/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/places/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::place()
+                ),
+            ],
+            'An organizer' => [
+                new Url('https://io.uitdatabank.dev/organizer/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/organizer/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::organizer()
+                ),
+            ],
+            'An organizer with plural path' => [
+                new Url('https://io.uitdatabank.dev/organizer/3c3f714f-4695-4237-87c5-780d0e599267'),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/organizer/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::organizer()
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/Model/ValueObject/Identity/ItemIdentifierTest.php
+++ b/tests/Model/ValueObject/Identity/ItemIdentifierTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use PHPUnit\Framework\TestCase;
+
+final class ItemIdentifierTest extends TestCase
+{
+    private ItemIdentifier $itemIdentifier;
+
+    protected function setUp(): void
+    {
+        $this->itemIdentifier = new ItemIdentifier(
+            new Url('https://io.uitdatabank.dev/organizers/8ebb29b4-e1b9-44f1-b8f0-0f170903720b'),
+            '8ebb29b4-e1b9-44f1-b8f0-0f170903720b',
+            ItemType::organizer()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_url(): void
+    {
+        $this->assertEquals(
+            new Url('https://io.uitdatabank.dev/organizers/8ebb29b4-e1b9-44f1-b8f0-0f170903720b'),
+            $this->itemIdentifier->getUrl()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_id(): void
+    {
+        $this->assertEquals(
+            '8ebb29b4-e1b9-44f1-b8f0-0f170903720b',
+            $this->itemIdentifier->getId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_item_type(): void
+    {
+        $this->assertEquals(
+            ItemType::organizer(),
+            $this->itemIdentifier->getItemType()
+        );
+    }
+}

--- a/tests/Model/ValueObject/Identity/ItemIdentifiersTest.php
+++ b/tests/Model/ValueObject/Identity/ItemIdentifiersTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Model\ValueObject\Identity;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
+use PHPUnit\Framework\TestCase;
+
+final class ItemIdentifiersTest extends TestCase
+{
+
+}

--- a/tests/Model/ValueObject/Identity/ItemIdentifiersTest.php
+++ b/tests/Model/ValueObject/Identity/ItemIdentifiersTest.php
@@ -2,12 +2,50 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Model\ValueObject\Identity;
+namespace CultuurNet\UDB3\Model\ValueObject\Identity;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
 
 final class ItemIdentifiersTest extends TestCase
 {
+    private ItemIdentifiers $itemIdentifiers;
 
+    protected function setUp(): void
+    {
+        $this->itemIdentifiers = new ItemIdentifiers(
+            new ItemIdentifier(
+                new Url('https://io.uitdatabank.dev/events/3c3f714f-4695-4237-87c5-780d0e599267'),
+                '3c3f714f-4695-4237-87c5-780d0e599267',
+                ItemType::event()
+            ),
+            new ItemIdentifier(
+                new Url('https://io.uitdatabank.dev/organizer/4ea3d26b-2b91-4dd3-a6c9-e55b1ddb00df'),
+                '4ea3d26b-2b91-4dd3-a6c9-e55b1ddb00df',
+                ItemType::organizer()
+            ),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_list_of_item_identifiers(): void
+    {
+        $this->assertEquals(
+            [
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/events/3c3f714f-4695-4237-87c5-780d0e599267'),
+                    '3c3f714f-4695-4237-87c5-780d0e599267',
+                    ItemType::event()
+                ),
+                new ItemIdentifier(
+                    new Url('https://io.uitdatabank.dev/organizer/4ea3d26b-2b91-4dd3-a6c9-e55b1ddb00df'),
+                    '4ea3d26b-2b91-4dd3-a6c9-e55b1ddb00df',
+                    ItemType::organizer()
+                ),
+            ],
+            $this->itemIdentifiers->toArray()
+        );
+    }
 }

--- a/tests/Search/ResultsGeneratorTest.php
+++ b/tests/Search/ResultsGeneratorTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\Web\Url;
 
 class ResultsGeneratorTest extends TestCase
 {
@@ -65,14 +65,12 @@ class ResultsGeneratorTest extends TestCase
             ->with($givenQuery, 1, 0)
             ->willReturn(
                 new Results(
-                    OfferIdentifierCollection::fromArray(
-                        [
-                            new IriOfferIdentifier(
-                                Url::fromNative('http://io.uitdatabank.dev/event/0d325df2-da0a-4d4e-957f-60220c2f9baf'),
-                                '0d325df2-da0a-4d4e-957f-60220c2f9baf',
-                                OfferType::event()
-                            ),
-                        ]
+                    new ItemIdentifiers(
+                        new ItemIdentifier(
+                            new Url('http://io.uitdatabank.dev/event/0d325df2-da0a-4d4e-957f-60220c2f9baf'),
+                            '0d325df2-da0a-4d4e-957f-60220c2f9baf',
+                            ItemType::event()
+                        )
                     ),
                     $expectedCount
                 )
@@ -158,7 +156,7 @@ class ResultsGeneratorTest extends TestCase
                     $currentPage++;
 
                     return new Results(
-                        OfferIdentifierCollection::fromArray($pageResults),
+                        new ItemIdentifiers(...$pageResults),
                         $totalResults
                     );
                 }
@@ -187,46 +185,46 @@ class ResultsGeneratorTest extends TestCase
 
     public function pagedResultsDataProvider(): array
     {
-        $event1 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/1'),
+        $event1 = new ItemIdentifier(
+            new Url('http://du.de/event/1'),
             '1',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event2 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/2'),
+        $event2 = new ItemIdentifier(
+            new Url('http://du.de/event/2'),
             '2',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event3 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/3'),
+        $event3 = new ItemIdentifier(
+            new Url('http://du.de/event/3'),
             '3',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event4 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/4'),
+        $event4 = new ItemIdentifier(
+            new Url('http://du.de/event/4'),
             '4',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event5 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/5'),
+        $event5 = new ItemIdentifier(
+            new Url('http://du.de/event/5'),
             '5',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event6 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/6'),
+        $event6 = new ItemIdentifier(
+            new Url('http://du.de/event/6'),
             '6',
-            OfferType::event()
+            ItemType::event()
         );
 
-        $event7 = new IriOfferIdentifier(
-            Url::fromNative('http://du.de/event/7'),
+        $event7 = new ItemIdentifier(
+            new Url('http://du.de/event/7'),
             '7',
-            OfferType::event()
+            ItemType::event()
         );
 
         return [

--- a/tests/Search/ResultsGeneratorTest.php
+++ b/tests/Search/ResultsGeneratorTest.php
@@ -10,7 +10,6 @@ use CultuurNet\UDB3\Offer\OfferType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\Number\Integer;
 use ValueObjects\Web\Url;
 
 class ResultsGeneratorTest extends TestCase
@@ -75,7 +74,7 @@ class ResultsGeneratorTest extends TestCase
                             ),
                         ]
                     ),
-                    new Integer($expectedCount)
+                    $expectedCount
                 )
             );
 
@@ -160,7 +159,7 @@ class ResultsGeneratorTest extends TestCase
 
                     return new Results(
                         OfferIdentifierCollection::fromArray($pageResults),
-                        new Integer($totalResults)
+                        $totalResults
                     );
                 }
             );

--- a/tests/Search/ResultsGeneratorTest.php
+++ b/tests/Search/ResultsGeneratorTest.php
@@ -23,39 +23,27 @@ class ResultsGeneratorTest extends TestCase
     /**
      * @var string[]
      */
-    private $sorting;
+    private array $sorting;
 
-    /**
-     * @var int
-     */
-    private $pageSize;
-
-    /**
-     * @var ResultsGenerator
-     */
-    private $generator;
+    private ResultsGenerator $generator;
 
     /**
      * @var LoggerInterface|MockObject
      */
     private $logger;
 
-    /**
-     * @var string
-     */
-    private $query;
+    private string $query;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->searchService = $this->createMock(SearchServiceInterface::class);
 
         $this->sorting = ['created' => 'asc'];
-        $this->pageSize = 2;
 
         $this->generator = new ResultsGenerator(
             $this->searchService,
             $this->sorting,
-            $this->pageSize
+            2
         );
 
         $this->logger = $this->createMock(LoggerInterface::class);
@@ -99,7 +87,7 @@ class ResultsGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function it_has_configurable_sorting_and_page_size_with_default_values()
+    public function it_has_configurable_sorting_and_page_size_with_default_values(): void
     {
         $generator = new ResultsGenerator($this->searchService);
 
@@ -132,11 +120,11 @@ class ResultsGeneratorTest extends TestCase
      *   All expected logs in a single array.
      */
     public function it_loops_over_all_pages_and_yields_each_unique_result_while_logging_duplicates(
-        $givenPageSize,
-        $givenPages,
-        $expectedResults,
-        $expectedLogs = []
-    ) {
+        int $givenPageSize,
+        array $givenPages,
+        array $expectedResults,
+        array $expectedLogs = []
+    ): void {
         $currentPage = 0;
         $totalPages = count($givenPages);
         $totalResults = count($expectedResults);
@@ -197,10 +185,8 @@ class ResultsGeneratorTest extends TestCase
         $this->assertEquals($expectedLogs, $actualLogs);
     }
 
-    /**
-     * @return array
-     */
-    public function pagedResultsDataProvider()
+
+    public function pagedResultsDataProvider(): array
     {
         $event1 = new IriOfferIdentifier(
             Url::fromNative('http://du.de/event/1'),

--- a/tests/Search/ResultsTest.php
+++ b/tests/Search/ResultsTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
 use TypeError;
-use ValueObjects\Web\Url;
 
 class ResultsTest extends TestCase
 {
@@ -18,29 +18,27 @@ class ResultsTest extends TestCase
      */
     public function it_is_instantiated_with_result_items_and_total(): void
     {
-        $items = OfferIdentifierCollection::fromArray(
-            [
-                new IriOfferIdentifier(
-                    Url::fromNative('http://du.de/event/1'),
-                    '1',
-                    OfferType::event()
-                ),
-                new IriOfferIdentifier(
-                    Url::fromNative('http://du.de/event/2'),
-                    '2',
-                    OfferType::event()
-                ),
-                new IriOfferIdentifier(
-                    Url::fromNative('http://du.de/event/3'),
-                    '3',
-                    OfferType::event()
-                ),
-                new IriOfferIdentifier(
-                    Url::fromNative('http://du.de/event/4'),
-                    '4',
-                    OfferType::event()
-                ),
-            ]
+        $items = new ItemIdentifiers(
+            new ItemIdentifier(
+                new Url('http://du.de/event/1'),
+                '1',
+                ItemType::event()
+            ),
+            new ItemIdentifier(
+                new Url('http://du.de/event/2'),
+                '2',
+                ItemType::event()
+            ),
+            new ItemIdentifier(
+                new Url('http://du.de/event/3'),
+                '3',
+                ItemType::event()
+            ),
+            new ItemIdentifier(
+                new Url('http://du.de/event/4'),
+                '4',
+                ItemType::event()
+            )
         );
         $totalItems = 20;
 
@@ -67,10 +65,8 @@ class ResultsTest extends TestCase
         $this->expectException(TypeError::class);
 
         new Results(
-            OfferIdentifierCollection::fromArray(
-                [
-                    new IriOfferIdentifier(Url::fromNative('http://du.de/event/1'), '1', OfferType::event()),
-                ]
+            new ItemIdentifiers(
+                new ItemIdentifier(new Url('http://du.de/event/1'), '1', ItemType::event()),
             ),
             'foo'
         );

--- a/tests/Search/ResultsTest.php
+++ b/tests/Search/ResultsTest.php
@@ -17,7 +17,7 @@ class ResultsTest extends TestCase
     /**
      * @test
      */
-    public function it_is_instantiated_with_result_items_and_total()
+    public function it_is_instantiated_with_result_items_and_total(): void
     {
         $items = OfferIdentifierCollection::fromArray(
             [
@@ -54,7 +54,7 @@ class ResultsTest extends TestCase
     /**
      * @test
      */
-    public function it_only_accepts_an_items_array()
+    public function it_only_accepts_an_items_array(): void
     {
         $this->expectException(TypeError::class);
         new Results('foo', new Integer(5));
@@ -63,7 +63,7 @@ class ResultsTest extends TestCase
     /**
      * @test
      */
-    public function it_only_accepts_a_total_items_integer()
+    public function it_only_accepts_a_total_items_integer(): void
     {
         $this->expectException(TypeError::class);
 

--- a/tests/Search/ResultsTest.php
+++ b/tests/Search/ResultsTest.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\Offer\OfferType;
 use PHPUnit\Framework\TestCase;
 use TypeError;
-use ValueObjects\Number\Integer;
 use ValueObjects\Web\Url;
 
 class ResultsTest extends TestCase
@@ -43,7 +42,7 @@ class ResultsTest extends TestCase
                 ),
             ]
         );
-        $totalItems = new Integer(20);
+        $totalItems = 20;
 
         $results = new Results($items, $totalItems);
 
@@ -57,7 +56,7 @@ class ResultsTest extends TestCase
     public function it_only_accepts_an_items_array(): void
     {
         $this->expectException(TypeError::class);
-        new Results('foo', new Integer(5));
+        new Results('foo', 5);
     }
 
     /**

--- a/tests/Search/Sapi3SearchServiceTest.php
+++ b/tests/Search/Sapi3SearchServiceTest.php
@@ -15,7 +15,6 @@ use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
-use ValueObjects\Number\Integer;
 use ValueObjects\Web\Url;
 
 class Sapi3SearchServiceTest extends TestCase
@@ -71,7 +70,7 @@ class Sapi3SearchServiceTest extends TestCase
                     OfferType::event()
                 ),
             ]),
-            Integer::fromNative(2)
+            2
         );
 
         $results = $this->searchService->search('foo:bar');

--- a/tests/Search/Sapi3SearchServiceTest.php
+++ b/tests/Search/Sapi3SearchServiceTest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Search;
 
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use CultuurNet\UDB3\Offer\IriOfferIdentifierFactory;
-use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifierFactory;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifiers;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
-use ValueObjects\Web\Url;
 
 class Sapi3SearchServiceTest extends TestCase
 {
@@ -33,10 +33,10 @@ class Sapi3SearchServiceTest extends TestCase
         $this->httpClient = $this->createMock(HttpClient::class);
         $this->searchLocation =  new Uri('http://udb-search.dev/offers/');
 
-        $offerIdentifier = new IriOfferIdentifierFactory(
-            'https?://udb-silex\.dev/(?<offertype>[event|place]+)/(?<offerid>[a-zA-Z0-9\-]+)'
+        $itemIdentifierFactory = new ItemIdentifierFactory(
+            'https?://udb-silex\.dev/(?<itemType>[event|place]+)/(?<itemId>[a-zA-Z0-9\-]+)'
         );
-        $this->searchService = new Sapi3SearchService($this->searchLocation, $this->httpClient, $offerIdentifier);
+        $this->searchService = new Sapi3SearchService($this->searchLocation, $this->httpClient, $itemIdentifierFactory);
     }
 
     /**
@@ -58,18 +58,18 @@ class Sapi3SearchServiceTest extends TestCase
             ->willReturn($searchResponse);
 
         $expectedResults = new Results(
-            OfferIdentifierCollection::fromArray([
-                new IriOfferIdentifier(
-                    Url::fromNative('http://udb-silex.dev/place/c90bc8d5-11c5-4ae3-9bf9-cce0969fdc56'),
+            new ItemIdentifiers(
+                new ItemIdentifier(
+                    new Url('http://udb-silex.dev/place/c90bc8d5-11c5-4ae3-9bf9-cce0969fdc56'),
                     'c90bc8d5-11c5-4ae3-9bf9-cce0969fdc56',
-                    OfferType::place()
+                    ItemType::place()
                 ),
-                new IriOfferIdentifier(
-                    Url::fromNative('http://udb-silex.dev/event/c54b1323-0928-402f-9419-16d7acd44d36'),
+                new ItemIdentifier(
+                    new Url('http://udb-silex.dev/event/c54b1323-0928-402f-9419-16d7acd44d36'),
                     'c54b1323-0928-402f-9419-16d7acd44d36',
-                    OfferType::event()
-                ),
-            ]),
+                    ItemType::event()
+                )
+            ),
             2
         );
 

--- a/tests/Search/Sapi3SearchServiceTest.php
+++ b/tests/Search/Sapi3SearchServiceTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Search;
 
 use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactory;
-use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\Offer\OfferType;
 use GuzzleHttp\Psr7\Request;
@@ -26,35 +25,25 @@ class Sapi3SearchServiceTest extends TestCase
      */
     private $httpClient;
 
-    /**
-     * @var IriOfferIdentifierFactoryInterface
-     */
-    private $offerIdentifier;
+    private Sapi3SearchService $searchService;
 
-    /**
-     * @var Sapi3SearchService
-     */
-    private $searchService;
+    private UriInterface $searchLocation;
 
-    /**
-     * @var UriInterface
-     */
-    private $searchLocation;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->httpClient = $this->createMock(HttpClient::class);
-        $this->offerIdentifier = new IriOfferIdentifierFactory(
+        $this->searchLocation =  new Uri('http://udb-search.dev/offers/');
+
+        $offerIdentifier = new IriOfferIdentifierFactory(
             'https?://udb-silex\.dev/(?<offertype>[event|place]+)/(?<offerid>[a-zA-Z0-9\-]+)'
         );
-        $this->searchLocation =  new Uri('http://udb-search.dev/offers/');
-        $this->searchService = new Sapi3SearchService($this->searchLocation, $this->httpClient, $this->offerIdentifier);
+        $this->searchService = new Sapi3SearchService($this->searchLocation, $this->httpClient, $offerIdentifier);
     }
 
     /**
      * @test
      */
-    public function it_should_fetch_search_results_from_sapi_3()
+    public function it_should_fetch_search_results_from_sapi_3(): void
     {
         $searchResponse = new Response(200, [], file_get_contents(__DIR__ . '/samples/search-response.json'));
 
@@ -93,7 +82,7 @@ class Sapi3SearchServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_should_properly_encode_plus_signs_in_queries()
+    public function it_should_properly_encode_plus_signs_in_queries(): void
     {
         $searchResponse = new Response(200, [], file_get_contents(__DIR__ . '/samples/search-response.json'));
 


### PR DESCRIPTION
### Added
- Added `ItemIdentifier` and `ItemType` to identify either an event, place or organizer
- Added `ItemIdentifierFactory` to easily create a `ItemIdentifier` from a `Url
- Added `ItemIdentifiers` which stores a list of `ItemIdentifier`
- Added `GeocodeOrganizerCommand` to trigger geocode commands for organizers

### Changed
- `Sapi3SearchService` now works with `ItemIdentifiers` to make it possible to also search for organizers
- Boy scouting on `Sapi3Search` related classes
- Boy scouting on `EventExportService`
- Remove dependency on `ValueObjects` for `Sapi3Search` related classes

---
Ticket: https://jira.uitdatabank.be/browse/III-4438
