### PR TITLE
III-4578 Fix PHP notice in event import with organizer

### DIFF
--- a/src/Model/Organizer/OrganizerReference.php
+++ b/src/Model/Organizer/OrganizerReference.php
@@ -10,16 +10,9 @@ class OrganizerReference
 {
     private UUID $organizerId;
 
-    private ?Organizer $embeddedOrganizer;
-
-    private function __construct(UUID $organizerId, Organizer $embeddedOrganizer = null)
+    private function __construct(UUID $organizerId)
     {
-        if ($embeddedOrganizer) {
-            $organizerId = $embeddedOrganizer->getId();
-        }
-
         $this->organizerId = $organizerId;
-        $this->embeddedOrganizer = $embeddedOrganizer;
     }
 
     public function getOrganizerId(): UUID
@@ -27,18 +20,8 @@ class OrganizerReference
         return $this->organizerId;
     }
 
-    public function getEmbeddedOrganizer(): ?Organizer
-    {
-        return $this->embeddedOrganizer;
-    }
-
     public static function createWithOrganizerId(UUID $organizerId): OrganizerReference
     {
         return new self($organizerId);
-    }
-
-    public static function createWithEmbeddedOrganizer(Organizer $organizer): OrganizerReference
-    {
-        return new self($organizer->getId(), $organizer);
     }
 }

--- a/src/Model/Serializer/Offer/OfferDenormalizer.php
+++ b/src/Model/Serializer/Offer/OfferDenormalizer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Offer\ImmutableOffer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerIDParser;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
-use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerReferenceDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Audience\AgeRangeDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar\CalendarDenormalizer;
@@ -105,10 +104,7 @@ abstract class OfferDenormalizer implements DenormalizerInterface
         }
 
         if (!$organizerReferenceDenormalizer) {
-            $organizerReferenceDenormalizer = new OrganizerReferenceDenormalizer(
-                new OrganizerIDParser(),
-                new OrganizerDenormalizer()
-            );
+            $organizerReferenceDenormalizer = new OrganizerReferenceDenormalizer(new OrganizerIDParser());
         }
 
         if (!$ageRangeDenormalizer) {

--- a/src/Model/Serializer/Organizer/OrganizerReferenceDenormalizer.php
+++ b/src/Model/Serializer/Organizer/OrganizerReferenceDenormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Serializer\Organizer;
 
-use CultuurNet\UDB3\Model\Organizer\Organizer;
 use CultuurNet\UDB3\Model\Organizer\OrganizerIDParser;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -15,14 +14,9 @@ class OrganizerReferenceDenormalizer implements DenormalizerInterface
 {
     private OrganizerIDParser $organizerIDParser;
 
-    private OrganizerDenormalizer $organizerDenormalizer;
-
-    public function __construct(
-        OrganizerIDParser $organizerIDParser,
-        OrganizerDenormalizer $organizerDenormalizer
-    ) {
+    public function __construct(OrganizerIDParser $organizerIDParser)
+    {
         $this->organizerIDParser = $organizerIDParser;
-        $this->organizerDenormalizer = $organizerDenormalizer;
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])
@@ -37,18 +31,6 @@ class OrganizerReferenceDenormalizer implements DenormalizerInterface
 
         $organizerIdUrl = new Url($data['@id']);
         $organizerId = $this->organizerIDParser->fromUrl($organizerIdUrl);
-        $organizer = null;
-        if (count($data) > 1) {
-            try {
-                $organizer = $this->organizerDenormalizer->denormalize($data, Organizer::class);
-            } catch (\Exception $e) {
-                $organizer = null;
-            }
-        }
-
-        if ($organizer) {
-            return OrganizerReference::createWithEmbeddedOrganizer($organizer);
-        }
 
         return OrganizerReference::createWithOrganizerId($organizerId);
     }

--- a/tests/Model/Organizer/OrganizerReferenceTest.php
+++ b/tests/Model/Organizer/OrganizerReferenceTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Model\Organizer;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\Text\Title;
-use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
-use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
-use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
 
 class OrganizerReferenceTest extends TestCase
@@ -22,35 +18,5 @@ class OrganizerReferenceTest extends TestCase
         $reference = OrganizerReference::createWithOrganizerId($id);
 
         $this->assertEquals($id, $reference->getOrganizerId());
-        $this->assertNull($reference->getEmbeddedOrganizer());
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_be_creatable_using_a_organizer()
-    {
-        $id = new UUID('38d78529-29b8-4635-a26e-51bbb2eba535');
-
-        $mainLanguage = new Language('nl');
-
-        $title = new TranslatedTitle(
-            $mainLanguage,
-            new Title('Publiq')
-        );
-
-        $url = new Url('http://www.publiq.be');
-
-        $organizer = new ImmutableOrganizer(
-            $id,
-            $mainLanguage,
-            $title,
-            $url
-        );
-
-        $reference = OrganizerReference::createWithEmbeddedOrganizer($organizer);
-
-        $this->assertEquals($id, $reference->getOrganizerId());
-        $this->assertEquals($organizer, $reference->getEmbeddedOrganizer());
     }
 }


### PR DESCRIPTION
### Fixed

- Fixed PHP notice when importing an event with an organizer, and the organizer contains more properties than just `@id`. (https://sentry.io/organizations/publiq-vzw/issues/3003000437/?project=5435528)

---
Ticket: https://jira.uitdatabank.be/browse/III-4578
