### PR TITLE
III-4528 Be more flexible in ISO-8601 date formats

### DIFF
--- a/src/BookingInfo.php
+++ b/src/BookingInfo.php
@@ -139,12 +139,12 @@ final class BookingInfo implements JsonLdSerializableInterface
 
         $availabilityStarts = null;
         if ($data['availabilityStarts']) {
-            $availabilityStarts = DateTimeImmutable::createFromFormat(\DATE_ATOM, $data['availabilityStarts']);
+            $availabilityStarts = DateTimeFactory::fromISO8601($data['availabilityStarts']);
         }
 
         $availabilityEnds = null;
         if ($data['availabilityEnds']) {
-            $availabilityEnds = DateTimeImmutable::createFromFormat(\DATE_ATOM, $data['availabilityEnds']);
+            $availabilityEnds = DateTimeFactory::fromISO8601($data['availabilityEnds']);
         }
 
         $urlLabel = null;

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use DateTimeImmutable;
+
+final class DateTimeFactory
+{
+    /**
+     * Converts ISO-8601 datetime strings to DateTimeImmutable objects.
+     * Use this as much as possible instead of doing DateTimeImmutable::createFromFormat() or new DateTimeImmutable()
+     * when converting datetime strings, to avoid common bugs and to ensure correct error handling.
+     */
+    public static function fromISO8601(string $datetime): DateTimeImmutable
+    {
+        // Don't use the ISO8601 constant, as it is in fact not compatible with ISO-8601 according to the PHP docs.
+        // See https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.iso8601
+        // The docs say to use ATOM instead, which is exactly the same as RFC3339.
+        // We also accept RFC3339_EXTENDED, which is the same but includes milliseconds, to ensure better compatibility
+        // with Javascript API clients.
+        // See https://datatracker.ietf.org/doc/html/rfc3339 for more info.
+        $acceptedFormats = [
+            DateTimeImmutable::RFC3339,
+            DateTimeImmutable::RFC3339_EXTENDED,
+        ];
+
+        foreach ($acceptedFormats as $acceptedFormat) {
+            $object = DateTimeImmutable::createFromFormat($acceptedFormat, $datetime);
+
+            // $object can be FALSE if the given $datetime was not in the accepted format.
+            // Only return it if it's actually a DateTimeImmutable, otherwise continue the loop.
+            if ($object instanceof DateTimeImmutable) {
+                return $object;
+            }
+        }
+
+        // If we have not returned a DateTimeImmutable object by now, the $datetime string is in an unsupported format.
+        // Throw a specific exception, so that it can be converted to a suitable ApiProblem higher up.
+        throw new DateTimeInvalid($datetime . ' does not appear to be a valid ISO-8601 datetime string.');
+    }
+}

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -20,10 +20,13 @@ final class DateTimeFactory
         // The docs say to use ATOM instead, which is exactly the same as RFC3339.
         // We also accept RFC3339_EXTENDED, which is the same but includes milliseconds, to ensure better compatibility
         // with Javascript API clients.
+        // We also accept "Y-m-d\TH:i:s.uP" which is the same as RFC3339_EXTENDED but with microseconds instead of
+        // milliseconds ("u" instead of "v"). Because the RFC3339 docs do not specify the amount of possible decimals.
         // See https://datatracker.ietf.org/doc/html/rfc3339 for more info.
         $acceptedFormats = [
             DateTimeImmutable::RFC3339,
             DateTimeImmutable::RFC3339_EXTENDED,
+            'Y-m-d\TH:i:s.uP',
         ];
 
         foreach ($acceptedFormats as $acceptedFormat) {

--- a/src/DateTimeInvalid.php
+++ b/src/DateTimeInvalid.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use InvalidArgumentException;
+
+final class DateTimeInvalid extends InvalidArgumentException
+{
+}

--- a/src/Http/Deserializer/BookingInfo/BookingInfoDataValidator.php
+++ b/src/Http/Deserializer/BookingInfo/BookingInfoDataValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Deserializer\BookingInfo;
 
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\DateTimeInvalid;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
@@ -28,17 +30,17 @@ class BookingInfoDataValidator implements DataValidatorInterface
         $availabilityFormatError = 'Invalid format. Expected ISO-8601 (eg. 2018-01-01T00:00:00+01:00).';
 
         if (isset($bookingInfo['availabilityStarts'])) {
-            $dateTime = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $bookingInfo['availabilityStarts']);
-
-            if (!$dateTime) {
+            try {
+                DateTimeFactory::fromISO8601($bookingInfo['availabilityStarts']);
+            } catch (DateTimeInvalid $e) {
                 $messages['bookingInfo.availabilityStarts'] = $availabilityFormatError;
             }
         }
 
         if (isset($bookingInfo['availabilityEnds'])) {
-            $dateTime = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $bookingInfo['availabilityEnds']);
-
-            if (!$dateTime) {
+            try {
+                DateTimeFactory::fromISO8601($bookingInfo['availabilityEnds']);
+            } catch (DateTimeInvalid $e) {
                 $messages['bookingInfo.availabilityEnds'] = $availabilityFormatError;
             }
         }

--- a/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Deserializer\BookingInfo;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
@@ -47,18 +48,12 @@ class BookingInfoJSONDeserializer extends JSONDeserializer
 
         $availabilityStarts = null;
         if (isset($bookingInfo['availabilityStarts'])) {
-            $availabilityStarts = \DateTimeImmutable::createFromFormat(
-                \DATE_ATOM,
-                $bookingInfo['availabilityStarts']
-            );
+            $availabilityStarts = DateTimeFactory::fromISO8601($bookingInfo['availabilityStarts']);
         }
 
         $availabilityEnds = null;
         if (isset($bookingInfo['availabilityEnds'])) {
-            $availabilityEnds = \DateTimeImmutable::createFromFormat(
-                \DATE_ATOM,
-                $bookingInfo['availabilityEnds']
-            );
+            $availabilityEnds = DateTimeFactory::fromISO8601($bookingInfo['availabilityEnds']);
         }
 
         $bookingInfo = new BookingInfo(

--- a/src/Http/Offer/DateRangeValidator.php
+++ b/src/Http/Offer/DateRangeValidator.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
+use CultuurNet\UDB3\DateTimeFactory;
+use CultuurNet\UDB3\DateTimeInvalid;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
-use DateTimeImmutable;
 
 class DateRangeValidator
 {
@@ -19,10 +20,11 @@ class DateRangeValidator
             return [];
         }
 
-        $startDate = DateTimeImmutable::createFromFormat(DATE_ATOM, $data->startDate);
-        $endDate = DateTimeImmutable::createFromFormat(DATE_ATOM, $data->endDate);
-        if ($startDate === false || $endDate === false) {
-            // Error(s) will be reported by the Schema validation.
+        try {
+            $startDate = DateTimeFactory::fromISO8601($data->startDate);
+            $endDate = DateTimeFactory::fromISO8601($data->endDate);
+        } catch (DateTimeInvalid $e) {
+            // Date format error(s) will be reported by the Schema validation.
             return [];
         }
 

--- a/src/Model/Serializer/Offer/OfferDenormalizer.php
+++ b/src/Model/Serializer/Offer/OfferDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\Offer;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Offer\ImmutableOffer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerIDParser;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
@@ -328,7 +329,7 @@ abstract class OfferDenormalizer implements DenormalizerInterface
     protected function denormalizeAvailableFrom(array $data, ImmutableOffer $offer): ImmutableOffer
     {
         if (isset($data['availableFrom'])) {
-            $availableFrom = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $data['availableFrom']);
+            $availableFrom = DateTimeFactory::fromISO8601($data['availableFrom']);
             $offer = $offer->withAvailableFrom($availableFrom);
         }
 

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
@@ -166,8 +167,8 @@ class CalendarDenormalizer implements DenormalizerInterface
 
     private function denormalizeDateRange(array $dateRangeData): DateRange
     {
-        $startDate = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $dateRangeData['startDate']);
-        $endDate = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $dateRangeData['endDate']);
+        $startDate = DateTimeFactory::fromISO8601($dateRangeData['startDate']);
+        $endDate = DateTimeFactory::fromISO8601($dateRangeData['endDate']);
 
         return new DateRange($startDate, $endDate);
     }

--- a/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Contact/BookingInfoDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\ValueObject\Contact;
 
+use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Web\TranslatedWebsiteLabelDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
@@ -71,12 +72,12 @@ class BookingInfoDenormalizer implements DenormalizerInterface
 
         $starts = null;
         if (isset($data['availabilityStarts'])) {
-            $starts = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $data['availabilityStarts']);
+            $starts = DateTimeFactory::fromISO8601($data['availabilityStarts']);
         }
 
         $ends = null;
         if (isset($data['availabilityEnds'])) {
-            $ends = \DateTimeImmutable::createFromFormat(\DATE_ATOM, $data['availabilityEnds']);
+            $ends = DateTimeFactory::fromISO8601($data['availabilityEnds']);
         }
 
         if ($starts || $ends) {

--- a/tests/DateTimeFactoryTest.php
+++ b/tests/DateTimeFactoryTest.php
@@ -40,6 +40,14 @@ class DateTimeFactoryTest extends TestCase
                 'given' => '2022-02-28T13:23:47.007+01:00',
                 'expectedAsRFC3339InBrussels' => '2022-02-28T13:23:47+01:00',
             ],
+            'utc_with_5μs_second_fraction' => [
+                'given' => '2022-02-28T13:23:47.000005Z',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T14:23:47+01:00',
+            ],
+            'offset_with_600μs_second_fraction' => [
+                'given' => '2022-02-28T13:23:47.000600+01:00',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T13:23:47+01:00',
+            ],
         ];
     }
 

--- a/tests/DateTimeFactoryTest.php
+++ b/tests/DateTimeFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider validISO8601DataProvider
+     */
+    public function it_creates_a_date_time_object_from_a_valid_iso_8601_string(string $given, string $expectedAsRFC3339InBrussels): void
+    {
+        $object = DateTimeFactory::fromISO8601($given)->setTimezone(new DateTimeZone('Europe/Brussels'));
+        $asRFC3339 = $object->format(DateTimeImmutable::RFC3339);
+        $this->assertEquals($expectedAsRFC3339InBrussels, $asRFC3339);
+    }
+
+    public function validISO8601DataProvider(): array
+    {
+        return [
+            'utc' => [
+                'given' => '2022-02-28T13:23:47Z',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T14:23:47+01:00',
+            ],
+            'offset' => [
+                'given' => '2022-02-28T13:23:47+01:30',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T12:53:47+01:00',
+            ],
+            'utc_with_100ms_second_fraction' => [
+                'given' => '2022-02-28T13:23:47.100Z',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T14:23:47+01:00',
+            ],
+            'offset_with_7ms_second_fraction' => [
+                'given' => '2022-02-28T13:23:47.007+01:00',
+                'expectedAsRFC3339InBrussels' => '2022-02-28T13:23:47+01:00',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidISO8601DataProvider
+     */
+    public function it_throws_when_given_an_invalid_iso_8601_string(string $invalidDateTime): void
+    {
+        $this->expectException(DateTimeInvalid::class);
+        DateTimeFactory::fromISO8601($invalidDateTime);
+    }
+
+    public function invalidISO8601DataProvider(): array
+    {
+        return [
+            'no_timezone' => ['dateTime' => '2022-02-28T13:23:47'],
+            'no_T' => ['dateTime' => '2022-02-28 13:23:47+01:30'],
+            'just_a_date' => ['dateTime' => '2022-02-28'],
+        ];
+    }
+}

--- a/tests/Http/Deserializer/BookingInfo/BookingInfoDataValidatorTest.php
+++ b/tests/Http/Deserializer/BookingInfo/BookingInfoDataValidatorTest.php
@@ -52,8 +52,8 @@ class BookingInfoDataValidatorTest extends TestCase
                 'urlLabel' => ['nl' => 'Publiq vzw'],
                 'phone' => '044/444444',
                 'email' => 'info@publiq.be',
-                'availabilityStarts' => '2018-01-01T00:00:00.234Z',
-                'availabilityEnds' => '2018-01-31T23:59:59.234Z',
+                'availabilityStarts' => '2018-01-01',
+                'availabilityEnds' => '2018-01-31',
             ],
         ];
 


### PR DESCRIPTION
### Changed

- Classes that validate / decode incoming JSON now parse datetimes in multiple possible ISO-8601 / RFC-3339 datetime formats. For example without second fractions, with milliseconds, and with microseconds. This fixes compatibility with older integrations that send use datetimes with milli/microseconds even though we never officially supported it, but because it happened to work by accident in the past.

---
Ticket: https://jira.uitdatabank.be/browse/III-4528

Note: There are more usages of `DateTime::createFromFormat()` and `DateTimeImmutable::createFromFormat()` then the ones I replaced in this PR, but I tried to change all those that handle datetime strings from "incoming" JSON. Classes/methods that decode datetime strings from e.g. the event store did not need to be replaced since we control the format those are stored in.
