### PR TITLE
III-4570 Fix hidden labels null value

### DIFF
--- a/app/Error/LoggerName.php
+++ b/app/Error/LoggerName.php
@@ -45,6 +45,11 @@ final class LoggerName
         return new self('web');
     }
 
+    public static function forConfig(): self
+    {
+        return new self('config');
+    }
+
     public static function forAmqpWorker(string $workerName, ?string $suffix = null): self
     {
         $fileName = 'amqp.' . $workerName;

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -31,6 +31,8 @@ use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepositor
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\Silex\Error\LoggerFactory;
+use CultuurNet\UDB3\Silex\Error\LoggerName;
 use CultuurNet\UDB3\Term\TermRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -80,6 +82,7 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                 $repository = new CuratorEnrichedOfferRepository(
                     $repository,
                     $app[NewsArticleRepository::class],
+                    LoggerFactory::create($app, LoggerName::forConfig()),
                     $app['config']['curator_labels']
                 );
 

--- a/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
@@ -63,6 +63,10 @@ final class CuratorEnrichedOfferRepository extends DocumentRepositoryDecorator
             $hiddenLabels[] = $this->curatorLabels[$curator];
         }
 
+        // Remove any duplicate labels. Because some old articles have as publisher "UiT" or "UiTinVlaanderen", while
+        // newer ones have "UiT in Vlaanderen". Same with Vlieg labels. This can cause duplicate curator labels.
+        $hiddenLabels = array_values(array_unique($hiddenLabels));
+
         // Make sure to not add an empty list of hiddenLabels.
         if (count($hiddenLabels) > 0) {
             $json['hiddenLabels'] = $hiddenLabels;

--- a/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
@@ -52,6 +52,9 @@ final class CuratorEnrichedOfferRepository extends DocumentRepositoryDecorator
         // Apply curator labels based on the publishers of the news articles.
         // This should also solve issues with the old code where deletes or updates of news articles were not handled.
         foreach ($curators as $curator) {
+            if (!isset($this->curatorLabels[$curator])) {
+                continue;
+            }
             $hiddenLabels[] = $this->curatorLabels[$curator];
         }
 

--- a/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepository.php
@@ -10,21 +10,25 @@ use CultuurNet\UDB3\Curators\NewsArticleSearch;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use Psr\Log\LoggerInterface;
 
 final class CuratorEnrichedOfferRepository extends DocumentRepositoryDecorator
 {
     private NewsArticleRepository $newsArticleRepository;
+    private LoggerInterface $logger;
 
     private array $curatorLabels;
 
     public function __construct(
         DocumentRepository $documentRepository,
         NewsArticleRepository $newsArticleRepository,
+        LoggerInterface $logger,
         array $curatorLabels
     ) {
         parent::__construct($documentRepository);
 
         $this->newsArticleRepository = $newsArticleRepository;
+        $this->logger = $logger;
         // The keys of the curator labels has mixed casing.
         // To work around this every key and every curator get converted to lower case.
         $this->curatorLabels = array_change_key_case($curatorLabels, CASE_LOWER);
@@ -53,6 +57,7 @@ final class CuratorEnrichedOfferRepository extends DocumentRepositoryDecorator
         // This should also solve issues with the old code where deletes or updates of news articles were not handled.
         foreach ($curators as $curator) {
             if (!isset($this->curatorLabels[$curator])) {
+                $this->logger->error('Curator label for "' . $curator . '" missing in config!');
                 continue;
             }
             $hiddenLabels[] = $this->curatorLabels[$curator];

--- a/tests/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/CuratorEnrichedOfferRepositoryTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 final class CuratorEnrichedOfferRepositoryTest extends TestCase
 {
@@ -34,6 +35,7 @@ final class CuratorEnrichedOfferRepositoryTest extends TestCase
         $this->curatorEnrichedOfferRepository = new CuratorEnrichedOfferRepository(
             new InMemoryDocumentRepository(),
             $this->newsArticleRepository,
+            new NullLogger(),
             [
                 'bill' => 'jongerenredactie',
                 'bruzz' => 'BRUZZ-redactioneel',


### PR DESCRIPTION
### Fixed

- Fixed `null` being added as a `hiddenLabel` when an event has a news article with a publisher that is not in the config list of publisher and their labels. If this happens an error will be logged in Sentry, but the code will continue without unintended side-effects.

---
Ticket: https://jira.uitdatabank.be/browse/III-4570
