### PR TITLE
III-4516 Add copied event to same production as original event

### DIFF
--- a/app/Event/EventCommandHandlerProvider.php
+++ b/app/Event/EventCommandHandlerProvider.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Event\CommandHandlers\RemoveThemeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAudienceHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateSubEventsHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateThemeHandler;
+use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -33,7 +34,10 @@ final class EventCommandHandlerProvider implements ServiceProviderInterface
         );
 
         $app[CopyEventHandler::class] = $app->share(
-            fn (Application $application) => new CopyEventHandler($app['event_repository'])
+            fn (Application $application) => new CopyEventHandler(
+                $app['event_repository'],
+                $app[ProductionRepository::class]
+            )
         );
     }
 

--- a/tests/Event/CommandHandlers/CopyEventHandlerTest.php
+++ b/tests/Event/CommandHandlers/CopyEventHandlerTest.php
@@ -7,11 +7,15 @@ namespace CultuurNet\UDB3\Event\CommandHandlers;
 use Broadway\Domain\DomainMessage;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Commands\CopyEvent;
 use CultuurNet\UDB3\Event\Event;
 use CultuurNet\UDB3\Event\EventRepository;
 use CultuurNet\UDB3\Event\Events\EventCopied;
 use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Event\Productions\Production;
+use CultuurNet\UDB3\Event\Productions\ProductionId;
+use CultuurNet\UDB3\Event\Productions\ProductionRepository;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -25,12 +29,14 @@ use PHPUnit\Framework\TestCase;
 class CopyEventHandlerTest extends TestCase
 {
     private MockObject $eventRepository;
+    private MockObject $productionRepository;
     private CopyEventHandler $copyEventHandler;
 
     protected function setUp(): void
     {
         $this->eventRepository = $this->createMock(EventRepository::class);
-        $this->copyEventHandler = new CopyEventHandler($this->eventRepository);
+        $this->productionRepository = $this->createMock(ProductionRepository::class);
+        $this->copyEventHandler = new CopyEventHandler($this->eventRepository, $this->productionRepository);
     }
 
     /**
@@ -87,6 +93,89 @@ class CopyEventHandlerTest extends TestCase
                     );
                 }
             );
+
+        $this->productionRepository->expects($this->once())
+            ->method('findProductionForEventId')
+            ->with($originalEventId)
+            ->willThrowException(new EntityNotFoundException('No production found for given event id'));
+
+        $this->productionRepository->expects($this->never())
+            ->method('addEvent');
+
+        $this->copyEventHandler->handle($command);
+
+        $this->assertEquals($expectedEvents, $actualEvents);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_the_new_event_to_the_same_production_as_the_original_event(): void
+    {
+        $originalEventId = '83a12220-9459-4fc8-b1ed-71b3d1668e65';
+        $newEventId = '5b9158c6-47ec-4f98-8d9e-edafc89870bc';
+        $newCalendar = new PermanentCalendar(new OpeningHours());
+
+        $command = new CopyEvent($originalEventId, $newEventId, $newCalendar);
+
+        $originalEvent = Event::create(
+            $originalEventId,
+            new Language('nl'),
+            new Title('Mock event'),
+            new EventType('0.0.0.0.1', 'Mock type'),
+            new LocationId('8aa2d316-0f5a-495d-9832-46fc22eeaa89'),
+            new Calendar(
+                CalendarType::SINGLE(),
+                null,
+                null,
+                [
+                    new Timestamp(
+                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-01T12:00:00+01:00'),
+                        DateTimeImmutable::createFromFormat(DATE_ATOM, '2022-01-02T12:00:00+01:00')
+                    ),
+                ]
+            )
+        );
+
+        // Fake a save to the event store.
+        // Otherwise there are uncommitted events on the original event, and it will refuse to copy itself.
+        $originalEvent->getUncommittedEvents();
+
+        $this->eventRepository->expects($this->once())
+            ->method('load')
+            ->with($originalEventId)
+            ->willReturn($originalEvent);
+
+        $expectedEvents = [
+            new EventCopied($newEventId, $originalEventId, Calendar::fromUdb3ModelCalendar($newCalendar)),
+        ];
+        $actualEvents = [];
+
+        $this->eventRepository->expects($this->once())
+            ->method('save')
+            ->willReturnCallback(
+                function (Event $newEvent) use (&$actualEvents): void {
+                    $actualEvents = array_map(
+                        fn (DomainMessage $domainMessage) => $domainMessage->getPayload(),
+                        $newEvent->getUncommittedEvents()->getIterator()->getArrayCopy()
+                    );
+                }
+            );
+
+        $production = new Production(
+            ProductionId::fromNative('159abe3a-bd77-4284-8623-17bae202c63b'),
+            'Mock production',
+            [$originalEventId]
+        );
+
+        $this->productionRepository->expects($this->once())
+            ->method('findProductionForEventId')
+            ->with($originalEventId)
+            ->willReturn($production);
+
+        $this->productionRepository->expects($this->once())
+            ->method('addEvent')
+            ->with($newEventId, $production);
 
         $this->copyEventHandler->handle($command);
 


### PR DESCRIPTION
### Changed

- `CopyEventHandler` now copies the production of the original event to the new event.

---
Ticket: https://jira.uitdatabank.be/browse/III-4516 
