### PR TITLE
III-4577 search result item identifier

### DIFF
--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -9,8 +9,8 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Event\Commands\UpdateLocation;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -61,9 +61,9 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListener, Lo
         $commands = [];
         $skipped = [];
 
-        /* @var IriOfferIdentifier $result */
+        /* @var ItemIdentifier $result */
         foreach ($results as $result) {
-            if (!$result->getType()->sameAs(OfferType::event())) {
+            if (!$result->getItemType()->sameAs(ItemType::event())) {
                 $skipped[] = $result->getId();
                 $this->logger->warning(
                     'Skipped result with id ' . $result->getId() . ' because it\'s not an event according to the @id parser.'

--- a/src/Offer/BulkLabelCommandHandler.php
+++ b/src/Offer/BulkLabelCommandHandler.php
@@ -7,6 +7,8 @@ namespace CultuurNet\UDB3\Offer;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToMultiple;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToQuery;
@@ -45,7 +47,7 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
         $query = $addLabelToQuery->getQuery();
 
         foreach ($this->resultsGenerator->search($query) as $result) {
-            /* @var IriOfferIdentifier $result */
+            /* @var ItemIdentifier $result */
             $this->label(
                 $result,
                 $label,
@@ -63,7 +65,11 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
 
         foreach ($offerIdentifiers as $offerIdentifier) {
             $this->label(
-                $offerIdentifier,
+                new ItemIdentifier(
+                    $offerIdentifier->getIri(),
+                    $offerIdentifier->getId(),
+                    new ItemType(strtolower($offerIdentifier->getType()->toString()))
+                ),
                 $label,
                 AddLabelToMultiple::class
             );
@@ -71,7 +77,7 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
     }
 
     private function label(
-        IriOfferIdentifier $offerIdentifier,
+        ItemIdentifier $offerIdentifier,
         Label $label,
         string $originalCommandName = null
     ): void {
@@ -81,7 +87,7 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
             );
         } catch (\Exception $e) {
             $logContext = [
-                'iri' => $offerIdentifier->getIri()->toString(),
+                'iri' => $offerIdentifier->getUrl()->toString(),
                 'command' => $originalCommandName,
                 'exception' => get_class($e),
                 'message' => $e->getMessage(),

--- a/tests/Event/LocationMarkedAsDuplicateProcessManagerTest.php
+++ b/tests/Event/LocationMarkedAsDuplicateProcessManagerTest.php
@@ -9,9 +9,9 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Event\Commands\UpdateLocation;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\Offer\IriOfferIdentifier;
-use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Place\Events\MarkedAsCanonical;
 use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
@@ -82,20 +82,20 @@ class LocationMarkedAsDuplicateProcessManagerTest extends TestCase
             ->willReturnCallback(
                 function () {
                     yield from [
-                        new IriOfferIdentifier(
+                        new ItemIdentifier(
                             new Url('http://www.uitdatabank.be/events/c393e98b-b33e-4948-b97a-3c48e3748398'),
                             'c393e98b-b33e-4948-b97a-3c48e3748398',
-                            OfferType::event()
+                            ItemType::event()
                         ),
-                        new IriOfferIdentifier(
+                        new ItemIdentifier(
                             new Url('http://www.uitdatabank.be/events/d8835de7-c84d-417b-a173-079401f29fde'),
                             'd8835de7-c84d-417b-a173-079401f29fde',
-                            OfferType::event()
+                            ItemType::event()
                         ),
-                        new IriOfferIdentifier(
+                        new ItemIdentifier(
                             new Url('http://www.uitdatabank.be/events/13ca4b6b-92b0-407d-b472-634dd0e654d0'),
                             '13ca4b6b-92b0-407d-b472-634dd0e654d0',
-                            OfferType::event()
+                            ItemType::event()
                         ),
                     ];
                 }

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -6,6 +6,8 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToMultiple;
@@ -48,6 +50,11 @@ class BulkLabelCommandHandlerTest extends TestCase
     private $offerIdentifiers;
 
     /**
+     * @var ItemIdentifier[]
+     */
+    private $itemIdentifiers;
+
+    /**
      * @var CommandBus|MockObject
      */
     private $commandBus;
@@ -80,6 +87,19 @@ class BulkLabelCommandHandlerTest extends TestCase
                 OfferType::place()
             ),
         ];
+
+        $this->itemIdentifiers = [
+            1 => new ItemIdentifier(
+                new Url('http://du.de/event/1'),
+                '1',
+                ItemType::event()
+            ),
+            2 => new ItemIdentifier(
+                new Url('http://du.de/place/2'),
+                '2',
+                ItemType::place()
+            ),
+        ];
     }
 
     /**
@@ -97,7 +117,7 @@ class BulkLabelCommandHandlerTest extends TestCase
             ->with($this->query)
             ->willReturnCallback(
                 function () {
-                    yield from $this->offerIdentifiers;
+                    yield from $this->itemIdentifiers;
                 }
             );
 


### PR DESCRIPTION
### Fixed
- Fixed `LocationMarkedAsDuplicateProcessManager` to work with `ItemIdentifier`
- Fixed `BulkLabelCommandHandler` to work partly with `ItemIdentifier`

Note: this is a temporary fix, the `BulkLabelCommandHandler` should also handle `AddLabelToMultiple` with `ItemIdentifier` but that command is still created with `IriOfferIdentifier`

---
Ticket: https://jira.uitdatabank.be/browse/III-4577
