### PR TITLE
III-4526 Update calendar in internal Event state after copy

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -209,6 +209,7 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     protected function applyEventCopied(EventCopied $eventCopied): void
     {
         $this->eventId = $eventCopied->getItemId();
+        $this->calendar = $eventCopied->getCalendar();
         $this->workflowStatus = WorkflowStatus::DRAFT();
         $this->labels = new LabelCollection();
     }


### PR DESCRIPTION
### Fixed

- Fixed calendar update issues with copied events by updating the copied event's internal calendar state to the new calendar in the copy event message.

---
Ticket: https://jira.uitdatabank.be/browse/III-4526

Note: Test added in https://github.com/cultuurnet/udb3-acceptance-tests/pull/59
