### PR TITLE
III-4539 Include StringLiteral

### DIFF
--- a/app/Console/ChangeOfferOwnerInBulk.php
+++ b/app/Console/ChangeOfferOwnerInBulk.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ChangeOfferOwnerInBulk extends AbstractCommand
 {

--- a/app/Console/ImportEventCdbXmlCommand.php
+++ b/app/Console/ImportEventCdbXmlCommand.php
@@ -14,7 +14,7 @@ use DateTimeImmutable;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportEventCdbXmlCommand extends AbstractCommand
 {

--- a/app/Console/ImportPlaceCdbXmlCommand.php
+++ b/app/Console/ImportPlaceCdbXmlCommand.php
@@ -14,7 +14,7 @@ use DateTimeImmutable;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportPlaceCdbXmlCommand extends AbstractCommand
 {

--- a/app/Curators/CuratorsServiceProvider.php
+++ b/app/Curators/CuratorsServiceProvider.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Silex\Error\LoggerName;
 use Ramsey\Uuid\UuidFactory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class CuratorsServiceProvider implements ServiceProviderInterface
 {

--- a/app/Event/EventPermissionServiceProvider.php
+++ b/app/Event/EventPermissionServiceProvider.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Event\ReadModel\Permission\Projector;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventPermissionServiceProvider implements ServiceProviderInterface
 {

--- a/app/Import/ImportConsumerServiceProvider.php
+++ b/app/Import/ImportConsumerServiceProvider.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Silex\Error\LoggerName;
 use GuzzleHttp\Client;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportConsumerServiceProvider implements ServiceProviderInterface
 {

--- a/app/JSONLD/ContextControllerProvider.php
+++ b/app/JSONLD/ContextControllerProvider.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContextControllerProvider implements ControllerProviderInterface
 {

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -34,7 +34,7 @@ use CultuurNet\UDB3\UDB2\Label\RelatedUDB3LabelApplier;
 use Monolog\Handler\StreamHandler;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelServiceProvider implements ServiceProviderInterface
 {

--- a/app/Migrations/Version20161220092125.php
+++ b/app/Migrations/Version20161220092125.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/app/Migrations/Version20181217144324.php
+++ b/app/Migrations/Version20181217144324.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Silex\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Version20181217144324 extends AbstractMigration
 {

--- a/app/Offer/DeprecatedOfferControllerProvider.php
+++ b/app/Offer/DeprecatedOfferControllerProvider.php
@@ -19,7 +19,7 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -29,7 +29,7 @@ use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OrganizerControllerProvider implements ControllerProviderInterface, ServiceProviderInterface
 {

--- a/app/Organizer/OrganizerPermissionServiceProvider.php
+++ b/app/Organizer/OrganizerPermissionServiceProvider.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Organizer\ReadModel\Permission\Projector;
 use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OrganizerPermissionServiceProvider implements ServiceProviderInterface
 {

--- a/app/Place/PlacePermissionServiceProvider.php
+++ b/app/Place/PlacePermissionServiceProvider.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\Doctrine\DBALResourceOwnerRepository;
 use CultuurNet\UDB3\Place\ReadModel\Permission\Projector;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PlacePermissionServiceProvider implements ServiceProviderInterface
 {

--- a/app/Proxy/ProxyServiceProvider.php
+++ b/app/Proxy/ProxyServiceProvider.php
@@ -14,7 +14,7 @@ use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProxyServiceProvider implements ServiceProviderInterface
 {

--- a/app/Role/UserPermissionsServiceProvider.php
+++ b/app/Role/UserPermissionsServiceProvider.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\UserPermissionsWriteRepo
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsProjector;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsServiceProvider implements ServiceProviderInterface
 {

--- a/app/SavedSearches/SavedSearchesServiceProvider.php
+++ b/app/SavedSearches/SavedSearchesServiceProvider.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
 use CultuurNet\UDB3\User\Auth0UserIdentityResolver;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SavedSearchesServiceProvider implements ServiceProviderInterface
 {

--- a/app/Security/GeneralSecurityServiceProvider.php
+++ b/app/Security/GeneralSecurityServiceProvider.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Role\ReadModel\Constraints\Doctrine\UserConstraintsReadRepos
 use CultuurNet\UDB3\Silex\Role\UserPermissionsServiceProvider;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Provides general security services usable by other services.

--- a/app/UDB2IncomingEventServicesProvider.php
+++ b/app/UDB2IncomingEventServicesProvider.php
@@ -40,7 +40,7 @@ use Ramsey\Uuid\UuidFactory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Yaml\Yaml;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UDB2IncomingEventServicesProvider implements ServiceProviderInterface
 {

--- a/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
+++ b/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepository;
 use Ramsey\Uuid\UuidFactory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UiTPASIncomingEventServicesProvider implements ServiceProviderInterface
 {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -91,7 +91,7 @@ use Silex\Application;
 use Silex\Provider\Psr7ServiceProvider;
 use SocketIO\Emitter;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 date_default_timezone_set('Europe/Brussels');
 

--- a/src/Address/Locality.php
+++ b/src/Address/Locality.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Address/PostalCode.php
+++ b/src/Address/PostalCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Address/Street.php
+++ b/src/Address/Street.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Address;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Broadway/AMQP/AbstractConsumer.php
+++ b/src/Broadway/AMQP/AbstractConsumer.php
@@ -10,7 +10,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use Psr\Log\LoggerAwareTrait;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractConsumer implements ConsumerInterface
 {

--- a/src/Broadway/AMQP/CommandBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/CommandBusForwardingConsumer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Broadway\AMQP;
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Forwards messages coming in via AMQP to an event bus.

--- a/src/Broadway/AMQP/EventBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumer.php
@@ -12,7 +12,7 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\Deserializer\DeserializerLocatorInterface;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Ramsey\Uuid\UuidFactoryInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Forwards messages coming in via AMQP to an event bus.

--- a/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidFactoryInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class EventBusForwardingConsumerFactory
 {

--- a/src/Cdb/CreatedByToUserIdResolverInterface.php
+++ b/src/Cdb/CreatedByToUserIdResolverInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Cdb;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface CreatedByToUserIdResolverInterface
 {

--- a/src/Cdb/Description/LongDescription.php
+++ b/src/Cdb/Description/LongDescription.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cdb\Description;
 
 use CultuurNet\UDB3\StringFilter\StringFilterInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LongDescription extends StringLiteral
 {

--- a/src/Cdb/Description/MergedDescription.php
+++ b/src/Cdb/Description/MergedDescription.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cdb\Description;
 
 use CultuurNet\UDB3\StringFilter\StringFilterInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MergedDescription extends StringLiteral
 {

--- a/src/Cdb/Description/ShortDescription.php
+++ b/src/Cdb/Description/ShortDescription.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cdb\Description;
 
 use CultuurNet\UDB3\StringFilter\StringFilterInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ShortDescription extends StringLiteral
 {

--- a/src/CommandHandling/AuthorizedCommandBus.php
+++ b/src/CommandHandling/AuthorizedCommandBus.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Security\CommandAuthorizationException;
 use CultuurNet\UDB3\Security\CommandBusSecurity;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AuthorizedCommandBus extends CommandBusDecoratorBase implements AuthorizedCommandBusInterface, LoggerAwareInterface, ContextAwareInterface
 {

--- a/src/CommandHandling/ResqueCommandBus.php
+++ b/src/CommandHandling/ResqueCommandBus.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerAwareTrait;
 use Broadway\Domain\Metadata;
 use Broadway\EventDispatcher\EventDispatcher;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Command bus decorator for asynchronous processing with PHP-Resque.

--- a/src/CommandHandling/UnauthorizableCommandException.php
+++ b/src/CommandHandling/UnauthorizableCommandException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\CommandHandling;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UnauthorizableCommandException extends \Exception
 {

--- a/src/Curators/Events/NewsArticleAboutEventAddedJSONDeserializer.php
+++ b/src/Curators/Events/NewsArticleAboutEventAddedJSONDeserializer.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Curators\PublisherName;
 use InvalidArgumentException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class NewsArticleAboutEventAddedJSONDeserializer extends JSONDeserializer
 {

--- a/src/Description.php
+++ b/src/Description.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Model\ValueObject\Text\Description as Udb3ModelDescription;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * @deprecated

--- a/src/DescriptionJSONDeserializer.php
+++ b/src/DescriptionJSONDeserializer.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Deserializer/DeserializerInterface.php
+++ b/src/Deserializer/DeserializerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface DeserializerInterface
 {

--- a/src/Deserializer/DeserializerLocatorInterface.php
+++ b/src/Deserializer/DeserializerLocatorInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface DeserializerLocatorInterface
 {

--- a/src/Deserializer/JSONDeserializer.php
+++ b/src/Deserializer/JSONDeserializer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class JSONDeserializer implements DeserializerInterface
 {

--- a/src/Deserializer/SimpleDeserializerLocator.php
+++ b/src/Deserializer/SimpleDeserializerLocator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Deserializer;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimpleDeserializerLocator implements DeserializerLocatorInterface
 {

--- a/src/Event/Commands/EventCommandFactory.php
+++ b/src/Event/Commands/EventCommandFactory.php
@@ -35,7 +35,7 @@ use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractFlagAsInappropriate;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractReject;
 use CultuurNet\UDB3\Offer\Commands\OfferCommandFactoryInterface;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCommandFactory implements OfferCommandFactoryInterface
 {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -87,7 +87,7 @@ use CultuurNet\UDB3\Timestamp;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Event extends Offer implements UpdateableWithCdbXmlInterface
 {

--- a/src/Event/EventEditingServiceInterface.php
+++ b/src/Event/EventEditingServiceInterface.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\Theme;
 use CultuurNet\UDB3\Title;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface EventEditingServiceInterface
 {

--- a/src/Event/EventThemeResolver.php
+++ b/src/Event/EventThemeResolver.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Offer\ThemeResolverInterface;
 use CultuurNet\UDB3\Theme;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventThemeResolver implements ThemeResolverInterface
 {

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventTypeResolver implements TypeResolverInterface
 {

--- a/src/Event/Productions/DBALProductionRepository.php
+++ b/src/Event/Productions/DBALProductionRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALProductionRepository extends AbstractDBALRepository implements ProductionRepository
 {

--- a/src/Event/Productions/SimilarEventsRepository.php
+++ b/src/Event/Productions/SimilarEventsRepository.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class SimilarEventsRepository extends AbstractDBALRepository
 {

--- a/src/Event/Productions/SkippedSimilarEventsRepository.php
+++ b/src/Event/Productions/SkippedSimilarEventsRepository.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event\Productions;
 
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SkippedSimilarEventsRepository extends AbstractDBALRepository
 {

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -75,7 +75,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\ReadModel\JsonDocumentMetaDataEnricherInterface;
 use CultuurNet\UDB3\RecordedOn;
 use CultuurNet\UDB3\Theme;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Projects state changes on Event entities to a JSON-LD read model in a

--- a/src/Event/ReadModel/JSONLD/Specifications/Has1Taalicoon.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/Has1Taalicoon.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Has1Taalicoon implements EventSpecificationInterface
 {

--- a/src/Event/ReadModel/JSONLD/Specifications/Has2Taaliconen.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/Has2Taaliconen.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Has2Taaliconen implements EventSpecificationInterface
 {

--- a/src/Event/ReadModel/JSONLD/Specifications/Has3Taaliconen.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/Has3Taaliconen.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Has3Taaliconen implements EventSpecificationInterface
 {

--- a/src/Event/ReadModel/JSONLD/Specifications/Has4Taaliconen.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/Has4Taaliconen.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Has4Taaliconen implements EventSpecificationInterface
 {

--- a/src/Event/ReadModel/JSONLD/Specifications/HasUiTPASBrand.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/HasUiTPASBrand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class HasUiTPASBrand implements EventSpecificationInterface
 {

--- a/src/Event/ReadModel/JSONLD/Specifications/Labelable.php
+++ b/src/Event/ReadModel/JSONLD/Specifications/Labelable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ReadModel\JSONLD\Specifications;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 trait Labelable
 {

--- a/src/Event/ReadModel/Permission/Projector.php
+++ b/src/Event/ReadModel/Permission/Projector.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Event\Events\EventImportedFromUDB2;
 use CultuurNet\UDB3\Event\Events\OwnerChanged;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Projector implements EventListener
 {

--- a/src/Event/ValueObjects/LocationId.php
+++ b/src/Event/ValueObjects/LocationId.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ValueObjects;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
+++ b/src/EventExport/Command/ExportEventsAsPDFJSONDeserializer.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Publisher;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Subtitle;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/EventExport/Command/ExportEventsJSONDeserializer.php
+++ b/src/EventExport/Command/ExportEventsJSONDeserializer.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\EventExport\EventExportQuery;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/EventExport/EventExportQuery.php
+++ b/src/EventExport/EventExportQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventExportQuery extends StringLiteral
 {

--- a/src/EventExport/Format/HTML/Properties/Footer.php
+++ b/src/EventExport/Format/HTML/Properties/Footer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Footer extends StringLiteral
 {

--- a/src/EventExport/Format/HTML/Properties/Publisher.php
+++ b/src/EventExport/Format/HTML/Properties/Publisher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Publisher extends StringLiteral
 {

--- a/src/EventExport/Format/HTML/Properties/Subtitle.php
+++ b/src/EventExport/Format/HTML/Properties/Subtitle.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Subtitle extends StringLiteral
 {

--- a/src/EventExport/Format/HTML/Properties/Title.php
+++ b/src/EventExport/Format/HTML/Properties/Title.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventExport\Format\HTML\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Title extends StringLiteral
 {

--- a/src/EventListener/ClassNameEventSpecification.php
+++ b/src/EventListener/ClassNameEventSpecification.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\EventListener;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ClassNameEventSpecification implements EventSpecification
 {

--- a/src/Http/CommandDeserializerControllerTrait.php
+++ b/src/Http/CommandDeserializerControllerTrait.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 trait CommandDeserializerControllerTrait
 {

--- a/src/Http/Deserializer/Address/AddressJSONDeserializer.php
+++ b/src/Http/Deserializer/Address/AddressJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Address;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Address\Address;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/BookingInfo/BookingInfoJSONDeserializer.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
+++ b/src/Http/Deserializer/Calendar/CalendarJSONDeserializer.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/ContactPoint/ContactPointJSONDeserializer.php
+++ b/src/Http/Deserializer/ContactPoint/ContactPointJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\ContactPoint;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\ContactPoint;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Event/CreateEventJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/CreateEventJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Event;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Language;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Event/EventTypeJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/EventTypeJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Event;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Event\EventType;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Event/MajorInfoJSONDeserializer.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Theme\ThemeJSONDeserializer;
 use CultuurNet\UDB3\Title;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Organizer/OrganizerCreationPayloadJSONDeserializer.php
+++ b/src/Http/Deserializer/Organizer/OrganizerCreationPayloadJSONDeserializer.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Http\Deserializer\Address\AddressJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\ContactPoint\ContactPointJSONDeserializer;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Title;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Organizer/UrlJSONDeserializer.php
+++ b/src/Http/Deserializer/Organizer/UrlJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Organizer;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Place/CreatePlaceJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/CreatePlaceJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Place;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Language;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/FacilitiesJSONDeserializer.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Facility;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\DataValidatorInterface;
 use CultuurNet\UDB3\Http\Deserializer\DataValidator\RequiredPropertiesDataValidator;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/Place/MajorInfoJSONDeserializer.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Http\Deserializer\Calendar\CalendarJSONParser;
 use CultuurNet\UDB3\Http\Deserializer\Event\EventTypeJSONDeserializer;
 use CultuurNet\UDB3\Http\Deserializer\Theme\ThemeJSONDeserializer;
 use CultuurNet\UDB3\Title;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializer.php
+++ b/src/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializer.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\PriceInfo\Tariff;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/Role/QueryJSONDeserializer.php
+++ b/src/Http/Deserializer/Role/QueryJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Role;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 
 /**

--- a/src/Http/Deserializer/Theme/ThemeJSONDeserializer.php
+++ b/src/Http/Deserializer/Theme/ThemeJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Theme;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Theme;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Deserializer/TitleJSONDeserializer.php
+++ b/src/Http/Deserializer/TitleJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Title;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Http/Event/EditEventRestController.php
+++ b/src/Http/Event/EditEventRestController.php
@@ -20,7 +20,7 @@ use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditEventRestController extends OfferRestBaseController
 {

--- a/src/Http/Event/UpdateMajorInfoRequestHandler.php
+++ b/src/Http/Event/UpdateMajorInfoRequestHandler.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
 {

--- a/src/Http/Import/ImportLabelVisibilityRequestBodyParser.php
+++ b/src/Http/Import/ImportLabelVisibilityRequestBodyParser.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface as LabelRelationsRepository;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use Psr\Http\Message\ServerRequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Manipulates the `labels` and `hiddenLabels` properties on JSON of events, places and organizers that need to be

--- a/src/Http/JSONLD/ContextController.php
+++ b/src/Http/JSONLD/ContextController.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\JSONLD;
 use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContextController
 {

--- a/src/Http/Jobs/JobsStatusFactoryInterface.php
+++ b/src/Http/Jobs/JobsStatusFactoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Jobs;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface JobsStatusFactoryInterface
 {

--- a/src/Http/Jobs/ReadRestController.php
+++ b/src/Http/Jobs/ReadRestController.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Jobs;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ReadRestController
 {

--- a/src/Http/Jobs/ResqueJobStatusFactory.php
+++ b/src/Http/Jobs/ResqueJobStatusFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Jobs;
 
 use Resque_Job_Status;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ResqueJobStatusFactory implements JobsStatusFactoryInterface
 {

--- a/src/Http/Label/Query/QueryFactory.php
+++ b/src/Http/Label/Query/QueryFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Label\Query;
 
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class QueryFactory implements QueryFactoryInterface
 {

--- a/src/Http/Label/ReadRestController.php
+++ b/src/Http/Label/ReadRestController.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ReadRestController
 {

--- a/src/Http/Management/UserPermissionsVoter.php
+++ b/src/Http/Management/UserPermissionsVoter.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsVoter implements VoterInterface
 {

--- a/src/Http/Media/EditMediaRestController.php
+++ b/src/Http/Media/EditMediaRestController.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditMediaRestController
 {

--- a/src/Http/Offer/EditOfferRestController.php
+++ b/src/Http/Offer/EditOfferRestController.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Http\Deserializer\PriceInfo\PriceInfoJSONDeserializer;
 use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditOfferRestController
 {

--- a/src/Http/Offer/OfferPermissionController.php
+++ b/src/Http/Offer/OfferPermissionController.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Security\Permission\PermissionVoter;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferPermissionController
 {

--- a/src/Http/Offer/OfferPermissionsController.php
+++ b/src/Http/Offer/OfferPermissionsController.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Security\Permission\PermissionVoter;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferPermissionsController
 {

--- a/src/Http/Offer/PatchOfferRestController.php
+++ b/src/Http/Offer/PatchOfferRestController.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use DateTime;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PatchOfferRestController
 {

--- a/src/Http/OfferRestBaseController.php
+++ b/src/Http/OfferRestBaseController.php
@@ -18,7 +18,7 @@ use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Base class for offer reset callbacks.

--- a/src/Http/Place/EditPlaceRestController.php
+++ b/src/Http/Place/EditPlaceRestController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditPlaceRestController extends OfferRestBaseController
 {

--- a/src/Http/Place/UpdateMajorInfoRequestHandler.php
+++ b/src/Http/Place/UpdateMajorInfoRequestHandler.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UpdateMajorInfoRequestHandler implements RequestHandlerInterface
 {

--- a/src/Http/Proxy/CdbXmlProxy.php
+++ b/src/Http/Proxy/CdbXmlProxy.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\PortNumber;
 use GuzzleHttp\ClientInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CdbXmlProxy extends Proxy
 {

--- a/src/Http/Proxy/Filter/AcceptFilter.php
+++ b/src/Http/Proxy/Filter/AcceptFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AcceptFilter implements FilterInterface
 {

--- a/src/Http/Proxy/Filter/ContentTypeFilter.php
+++ b/src/Http/Proxy/Filter/ContentTypeFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContentTypeFilter implements FilterInterface
 {

--- a/src/Http/Proxy/Filter/HeaderFilter.php
+++ b/src/Http/Proxy/Filter/HeaderFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class HeaderFilter implements FilterInterface
 {

--- a/src/Http/Proxy/Filter/MethodFilter.php
+++ b/src/Http/Proxy/Filter/MethodFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MethodFilter implements FilterInterface
 {

--- a/src/Http/Proxy/Filter/PreflightFilter.php
+++ b/src/Http/Proxy/Filter/PreflightFilter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use CultuurNet\UDB3\Http\Proxy\FilterPathRegex;
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PreflightFilter implements FilterInterface
 {

--- a/src/Http/Proxy/FilterPathMethodProxy.php
+++ b/src/Http/Proxy/FilterPathMethodProxy.php
@@ -18,7 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\PortNumber;
 use GuzzleHttp\ClientInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class FilterPathMethodProxy extends Proxy
 {

--- a/src/Http/Proxy/FilterPathRegex.php
+++ b/src/Http/Proxy/FilterPathRegex.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Proxy;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class FilterPathRegex extends StringLiteral
 {

--- a/src/Http/Role/EditRoleRestController.php
+++ b/src/Http/Role/EditRoleRestController.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditRoleRestController
 {

--- a/src/Http/Role/ReadRoleRestController.php
+++ b/src/Http/Role/ReadRoleRestController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ReadRoleRestController
 {

--- a/src/Http/SavedSearches/EditSavedSearchesRestController.php
+++ b/src/Http/SavedSearches/EditSavedSearchesRestController.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\SavedSearches\Command\UnsubscribeFromSavedSearch;
 use CultuurNet\UDB3\HttpFoundation\Response\NoContent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditSavedSearchesRestController
 {

--- a/src/Jwt/Symfony/Authentication/JsonWebToken.php
+++ b/src/Jwt/Symfony/Authentication/JsonWebToken.php
@@ -14,7 +14,7 @@ use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\ValidationData;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class JsonWebToken extends AbstractToken
 {

--- a/src/Label/Label.php
+++ b/src/Label/Label.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Label\Events\MadeVisible;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Label extends EventSourcedAggregateRoot
 {

--- a/src/Label/ReadModels/Doctrine/AbstractDBALRepository.php
+++ b/src/Label/ReadModels/Doctrine/AbstractDBALRepository.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractDBALRepository
 {

--- a/src/Label/ReadModels/JSON/Projector.php
+++ b/src/Label/ReadModels/JSON/Projector.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\WriteRepositoryInterface;
 use CultuurNet\UDB3\LabelEventInterface;
 use CultuurNet\UDB3\LabelsImportedEventInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Projector extends AbstractProjector
 {

--- a/src/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecorator.php
+++ b/src/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecorator.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Label\Events\LabelDetailsProjectedToJSONLD;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class BroadcastingWriteRepositoryDecorator implements WriteRepositoryInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as PermissionsSchemaConfigurator;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class DBALReadRepository extends AbstractDBALRepository implements ReadRepositoryInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use ValueObjects\Number\Integer as IntegerValue;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepository extends AbstractDBALRepository implements WriteRepositoryInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepository.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\WriteRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\Number\Integer as IntegerValue;
 use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepository extends AbstractDBALRepository implements WriteRepositoryInterface
@@ -85,16 +84,15 @@ class DBALWriteRepository extends AbstractDBALRepository implements WriteReposit
     public function updateCountIncrement(UUID $uuid)
     {
         $this->executeCountUpdate(
-            new IntegerValue(+1),
+            1,
             $uuid
         );
     }
 
-
     public function updateCountDecrement(UUID $uuid)
     {
         $this->executeCountUpdate(
-            new IntegerValue(-1),
+            -1,
             $uuid
         );
     }
@@ -122,11 +120,11 @@ class DBALWriteRepository extends AbstractDBALRepository implements WriteReposit
 
 
     private function executeCountUpdate(
-        IntegerValue $value,
+        int $value,
         UUID $uuid
     ) {
-        $currentCount = $this->getCurrentCount($uuid)->toNative();
-        $newCount = $currentCount + $value->toNative();
+        $currentCount = $this->getCurrentCount($uuid);
+        $newCount = $currentCount + $value;
 
         $queryBuilder = $this->createQueryBuilder()
             ->update($this->getTableName()->toNative())
@@ -140,7 +138,7 @@ class DBALWriteRepository extends AbstractDBALRepository implements WriteReposit
         $queryBuilder->execute();
     }
 
-    private function getCurrentCount(UUID $uuid): IntegerValue
+    private function getCurrentCount(UUID $uuid): int
     {
         $queryBuilder = $this->createQueryBuilder()
             ->select([SchemaConfigurator::COUNT_COLUMN])
@@ -151,6 +149,6 @@ class DBALWriteRepository extends AbstractDBALRepository implements WriteReposit
         $statement = $queryBuilder->execute();
         $row = $statement->fetch(\PDO::FETCH_NUM);
 
-        return new IntegerValue($row[0]);
+        return (int) $row[0];
     }
 }

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/SchemaConfigurator.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/Entity.php
+++ b/src/Label/ReadModels/JSON/Repository/Entity.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use InvalidArgumentException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Entity implements \JsonSerializable
 {

--- a/src/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecorator.php
+++ b/src/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecorator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class GodUserReadRepositoryDecorator implements ReadRepositoryInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/Query.php
+++ b/src/Label/ReadModels/JSON/Repository/Query.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class Query
 {

--- a/src/Label/ReadModels/JSON/Repository/ReadRepositoryInterface.php
+++ b/src/Label/ReadModels/JSON/Repository/ReadRepositoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ReadRepositoryInterface
 {

--- a/src/Label/ReadModels/JSON/Repository/SimilaritySorter.php
+++ b/src/Label/ReadModels/JSON/Repository/SimilaritySorter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimilaritySorter
 {

--- a/src/Label/ReadModels/JSON/Repository/WriteRepositoryInterface.php
+++ b/src/Label/ReadModels/JSON/Repository/WriteRepositoryInterface.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface WriteRepositoryInterface
 {

--- a/src/Label/ReadModels/Relations/Projector.php
+++ b/src/Label/ReadModels/Relations/Projector.php
@@ -25,7 +25,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Projector extends AbstractProjector
 {

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepository.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALReadRepository extends AbstractDBALRepository implements ReadRepositoryInterface
 {

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepository.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\WriteRepositoryInterfa
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use Doctrine\DBAL\Query\QueryBuilder;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepository extends AbstractDBALRepository implements WriteRepositoryInterface
 {

--- a/src/Label/ReadModels/Relations/Repository/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/Relations/Repository/Doctrine/SchemaConfigurator.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Label/ReadModels/Relations/Repository/LabelRelation.php
+++ b/src/Label/ReadModels/Relations/Repository/LabelRelation.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine\SchemaConfigu
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use JsonSerializable;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelRelation implements JsonSerializable
 {

--- a/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
+++ b/src/Label/ReadModels/Relations/Repository/ReadRepositoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository;
 
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ReadRepositoryInterface
 {

--- a/src/Label/ReadModels/Relations/Repository/WriteRepositoryInterface.php
+++ b/src/Label/ReadModels/Relations/Repository/WriteRepositoryInterface.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository;
 
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface WriteRepositoryInterface
 {

--- a/src/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepository.php
+++ b/src/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine;
 use CultuurNet\UDB3\Label\ReadModels\Roles\LabelRolesWriteRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelRolesWriteRepository implements LabelRolesWriteRepositoryInterface
 {

--- a/src/Label/ReadModels/Roles/Doctrine/SchemaConfigurator.php
+++ b/src/Label/ReadModels/Roles/Doctrine/SchemaConfigurator.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Roles\Doctrine;
 use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Label/Services/ReadService.php
+++ b/src/Label/Services/ReadService.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ReadService implements ReadServiceInterface
 {

--- a/src/Label/Services/ReadServiceInterface.php
+++ b/src/Label/Services/ReadServiceInterface.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\Services;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ReadServiceInterface
 {

--- a/src/Label/ValueObjects/LabelName.php
+++ b/src/Label/ValueObjects/LabelName.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Label\ValueObjects;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/LabelJSONDeserializer.php
+++ b/src/LabelJSONDeserializer.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Media/Commands/UploadImage.php
+++ b/src/Media/Commands/UploadImage.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UploadImage
 {

--- a/src/Media/Events/MediaObjectCreated.php
+++ b/src/Media/Events/MediaObjectCreated.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class MediaObjectCreated implements Serializable
 {

--- a/src/Media/ImageUploaderInterface.php
+++ b/src/Media/ImageUploaderInterface.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ImageUploaderInterface
 {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImageUploaderService implements ImageUploaderInterface
 {

--- a/src/Media/MediaManager.php
+++ b/src/Media/MediaManager.php
@@ -18,7 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MediaManager extends Udb3CommandHandler implements LoggerAwareInterface, MediaManagerInterface
 {

--- a/src/Media/MediaManagerInterface.php
+++ b/src/Media/MediaManagerInterface.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface MediaManagerInterface extends CommandHandler
 {

--- a/src/Media/MediaObject.php
+++ b/src/Media/MediaObject.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * MediaObjects for UDB3.

--- a/src/Media/PathGeneratorInterface.php
+++ b/src/Media/PathGeneratorInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface PathGeneratorInterface
 {

--- a/src/Media/Properties/Description.php
+++ b/src/Media/Properties/Description.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Description extends StringLiteral
 {

--- a/src/Media/Properties/MIMEType.php
+++ b/src/Media/Properties/MIMEType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media\Properties;
 
 use InvalidArgumentException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use function is_string;
 
 final class MIMEType extends StringLiteral

--- a/src/Media/SimplePathGenerator.php
+++ b/src/Media/SimplePathGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimplePathGenerator implements PathGeneratorInterface
 {

--- a/src/Model/Import/Command/Deserializer/ImportDocumentDeserializer.php
+++ b/src/Model/Import/Command/Deserializer/ImportDocumentDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Import\Command\Deserializer;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\Import\Command\ImportDocument;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class ImportDocumentDeserializer extends JSONDeserializer
 {

--- a/src/Model/Import/PreProcessing/LabelPreProcessingDocumentImporter.php
+++ b/src/Model/Import/PreProcessing/LabelPreProcessingDocumentImporter.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterfac
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated Use CultuurNet\UDB3\Http\Import\ImportLabelVisibilityRequestBodyParser instead.

--- a/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
+++ b/src/Model/Import/Taxonomy/Category/LegacyBridgeCategoryResolver.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
 use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Offer\ThemeResolverInterface;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LegacyBridgeCategoryResolver implements CategoryResolverInterface
 {

--- a/src/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepository.php
+++ b/src/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterfac
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class RelationshipModelLockedLabelRepository implements LockedLabelRepository
 {

--- a/src/Model/Import/Validation/Taxonomy/Label/LabelPermissionRule.php
+++ b/src/Model/Import/Validation/Taxonomy/Label/LabelPermissionRule.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterfac
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Rules\AbstractRule;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelPermissionRule extends AbstractRule
 {

--- a/src/Offer/CommandHandlers/AddLabelHandler.php
+++ b/src/Offer/CommandHandlers/AddLabelHandler.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\OfferRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class AddLabelHandler implements CommandHandler
 {

--- a/src/Offer/CommandHandlers/ChangeOwnerHandler.php
+++ b/src/Offer/CommandHandlers/ChangeOwnerHandler.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Offer\Commands\ChangeOwner;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ChangeOwnerHandler implements CommandHandler
 {

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractLabelCommand extends AbstractCommand implements AuthorizableLabelCommand
 {

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Label;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Offer/Commands/Image/AbstractUpdateImage.php
+++ b/src/Offer/Commands/Image/AbstractUpdateImage.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\Commands\Image;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractUpdateImage extends AbstractCommand
 {

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabels extends AbstractCommand implements AuthorizableLabelCommand
 {

--- a/src/Offer/Commands/Moderation/AbstractReject.php
+++ b/src/Offer/Commands/Moderation/AbstractReject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands\Moderation;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractReject extends AbstractModerationCommand
 {

--- a/src/Offer/Commands/OfferCommandFactoryInterface.php
+++ b/src/Offer/Commands/OfferCommandFactoryInterface.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractFlagAsDuplicate;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractFlagAsInappropriate;
 use CultuurNet\UDB3\Offer\Commands\Moderation\AbstractReject;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Language;
 
 interface OfferCommandFactoryInterface

--- a/src/Offer/DefaultOfferEditingService.php
+++ b/src/Offer/DefaultOfferEditingService.php
@@ -18,7 +18,7 @@ use CultuurNet\UDB3\Offer\Commands\OfferCommandFactoryInterface;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DefaultOfferEditingService implements OfferEditingServiceInterface
 {

--- a/src/Offer/Events/Image/AbstractImageUpdated.php
+++ b/src/Offer/Events/Image/AbstractImageUpdated.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\Events\Image;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractImageUpdated extends AbstractEvent
 {

--- a/src/Offer/Events/Moderation/AbstractRejected.php
+++ b/src/Offer/Events/Moderation/AbstractRejected.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Events\Moderation;
 
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractRejected extends AbstractEvent
 {

--- a/src/Offer/IriOfferIdentifierJSONDeserializer.php
+++ b/src/Offer/IriOfferIdentifierJSONDeserializer.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -74,7 +74,7 @@ use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggregateRoot
 {

--- a/src/Offer/OfferEditingServiceInterface.php
+++ b/src/Offer/OfferEditingServiceInterface.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Media\Image;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface OfferEditingServiceInterface
 {

--- a/src/Offer/OfferFacilityResolver.php
+++ b/src/Offer/OfferFacilityResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Facility;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class OfferFacilityResolver implements OfferFacilityResolverInterface
 {

--- a/src/Offer/OfferFacilityResolverInterface.php
+++ b/src/Offer/OfferFacilityResolverInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Facility;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface OfferFacilityResolverInterface
 {

--- a/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
+++ b/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\ReadModel\MultilingualJsonLDProjectorTrait;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CdbXMLItemBaseImporter
 {

--- a/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
+++ b/src/Offer/ReadModel/Metadata/OfferMetadataRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\ReadModel\Metadata;
 use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Label\ReadModels\Doctrine\AbstractDBALRepository;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferMetadataRepository extends AbstractDBALRepository
 {

--- a/src/Offer/ThemeResolverInterface.php
+++ b/src/Offer/ThemeResolverInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Theme;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ThemeResolverInterface
 {

--- a/src/Offer/TypeResolverInterface.php
+++ b/src/Offer/TypeResolverInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use CultuurNet\UDB3\Event\EventType;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface TypeResolverInterface
 {

--- a/src/Organizer/CommandHandler/ImportLabelsHandler.php
+++ b/src/Organizer/CommandHandler/ImportLabelsHandler.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Organizer\Commands\ImportLabels;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabelsHandler implements CommandHandler
 {

--- a/src/Organizer/CommandHandler/RemoveLabelHandler.php
+++ b/src/Organizer/CommandHandler/RemoveLabelHandler.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Organizer\Commands\RemoveLabel;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class RemoveLabelHandler implements CommandHandler
 {

--- a/src/Organizer/Commands/AbstractLabelCommand.php
+++ b/src/Organizer/Commands/AbstractLabelCommand.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Security\AuthorizableCommand;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractLabelCommand implements AuthorizableCommand, AuthorizableLabelCommand
 {

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Security\AuthorizableCommand;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabels implements AuthorizableCommand
 {

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Projector implements EventListener
 {

--- a/src/Place/Commands/PlaceCommandFactory.php
+++ b/src/Place/Commands/PlaceCommandFactory.php
@@ -35,7 +35,7 @@ use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsDuplicate;
 use CultuurNet\UDB3\Place\Commands\Moderation\FlagAsInappropriate;
 use CultuurNet\UDB3\Place\Commands\Moderation\Reject;
 use CultuurNet\UDB3\PriceInfo\PriceInfo;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PlaceCommandFactory implements OfferCommandFactoryInterface
 {

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -75,7 +75,7 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
 use DateTimeInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Place extends Offer implements UpdateableWithCdbXmlInterface
 {

--- a/src/Place/PlaceTypeResolver.php
+++ b/src/Place/PlaceTypeResolver.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Place;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Offer\TypeResolverInterface;
 use Exception;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PlaceTypeResolver implements TypeResolverInterface
 {

--- a/src/Place/ReadModel/Permission/Projector.php
+++ b/src/Place/ReadModel/Permission/Projector.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use CultuurNet\UDB3\Place\Events\OwnerChanged;
 use CultuurNet\UDB3\Place\Events\PlaceCreated;
 use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Projector implements EventListener
 {

--- a/src/Role/Commands/AbstractUserCommand.php
+++ b/src/Role/Commands/AbstractUserCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractUserCommand extends AbstractCommand
 {

--- a/src/Role/Commands/CreateRole.php
+++ b/src/Role/Commands/CreateRole.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CreateRole extends AbstractCommand
 {

--- a/src/Role/Commands/RenameRole.php
+++ b/src/Role/Commands/RenameRole.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RenameRole extends AbstractCommand
 {

--- a/src/Role/Commands/UpdateRoleRequestDeserializer.php
+++ b/src/Role/Commands/UpdateRoleRequestDeserializer.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\MissingContentTypeException;
 use CultuurNet\UDB3\Role\UnknownContentTypeException;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UpdateRoleRequestDeserializer
 {

--- a/src/Role/Events/AbstractUserEvent.php
+++ b/src/Role/Events/AbstractUserEvent.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractUserEvent extends AbstractEvent
 {

--- a/src/Role/Events/RoleCreated.php
+++ b/src/Role/Events/RoleCreated.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class RoleCreated extends AbstractEvent
 {

--- a/src/Role/Events/RoleRenamed.php
+++ b/src/Role/Events/RoleRenamed.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class RoleRenamed extends AbstractEvent
 {

--- a/src/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepository.php
+++ b/src/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepository.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as Pe
 use CultuurNet\UDB3\Role\ReadModel\Search\Doctrine\SchemaConfigurator as SearchSchemaConfigurator;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserConstraintsReadRepository implements UserConstraintsReadRepositoryInterface
 {

--- a/src/Role/ReadModel/Constraints/UserConstraintsReadRepositoryInterface.php
+++ b/src/Role/ReadModel/Constraints/UserConstraintsReadRepositoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\ReadModel\Constraints;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface UserConstraintsReadRepositoryInterface
 {

--- a/src/Role/ReadModel/Permissions/Doctrine/SchemaConfigurator.php
+++ b/src/Role/ReadModel/Permissions/Doctrine/SchemaConfigurator.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine;
 use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepository.php
+++ b/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsReadRepository implements UserPermissionsReadRepositoryInterface
 {

--- a/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepository.php
+++ b/src/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepository.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsWriteRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsWriteRepository implements UserPermissionsWriteRepositoryInterface
 {

--- a/src/Role/ReadModel/Permissions/UserPermissionsReadRepositoryInterface.php
+++ b/src/Role/ReadModel/Permissions/UserPermissionsReadRepositoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Role\ReadModel\Permissions;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface UserPermissionsReadRepositoryInterface
 {

--- a/src/Role/ReadModel/Permissions/UserPermissionsWriteRepositoryInterface.php
+++ b/src/Role/ReadModel/Permissions/UserPermissionsWriteRepositoryInterface.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\ReadModel\Permissions;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface UserPermissionsWriteRepositoryInterface
 {

--- a/src/Role/ReadModel/Search/Doctrine/DBALRepository.php
+++ b/src/Role/ReadModel/Search/Doctrine/DBALRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\ReadModel\Search\Doctrine;
 use CultuurNet\UDB3\Role\ReadModel\Search\RepositoryInterface;
 use CultuurNet\UDB3\Role\ReadModel\Search\Results;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALRepository implements RepositoryInterface
 {

--- a/src/Role/ReadModel/Search/Doctrine/SchemaConfigurator.php
+++ b/src/Role/ReadModel/Search/Doctrine/SchemaConfigurator.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Role/Role.php
+++ b/src/Role/Role.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Role\Events\UserAdded;
 use CultuurNet\UDB3\Role\Events\UserRemoved;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Role extends EventSourcedAggregateRoot
 {

--- a/src/Role/Services/DefaultRoleEditingService.php
+++ b/src/Role/Services/DefaultRoleEditingService.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Role\Commands\UpdateConstraint;
 use CultuurNet\UDB3\Role\Role;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DefaultRoleEditingService implements RoleEditingServiceInterface
 {

--- a/src/Role/Services/LocalRoleReadingService.php
+++ b/src/Role/Services/LocalRoleReadingService.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\LocalEntityService;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LocalRoleReadingService extends LocalEntityService implements RoleReadingServiceInterface
 {

--- a/src/Role/Services/RoleEditingServiceInterface.php
+++ b/src/Role/Services/RoleEditingServiceInterface.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\Services;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface RoleEditingServiceInterface
 {

--- a/src/Role/Services/RoleReadingServiceInterface.php
+++ b/src/Role/Services/RoleReadingServiceInterface.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Services;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface RoleReadingServiceInterface
 {

--- a/src/Role/ValueObjects/Query.php
+++ b/src/Role/ValueObjects/Query.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Role\ValueObjects;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Query extends StringLiteral
 {

--- a/src/SavedSearches/Command/SavedSearchCommand.php
+++ b/src/SavedSearches/Command/SavedSearchCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class SavedSearchCommand
 {

--- a/src/SavedSearches/Command/SubscribeToSavedSearch.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearch.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SubscribeToSavedSearch extends SavedSearchCommand
 {

--- a/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
+++ b/src/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SavedSearches\Command;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/src/SavedSearches/Command/UnsubscribeFromSavedSearch.php
+++ b/src/SavedSearches/Command/UnsubscribeFromSavedSearch.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UnsubscribeFromSavedSearch extends SavedSearchCommand
 {

--- a/src/SavedSearches/Doctrine/SchemaConfigurator.php
+++ b/src/SavedSearches/Doctrine/SchemaConfigurator.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/SavedSearches/Properties/QueryString.php
+++ b/src/SavedSearches/Properties/QueryString.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\SavedSearches\Properties;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class QueryString extends StringLiteral
 {

--- a/src/SavedSearches/ReadModel/SavedSearch.php
+++ b/src/SavedSearches/ReadModel/SavedSearch.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\ReadModel;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SavedSearch implements \JsonSerializable
 {

--- a/src/SavedSearches/Sapi3FixedSavedSearchRepository.php
+++ b/src/SavedSearches/Sapi3FixedSavedSearchRepository.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
 use CultuurNet\UDB3\User\UserIdentityResolver;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Sapi3FixedSavedSearchRepository implements SavedSearchRepositoryInterface
 {

--- a/src/SavedSearches/UDB3SavedSearchRepository.php
+++ b/src/SavedSearches/UDB3SavedSearchRepository.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface as SavedSearchReadModelRepositoryInterface;
 use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface as SavedSearchWriteModelRepositoryInterface;
 use Doctrine\DBAL\Connection;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UDB3SavedSearchRepository implements SavedSearchReadModelRepositoryInterface, SavedSearchWriteModelRepositoryInterface
 {

--- a/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
+++ b/src/SavedSearches/WriteModel/SavedSearchRepositoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\WriteModel;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface SavedSearchRepositoryInterface
 {

--- a/src/Security/AuthorizableLabelCommand.php
+++ b/src/Security/AuthorizableLabelCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface AuthorizableLabelCommand
 {

--- a/src/Security/CommandAuthorizationException.php
+++ b/src/Security/CommandAuthorizationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CommandAuthorizationException extends \Exception
 {

--- a/src/Security/LabelCommandBusSecurity.php
+++ b/src/Security/LabelCommandBusSecurity.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Checks commands that add/remove labels from entities to see if the user is allowed to use those specific labels.

--- a/src/Security/Permission/AnyOfVoter.php
+++ b/src/Security/Permission/AnyOfVoter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AnyOfVoter implements PermissionVoter
 {

--- a/src/Security/Permission/GodUserVoter.php
+++ b/src/Security/Permission/GodUserVoter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class GodUserVoter implements PermissionVoter
 {

--- a/src/Security/Permission/PermissionSwitchVoter.php
+++ b/src/Security/Permission/PermissionSwitchVoter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Delegates voting to another voter based on which permission needs checking.

--- a/src/Security/Permission/PermissionVoter.php
+++ b/src/Security/Permission/PermissionVoter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface PermissionVoter
 {

--- a/src/Security/Permission/ResourceOwnerVoter.php
+++ b/src/Security/Permission/ResourceOwnerVoter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ResourceOwnerVoter implements PermissionVoter
 {

--- a/src/Security/Permission/Sapi3RoleConstraintVoter.php
+++ b/src/Security/Permission/Sapi3RoleConstraintVoter.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use GuzzleHttp\Psr7\Request;
 use Http\Client\HttpClient;
 use Psr\Http\Message\UriInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Sapi3RoleConstraintVoter implements PermissionVoter
 {

--- a/src/Security/Permission/UserPermissionVoter.php
+++ b/src/Security/Permission/UserPermissionVoter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionVoter implements PermissionVoter
 {

--- a/src/Security/PermissionVoterCommandBusSecurity.php
+++ b/src/Security/PermissionVoterCommandBusSecurity.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Security;
 
 use CultuurNet\UDB3\Security\Permission\PermissionVoter;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PermissionVoterCommandBusSecurity implements CommandBusSecurity
 {

--- a/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/CombinedResourceOwnerQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CombinedResourceOwnerQuery implements ResourceOwnerQuery
 {

--- a/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepository.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALResourceOwnerRepository implements ResourceOwnerRepository, ResourceOwnerQuery
 {

--- a/src/Security/ResourceOwner/Doctrine/SchemaConfigurator.php
+++ b/src/Security/ResourceOwner/Doctrine/SchemaConfigurator.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\ResourceOwner\Doctrine;
 
 use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SchemaConfigurator implements SchemaConfiguratorInterface
 {

--- a/src/Security/ResourceOwner/ResourceOwnerQuery.php
+++ b/src/Security/ResourceOwner/ResourceOwnerQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ResourceOwnerQuery
 {

--- a/src/Security/ResourceOwner/ResourceOwnerRepository.php
+++ b/src/Security/ResourceOwner/ResourceOwnerRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security\ResourceOwner;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface ResourceOwnerRepository
 {

--- a/src/StringLiteral.php
+++ b/src/StringLiteral.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3;
+
+/**
+ * @deprecated Should not be used. Only here to get rid of ValueObjects dependency
+ */
+class StringLiteral
+{
+    protected string $value;
+
+    /**
+     * @return static
+     */
+    public static function fromNative(string $value)
+    {
+        // @phpstan-ignore-next-line
+        return new static($value);
+    }
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function toNative(): string
+    {
+        return $this->value;
+    }
+
+    public function sameValueAs(StringLiteral $stringLiteral): bool
+    {
+        return $this->toNative() === $stringLiteral->toNative();
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->toNative() === '';
+    }
+
+    public function __toString(): string
+    {
+        return $this->toNative();
+    }
+}

--- a/src/Title.php
+++ b/src/Title.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Model\ValueObject\Text\Title as Udb3ModelTitle;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * @deprecated

--- a/src/UDB2/Actor/ActorEventCdbXmlEnricher.php
+++ b/src/UDB2/Actor/ActorEventCdbXmlEnricher.php
@@ -25,7 +25,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\UuidFactoryInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use XMLReader;
 
 /**

--- a/src/UDB2/Actor/ActorImporter.php
+++ b/src/UDB2/Actor/ActorImporter.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\UDB2\OfferAlreadyImportedException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Applies incoming UDB2 actor events enriched with cdb xml on UDB3 organizers.

--- a/src/UDB2/Actor/Events/ActorCreatedEnrichedWithCdbXml.php
+++ b/src/UDB2/Actor/Events/ActorCreatedEnrichedWithCdbXml.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Cdb\CdbXmlContainerInterface;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\UDB2\DomainEvents\ActorCreated;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorCreatedEnrichedWithCdbXml extends ActorCreated implements CdbXmlContainerInterface
 {

--- a/src/UDB2/Actor/Events/ActorUpdatedEnrichedWithCdbXml.php
+++ b/src/UDB2/Actor/Events/ActorUpdatedEnrichedWithCdbXml.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Cdb\CdbXmlContainerInterface;
 use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\UDB2\DomainEvents\ActorUpdated;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorUpdatedEnrichedWithCdbXml extends ActorUpdated implements CdbXmlContainerInterface
 {

--- a/src/UDB2/DomainEvents/AbstractActorEvent.php
+++ b/src/UDB2/DomainEvents/AbstractActorEvent.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractActorEvent implements Serializable
 {

--- a/src/UDB2/DomainEvents/AbstractEventEvent.php
+++ b/src/UDB2/DomainEvents/AbstractEventEvent.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use Broadway\Serializer\Serializable;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractEventEvent implements Serializable
 {

--- a/src/UDB2/DomainEvents/ActorCreatedJSONDeserializer.php
+++ b/src/UDB2/DomainEvents/ActorCreatedJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorCreatedJSONDeserializer extends JSONDeserializer
 {

--- a/src/UDB2/DomainEvents/ActorUpdatedJSONDeserializer.php
+++ b/src/UDB2/DomainEvents/ActorUpdatedJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorUpdatedJSONDeserializer extends JSONDeserializer
 {

--- a/src/UDB2/DomainEvents/EventCreatedJSONDeserializer.php
+++ b/src/UDB2/DomainEvents/EventCreatedJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCreatedJSONDeserializer extends JSONDeserializer
 {

--- a/src/UDB2/DomainEvents/EventUpdatedJSONDeserializer.php
+++ b/src/UDB2/DomainEvents/EventUpdatedJSONDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventUpdatedJSONDeserializer extends JSONDeserializer
 {

--- a/src/UDB2/DomainEvents/HasActorIdTrait.php
+++ b/src/UDB2/DomainEvents/HasActorIdTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 trait HasActorIdTrait
 {

--- a/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
+++ b/src/UDB2/DomainEvents/HasAuthoringMetadataTrait.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use DateTimeInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 trait HasAuthoringMetadataTrait
 {

--- a/src/UDB2/DomainEvents/HasEventIdTrait.php
+++ b/src/UDB2/DomainEvents/HasEventIdTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 trait HasEventIdTrait
 {

--- a/src/UDB2/DomainEvents/ISO8601DateTimeDeserializer.php
+++ b/src/UDB2/DomainEvents/ISO8601DateTimeDeserializer.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use DateTimeImmutable;
 use DateTimeInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ISO8601DateTimeDeserializer
 {

--- a/src/UDB2/Event/EventCdbXmlEnricher.php
+++ b/src/UDB2/Event/EventCdbXmlEnricher.php
@@ -26,7 +26,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\UuidFactoryInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use XMLReader;
 
 /**

--- a/src/UDB2/Event/EventImporter.php
+++ b/src/UDB2/Event/EventImporter.php
@@ -28,7 +28,7 @@ use CultuurNet\UDB3\UDB2\OfferAlreadyImportedException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Applies incoming UDB2 events enriched with cdb xml towards UDB3 Offer.

--- a/src/UDB2/Event/EventXMLValidatorService.php
+++ b/src/UDB2/Event/EventXMLValidatorService.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UDB2\Event;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\UDB2\XML\XMLValidationError;
 use CultuurNet\UDB3\UDB2\XML\XMLValidationServiceInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventXMLValidatorService implements XMLValidationServiceInterface
 {

--- a/src/UDB2/Event/Events/EventCreatedEnrichedWithCdbXml.php
+++ b/src/UDB2/Event/Events/EventCreatedEnrichedWithCdbXml.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\UDB2\DomainEvents\EventCreated;
 use DateTimeImmutable;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCreatedEnrichedWithCdbXml extends EventCreated implements CdbXmlContainerInterface
 {

--- a/src/UDB2/Event/Events/EventUpdatedEnrichedWithCdbXml.php
+++ b/src/UDB2/Event/Events/EventUpdatedEnrichedWithCdbXml.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\HasCdbXmlTrait;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\UDB2\DomainEvents\EventUpdated;
 use DateTimeImmutable;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventUpdatedEnrichedWithCdbXml extends EventUpdated implements CdbXmlContainerInterface
 {

--- a/src/UDB2/Label/RelatedUDB3LabelApplier.php
+++ b/src/UDB2/Label/RelatedUDB3LabelApplier.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\LabelAwareAggregateRoot;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RelatedUDB3LabelApplier implements LabelApplierInterface
 {

--- a/src/UiTID/CdbXmlCreatedByToUserIdResolver.php
+++ b/src/UiTID/CdbXmlCreatedByToUserIdResolver.php
@@ -14,7 +14,7 @@ use InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CdbXmlCreatedByToUserIdResolver implements LoggerAwareInterface, CreatedByToUserIdResolverInterface
 {

--- a/src/UiTPAS/CardSystem/CardSystem.php
+++ b/src/UiTPAS/CardSystem/CardSystem.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\UiTPAS\CardSystem;
 
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CardSystem
 {

--- a/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
+++ b/src/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializer.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * Deserializes `application/vnd.cultuurnet.uitpas-events.event-card-systems-updated+json` messages

--- a/src/UiTPAS/ValueObject/Id.php
+++ b/src/UiTPAS/ValueObject/Id.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\ValueObject;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Id extends StringLiteral
 {

--- a/src/User/Auth0UserIdentityResolver.php
+++ b/src/User/Auth0UserIdentityResolver.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\User;
 
 use Auth0\SDK\API\Management;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class Auth0UserIdentityResolver implements UserIdentityResolver
 {

--- a/src/User/UserIdentityResolver.php
+++ b/src/User/UserIdentityResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\User;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 interface UserIdentityResolver
 {

--- a/src/ValueObject/MultilingualString.php
+++ b/src/ValueObject/MultilingualString.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\ValueObject;
 
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Translation\TranslatedValueObject;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -34,7 +34,6 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 {

--- a/tests/BookingInfoTest.php
+++ b/tests/BookingInfoTest.php
@@ -13,7 +13,6 @@ use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLabel;
 use CultuurNet\UDB3\Model\ValueObject\Web\WebsiteLink;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class BookingInfoTest extends TestCase
 {

--- a/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/CommandBusForwardingConsumerTest.php
@@ -13,7 +13,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CommandBusForwardingConsumerTest extends TestCase
 {

--- a/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
+++ b/tests/Broadway/AMQP/EventBusForwardingConsumerTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventBusForwardingConsumerTest extends TestCase
 {

--- a/tests/Curators/Events/NewsArticleAboutEventAddedJSONDeserializerTest.php
+++ b/tests/Curators/Events/NewsArticleAboutEventAddedJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Curators\PublisherName;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class NewsArticleAboutEventAddedJSONDeserializerTest extends TestCase
 {

--- a/tests/Curators/NewsArticleProcessManagerTest.php
+++ b/tests/Curators/NewsArticleProcessManagerTest.php
@@ -18,7 +18,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class NewsArticleProcessManagerTest extends TestCase
 {

--- a/tests/DescriptionJSONDeserializerTest.php
+++ b/tests/DescriptionJSONDeserializerTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class DescriptionJSONDeserializerTest extends TestCase
 {

--- a/tests/Deserializer/JSONDeserializerTest.php
+++ b/tests/Deserializer/JSONDeserializerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Deserializer;
 
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class JSONDeserializerTest extends TestCase
 {

--- a/tests/Deserializer/SimpleDeserializerLocatorTest.php
+++ b/tests/Deserializer/SimpleDeserializerLocatorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Deserializer;
 
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimpleDeserializerLocatorTest extends TestCase
 {

--- a/tests/Event/Commands/UpdateBookingInfoTest.php
+++ b/tests/Event/Commands/UpdateBookingInfoTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UpdateBookingInfoTest extends TestCase
 {

--- a/tests/Event/EventEditingServiceTest.php
+++ b/tests/Event/EventEditingServiceTest.php
@@ -28,7 +28,7 @@ use CultuurNet\UDB3\Title;
 use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class EventEditingServiceTest extends TestCase
 {

--- a/tests/Event/EventFacilityResolverTest.php
+++ b/tests/Event/EventFacilityResolverTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventFacilityResolverTest extends TestCase
 {

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -53,7 +53,7 @@ use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use RuntimeException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventTest extends AggregateRootScenarioTestCase
 {

--- a/tests/Event/EventThemeResolverTest.php
+++ b/tests/Event/EventThemeResolverTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Event;
 
 use CultuurNet\UDB3\Theme;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventThemeResolverTest extends TestCase
 {

--- a/tests/Event/Events/BookingInfoUpdatedTest.php
+++ b/tests/Event/Events/BookingInfoUpdatedTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class BookingInfoUpdatedTest extends TestCase
 {

--- a/tests/Event/Events/ImageUpdatedTest.php
+++ b/tests/Event/Events/ImageUpdatedTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Event\Events;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImageUpdatedTest extends TestCase
 {

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -85,7 +85,7 @@ use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class HistoryProjectorTest extends TestCase
 {

--- a/tests/Event/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Event/ReadModel/Permission/ProjectorTest.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsAsPDFJSONDeserializerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Subtitle;
 use CultuurNet\UDB3\EventExport\Format\HTML\Properties\Title;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ExportEventsAsPDFJSONDeserializerTest extends TestCase
 {

--- a/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
+++ b/tests/EventExport/Command/ExportEventsJSONDeserializerTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\EventExport\EventExportQuery;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ExportEventsJSONDeserializerTest extends TestCase
 {

--- a/tests/EventListener/ClassNameEventSpecificationTest.php
+++ b/tests/EventListener/ClassNameEventSpecificationTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Offer\Item\Events\LabelAdded;
 use CultuurNet\UDB3\Offer\Item\Events\LabelRemoved;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ClassNameEventSpecificationTest extends TestCase
 {

--- a/tests/Http/CommandDeserializerControllerTest.php
+++ b/tests/Http/CommandDeserializerControllerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CommandDeserializerControllerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Address/AddressJSONDeserializerTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AddressJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Calendar/CalendarJSONDeserializerTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Timestamp;
 use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CalendarJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/ContactPoint/ContactPointJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\ContactPoint;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\ContactPoint;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContactPointJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/CreateEventJSONDeserializerTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CreateEventJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Event/MajorInfoJSONDeserializerTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MajorInfoJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Organizer/UrlJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Organizer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UrlJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/CreatePlaceJSONDeserializerTest.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CreatePlaceJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Place/MajorInfoJSONDeserializerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MajorInfoJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/PriceInfo/PriceInfoJSONDeserializerTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PriceInfoJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/Role/QueryJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/Role/QueryJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer\Role;
 use CultuurNet\UDB3\Deserializer\DataValidationException;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class QueryJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Deserializer/TitleJSONDeserializerTest.php
+++ b/tests/Http/Deserializer/TitleJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Deserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class TitleJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Import/ImportLabelVisibilityRequestBodyParserTest.php
+++ b/tests/Http/Import/ImportLabelVisibilityRequestBodyParserTest.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportLabelVisibilityRequestBodyParserTest extends TestCase
 {

--- a/tests/Http/JSONLD/ContextControllerTest.php
+++ b/tests/Http/JSONLD/ContextControllerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\JSONLD;
 use CultuurNet\UDB3\HttpFoundation\Response\JsonLdResponse;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContextControllerTest extends TestCase
 {

--- a/tests/Http/Label/Query/QueryFactoryTest.php
+++ b/tests/Http/Label/Query/QueryFactoryTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Label\Query;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class QueryFactoryTest extends TestCase
 {

--- a/tests/Http/Label/ReadRestControllerTest.php
+++ b/tests/Http/Label/ReadRestControllerTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ReadRestControllerTest extends TestCase
 {

--- a/tests/Http/Media/ReadMediaRestControllerTest.php
+++ b/tests/Http/Media/ReadMediaRestControllerTest.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ReadMediaRestControllerTest extends TestCase
 {

--- a/tests/Http/Offer/EditOfferRestControllerTest.php
+++ b/tests/Http/Offer/EditOfferRestControllerTest.php
@@ -27,7 +27,7 @@ use Money\Money;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditOfferRestControllerTest extends TestCase
 {

--- a/tests/Http/Offer/OfferPermissionControllerTest.php
+++ b/tests/Http/Offer/OfferPermissionControllerTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferPermissionControllerTest extends TestCase
 {

--- a/tests/Http/Offer/OfferPermissionsControllerTest.php
+++ b/tests/Http/Offer/OfferPermissionsControllerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Http\Assert\JsonEquals;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferPermissionsControllerTest extends TestCase
 {

--- a/tests/Http/Offer/PatchOfferRestControllerTest.php
+++ b/tests/Http/Offer/PatchOfferRestControllerTest.php
@@ -20,7 +20,7 @@ use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PatchOfferRestControllerTest extends TestCase
 {

--- a/tests/Http/OfferRestBaseControllerTest.php
+++ b/tests/Http/OfferRestBaseControllerTest.php
@@ -19,7 +19,7 @@ use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferRestBaseControllerTest extends TestCase
 {

--- a/tests/Http/Organizer/AddImageRequestHandlerTest.php
+++ b/tests/Http/Organizer/AddImageRequestHandlerTest.php
@@ -23,7 +23,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Organizer\Commands\AddImage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class AddImageRequestHandlerTest extends TestCase
 {

--- a/tests/Http/Place/FacilitiesJSONDeserializerTest.php
+++ b/tests/Http/Place/FacilitiesJSONDeserializerTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Offer\OfferFacilityResolverInterface;
 use CultuurNet\UDB3\Place\PlaceFacilityResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class FacilitiesJSONDeserializerTest extends TestCase
 {

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -65,7 +65,7 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportPlaceRequestHandlerTest extends TestCase
 {

--- a/tests/Http/Proxy/CdbXmlProxyTest.php
+++ b/tests/Http/Proxy/CdbXmlProxyTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use Zend\Diactoros\Uri;
 
 class CdbXmlProxyTest extends TestCase

--- a/tests/Http/Proxy/Filter/AcceptFilterTest.php
+++ b/tests/Http/Proxy/Filter/AcceptFilterTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AcceptFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/AndFilterTest.php
+++ b/tests/Http/Proxy/Filter/AndFilterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AndFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/ContentTypeFilterTest.php
+++ b/tests/Http/Proxy/Filter/ContentTypeFilterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ContentTypeFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/HeaderFilterTest.php
+++ b/tests/Http/Proxy/Filter/HeaderFilterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class HeaderFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/MethodFilterTest.php
+++ b/tests/Http/Proxy/Filter/MethodFilterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MethodFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/OrFilterTest.php
+++ b/tests/Http/Proxy/Filter/OrFilterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OrFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/Filter/PreflightFilterTest.php
+++ b/tests/Http/Proxy/Filter/PreflightFilterTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Proxy\Filter;
 use CultuurNet\UDB3\Http\Proxy\FilterPathRegex;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PreflightFilterTest extends TestCase
 {

--- a/tests/Http/Proxy/FilterPathMethodProxyTest.php
+++ b/tests/Http/Proxy/FilterPathMethodProxyTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class FilterPathMethodProxyTest extends TestCase
 {

--- a/tests/Http/Role/EditRoleRestControllerTest.php
+++ b/tests/Http/Role/EditRoleRestControllerTest.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EditRoleRestControllerTest extends TestCase
 {

--- a/tests/Http/Role/ReadRoleRestControllerTest.php
+++ b/tests/Http/Role/ReadRoleRestControllerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 
 class ReadRoleRestControllerTest extends TestCase

--- a/tests/Http/SavedSearches/ReadSavedSearchesControllerTest.php
+++ b/tests/Http/SavedSearches/ReadSavedSearchesControllerTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ReadSavedSearchesControllerTest extends TestCase
 {

--- a/tests/Http/User/UserIdentityControllerTest.php
+++ b/tests/Http/User/UserIdentityControllerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Psr7\Headers;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 use Zend\Diactoros\ServerRequest;
 
 class UserIdentityControllerTest extends TestCase

--- a/tests/Label/ReadModels/Doctrine/AbstractDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/Doctrine/AbstractDBALRepositoryTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractDBALRepositoryTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/ItemVisibilityProjectorTest.php
+++ b/tests/Label/ReadModels/JSON/ItemVisibilityProjectorTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ItemVisibilityProjectorTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/ProjectorTest.php
+++ b/tests/Label/ReadModels/JSON/ProjectorTest.php
@@ -31,7 +31,7 @@ use CultuurNet\UDB3\Place\Events\LabelAdded as LabelAddedToPlace;
 use CultuurNet\UDB3\Place\Events\LabelRemoved as LabelRemovedFromPlace;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecoratorTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/BroadcastingWriteRepositoryDecoratorTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class BroadcastingWriteRepositoryDecoratorTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class BaseDBALRepositoryTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as PermissionsSchemaConfigurator;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class DBALReadRepositoryTest extends BaseDBALRepositoryTest
 {

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALWriteRepositoryTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepositoryTest extends BaseDBALRepositoryTest
 {

--- a/tests/Label/ReadModels/JSON/Repository/EntityTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/EntityTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EntityTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecoratorTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecoratorTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class GodUserReadRepositoryDecoratorTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/QueryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/QueryTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\JSON\Repository;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class QueryTest extends TestCase
 {

--- a/tests/Label/ReadModels/JSON/Repository/SimilaritySorterTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/SimilaritySorterTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimilaritySorterTest extends TestCase
 {

--- a/tests/Label/ReadModels/Relations/ProjectorTest.php
+++ b/tests/Label/ReadModels/Relations/ProjectorTest.php
@@ -38,7 +38,7 @@ use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Place\Events\PlaceUpdatedFromUDB2;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/BaseDBALRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/BaseDBALRepositoryTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine;
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 abstract class BaseDBALRepositoryTest extends TestCase
 {

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Label\ReadModels\Relations\Repository\Doctrine;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALReadRepositoryTest extends BaseDBALRepositoryTest
 {

--- a/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/Doctrine/DBALWriteRepositoryTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALWriteRepositoryTest extends BaseDBALRepositoryTest
 {

--- a/tests/Label/ReadModels/Relations/Repository/OfferLabelRelationTest.php
+++ b/tests/Label/ReadModels/Relations/Repository/OfferLabelRelationTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Label\ValueObjects\RelationType;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferLabelRelationTest extends TestCase
 {

--- a/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
+++ b/tests/Label/ReadModels/Roles/Doctrine/LabelRolesWriteRepositoryTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Label\ReadModels\Roles\LabelRolesWriteRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelRolesWriteRepositoryTest extends TestCase
 {

--- a/tests/Label/Services/ReadServiceTest.php
+++ b/tests/Label/Services/ReadServiceTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ReadServiceTest extends TestCase
 {

--- a/tests/LabelJSONDeserializerTest.php
+++ b/tests/LabelJSONDeserializerTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
 
 class LabelJSONDeserializerTest extends TestCase
 {

--- a/tests/Media/Commands/UploadImageTest.php
+++ b/tests/Media/Commands/UploadImageTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UploadImageTest extends TestCase
 {

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImageUploaderServiceTest extends TestCase
 {

--- a/tests/Media/MediaManagerTest.php
+++ b/tests/Media/MediaManagerTest.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MediaManagerTest extends TestCase
 {

--- a/tests/Media/MediaObjectCreatedTest.php
+++ b/tests/Media/MediaObjectCreatedTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MediaObjectCreatedTest extends TestCase
 {

--- a/tests/Media/MediaObjectTest.php
+++ b/tests/Media/MediaObjectTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MediaObjectTest extends AggregateRootScenarioTestCase
 {

--- a/tests/Media/SimplePathGeneratorTest.php
+++ b/tests/Media/SimplePathGeneratorTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SimplePathGeneratorTest extends TestCase
 {

--- a/tests/Model/Import/Command/Deserializer/ImportEventDocumentDeserializerTest.php
+++ b/tests/Model/Import/Command/Deserializer/ImportEventDocumentDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Import\Command\Deserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\Import\Command\ImportEventDocument;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportEventDocumentDeserializerTest extends TestCase
 {

--- a/tests/Model/Import/Command/Deserializer/ImportOrganizerDocumentDeserializerTest.php
+++ b/tests/Model/Import/Command/Deserializer/ImportOrganizerDocumentDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Import\Command\Deserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\Import\Command\ImportOrganizerDocument;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportOrganizerDocumentDeserializerTest extends TestCase
 {

--- a/tests/Model/Import/Command/Deserializer/ImportPlaceDocumentDeserializerTest.php
+++ b/tests/Model/Import/Command/Deserializer/ImportPlaceDocumentDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Model\Import\Command\Deserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\Import\Command\ImportPlaceDocument;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportPlaceDocumentDeserializerTest extends TestCase
 {

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -50,7 +50,7 @@ use DateTimeImmutable;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Udb3ModelToLegacyOfferAdapterTest extends TestCase
 {

--- a/tests/Model/Import/PreProcessing/LabelPreProcessingDocumentImporterTest.php
+++ b/tests/Model/Import/PreProcessing/LabelPreProcessingDocumentImporterTest.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelPreProcessingDocumentImporterTest extends TestCase
 {

--- a/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
+++ b/tests/Model/Import/Taxonomy/Label/RelationshipModelLockedLabelRepositoryTest.php
@@ -13,7 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class RelationshipModelLockedLabelRepositoryTest extends TestCase
 {

--- a/tests/Model/Import/Validation/MediaObject/MediaObjectsExistValidatorTest.php
+++ b/tests/Model/Import/Validation/MediaObject/MediaObjectsExistValidatorTest.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\GroupedValidationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MediaObjectsExistValidatorTest extends TestCase
 {

--- a/tests/Model/Import/Validation/Taxonomy/Label/DocumentLabelPermissionRuleTest.php
+++ b/tests/Model/Import/Validation/Taxonomy/Label/DocumentLabelPermissionRuleTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Model\Event\EventIDParser;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DocumentLabelPermissionRuleTest extends TestCase
 {

--- a/tests/Model/Import/Validation/Taxonomy/Label/LabelPermissionRuleTest.php
+++ b/tests/Model/Import/Validation/Taxonomy/Label/LabelPermissionRuleTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class LabelPermissionRuleTest extends TestCase
 {

--- a/tests/Offer/AvailableToTest.php
+++ b/tests/Offer/AvailableToTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Timestamp;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AvailableToTest extends TestCase
 {

--- a/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
+++ b/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
@@ -29,7 +29,7 @@ use CultuurNet\UDB3\Place\PlaceRepository;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Offer/CommandHandlers/ChangeOwnerHandlerTest.php
+++ b/tests/Offer/CommandHandlers/ChangeOwnerHandlerTest.php
@@ -23,7 +23,7 @@ use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
 use CultuurNet\UDB3\Place\PlaceRepository;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ChangeOwnerHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Offer/CommandHandlers/UpdateAvailableFromHandlerTest.php
+++ b/tests/Offer/CommandHandlers/UpdateAvailableFromHandlerTest.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Place\PlaceRepository;
 use CultuurNet\UDB3\Title;
 use DateTimeImmutable;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class UpdateAvailableFromHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Offer/Commands/AbstractLabelCommandTest.php
+++ b/tests/Offer/Commands/AbstractLabelCommandTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractLabelCommandTest extends TestCase
 {

--- a/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
+++ b/tests/Offer/Commands/AbstractUpdateBookingInfoTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractUpdateBookingInfoTest extends TestCase
 {

--- a/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\Offer\OfferType;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AddLabelToMultipleJSONDeserializerTest extends TestCase
 {

--- a/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Offer\Commands;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Label;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AddLabelToQueryJSONDeserializerTest extends TestCase
 {

--- a/tests/Offer/Commands/Moderation/AbstractRejectTest.php
+++ b/tests/Offer/Commands/Moderation/AbstractRejectTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands\Moderation;
 
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractRejectTest extends AbstractModerationCommandTestBase
 {

--- a/tests/Offer/Events/AbstractBookingInfoEventTest.php
+++ b/tests/Offer/Events/AbstractBookingInfoEventTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractBookingInfoEventTest extends TestCase
 {

--- a/tests/Offer/Events/Moderation/AbstractRejectedTest.php
+++ b/tests/Offer/Events/Moderation/AbstractRejectedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer\Events\Moderation;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractRejectedTest extends TestCase
 {

--- a/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
+++ b/tests/Offer/IriOfferIdentifierJSONDeserializerTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Deserializer\NotWellFormedException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class IriOfferIdentifierJSONDeserializerTest extends TestCase
 {

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -63,7 +63,7 @@ use CultuurNet\UDB3\PriceInfo\PriceInfo;
 use CultuurNet\UDB3\Title;
 use DateTimeInterface;
 use RuntimeException;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 /**
  * @deprecated

--- a/tests/Offer/OfferCommandHandlerTest.php
+++ b/tests/Offer/OfferCommandHandlerTest.php
@@ -37,7 +37,7 @@ use CultuurNet\UDB3\Title;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\MockObject\MockObject;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -59,7 +59,7 @@ use CultuurNet\UDB3\Offer\Item\Item;
 use CultuurNet\UDB3\Title;
 use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Exception;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferTest extends AggregateRootScenarioTestCase
 {

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -68,7 +68,7 @@ use Money\Money;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class OfferLDProjectorTest extends TestCase
 {

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -21,7 +21,6 @@ use CultuurNet\UDB3\Offer\Item\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Organizer\Organizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionObject;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * Provides a trait to test commands that are applicable for all UDB3 offer types

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -22,7 +22,6 @@ use CultuurNet\UDB3\ValueObject\MultilingualString;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use ValueObjects\StringLiteral\StringLiteral;
 
 /**
  * Base test  case class for testing common Offer JSON-LD projector

--- a/tests/Organizer/CommandHandler/ImportLabelsHandlerTest.php
+++ b/tests/Organizer/CommandHandler/ImportLabelsHandlerTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Organizer\Events\LabelsImported;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\OrganizerRepository;
 use PHPUnit\Framework\MockObject\MockObject;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Organizer/Commands/AbstractLabelCommandTest.php
+++ b/tests/Organizer/Commands/AbstractLabelCommandTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractLabelCommandTest extends TestCase
 {

--- a/tests/Organizer/Commands/ImportLabelsTest.php
+++ b/tests/Organizer/Commands/ImportLabelsTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ImportLabelsTest extends TestCase
 {

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -53,7 +53,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\RecordedOn;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 final class OrganizerLDProjectorTest extends TestCase
 {

--- a/tests/Place/PlaceFacilityResolverTest.php
+++ b/tests/Place/PlaceFacilityResolverTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place;
 
 use CultuurNet\UDB3\Facility;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PlaceFacilityResolverTest extends TestCase
 {

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -45,7 +45,7 @@ use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use Ramsey\Uuid\Uuid;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PlaceTest extends AggregateRootScenarioTestCase
 {

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -84,7 +84,7 @@ use DateTimeInterface;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class HistoryProjectorTest extends TestCase
 {

--- a/tests/Place/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Place/ReadModel/Permission/ProjectorTest.php
@@ -23,7 +23,7 @@ use CultuurNet\UDB3\Place\Events\PlaceImportedFromUDB2;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -12,7 +12,7 @@ use CultuurNet\UDB3\ValueObject\MultilingualString;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PriceInfoTest extends TestCase
 {

--- a/tests/Role/CommandHandlerTest.php
+++ b/tests/Role/CommandHandlerTest.php
@@ -34,7 +34,7 @@ use CultuurNet\UDB3\Role\Events\UserAdded;
 use CultuurNet\UDB3\Role\Events\UserRemoved;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CommandHandlerTest extends CommandHandlerScenarioTestCase
 {

--- a/tests/Role/Commands/AbstractUserCommandTest.php
+++ b/tests/Role/Commands/AbstractUserCommandTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\Commands;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractUserCommandTest extends TestCase
 {

--- a/tests/Role/Commands/AddUserTest.php
+++ b/tests/Role/Commands/AddUserTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AddUserTest extends TestCase
 {

--- a/tests/Role/Commands/CreateRoleTest.php
+++ b/tests/Role/Commands/CreateRoleTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CreateRoleTest extends TestCase
 {

--- a/tests/Role/Commands/RemoveUserTest.php
+++ b/tests/Role/Commands/RemoveUserTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RemoveUserTest extends TestCase
 {

--- a/tests/Role/Commands/RenameRoleTest.php
+++ b/tests/Role/Commands/RenameRoleTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RenameRoleTest extends TestCase
 {

--- a/tests/Role/Commands/UpdateRoleRequestDeserializerTest.php
+++ b/tests/Role/Commands/UpdateRoleRequestDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\MissingContentTypeException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UpdateRoleRequestDeserializerTest extends TestCase
 {

--- a/tests/Role/Events/AbstractUserEventTest.php
+++ b/tests/Role/Events/AbstractUserEventTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Role\Events;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class AbstractUserEventTest extends TestCase
 {

--- a/tests/Role/Events/RoleCreatedTest.php
+++ b/tests/Role/Events/RoleCreatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RoleCreatedTest extends TestCase
 {

--- a/tests/Role/Events/RoleRenamedTest.php
+++ b/tests/Role/Events/RoleRenamedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RoleRenamedTest extends TestCase
 {

--- a/tests/Role/Events/UserAddedTest.php
+++ b/tests/Role/Events/UserAddedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserAddedTest extends TestCase
 {

--- a/tests/Role/Events/UserRemovedTest.php
+++ b/tests/Role/Events/UserRemovedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserRemovedTest extends TestCase
 {

--- a/tests/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepositoryTest.php
+++ b/tests/Role/ReadModel/Constraints/Doctrine/UserConstraintsReadRepositoryTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\Role\ReadModel\Permissions\Doctrine\SchemaConfigurator as Pe
 use CultuurNet\UDB3\Role\ReadModel\Search\Doctrine\SchemaConfigurator as SearchSchemaConfigurator;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserConstraintsReadRepositoryTest extends TestCase
 {

--- a/tests/Role/ReadModel/Detail/ProjectorTest.php
+++ b/tests/Role/ReadModel/Detail/ProjectorTest.php
@@ -23,7 +23,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
+++ b/tests/Role/ReadModel/Labels/RoleLabelsProjectorTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Role\Events\RoleCreated;
 use CultuurNet\UDB3\Role\Events\RoleDeleted;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RoleLabelsProjectorTest extends TestCase
 {

--- a/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepositoryTest.php
+++ b/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsReadRepositoryTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\DBALTestConnectionTrait;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsReadRepositoryTest extends TestCase
 {

--- a/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepositoryTest.php
+++ b/tests/Role/ReadModel/Permissions/Doctrine/UserPermissionsWriteRepositoryTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsWriteRepositoryInterface;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsWriteRepositoryTest extends TestCase
 {

--- a/tests/Role/ReadModel/Permissions/UserPermissionsProjectorTest.php
+++ b/tests/Role/ReadModel/Permissions/UserPermissionsProjectorTest.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Role\Events\UserRemoved;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionsProjectorTest extends TestCase
 {

--- a/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
+++ b/tests/Role/ReadModel/Search/Doctrine/DBALRepositoryTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Role\ReadModel\Search\Doctrine;
 
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALRepositoryTest extends TestCase
 {

--- a/tests/Role/ReadModel/Search/ProjectorTest.php
+++ b/tests/Role/ReadModel/Search/ProjectorTest.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\Role\Events\RoleDeleted;
 use CultuurNet\UDB3\Role\Events\RoleRenamed;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ProjectorTest extends TestCase
 {

--- a/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
+++ b/tests/Role/ReadModel/Users/RoleUsersProjectorTest.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\User\UserIdentityDetails;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RoleUsersProjectorTest extends TestCase
 {

--- a/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
+++ b/tests/Role/ReadModel/Users/UserRolesProjectorTest.php
@@ -18,7 +18,7 @@ use CultuurNet\UDB3\Role\Events\UserRemoved;
 use CultuurNet\UDB3\User\UserIdentityDetails;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserRolesProjectorTest extends TestCase
 {

--- a/tests/Role/RoleTest.php
+++ b/tests/Role/RoleTest.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Role\Events\RoleCreated;
 use CultuurNet\UDB3\Role\Events\RoleRenamed;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RoleTest extends AggregateRootScenarioTestCase
 {

--- a/tests/Role/Services/DefaultRoleEditingServiceTest.php
+++ b/tests/Role/Services/DefaultRoleEditingServiceTest.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Role\ValueObjects\Query;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DefaultRoleEditingServiceTest extends TestCase
 {

--- a/tests/SavedSearches/CombinedSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/CombinedSavedSearchRepositoryTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearchRepositoryInterface;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CombinedSavedSearchRepositoryTest extends TestCase
 {

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchJSONDeserializerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SavedSearches\Command;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SubscribeToSavedSearchJSONDeserializerTest extends TestCase
 {

--- a/tests/SavedSearches/Command/SubscribeToSavedSearchTest.php
+++ b/tests/SavedSearches/Command/SubscribeToSavedSearchTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\SavedSearches\Command;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SubscribeToSavedSearchTest extends TestCase
 {

--- a/tests/SavedSearches/Command/UnsubscribeFromSavedSearchTest.php
+++ b/tests/SavedSearches/Command/UnsubscribeFromSavedSearchTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\SavedSearches\Command;
 
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UnsubscribeFromSavedSearchTest extends TestCase
 {

--- a/tests/SavedSearches/ReadModel/SavedSearchTest.php
+++ b/tests/SavedSearches/ReadModel/SavedSearchTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\SavedSearches\ReadModel;
 
 use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class SavedSearchTest extends TestCase
 {

--- a/tests/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/Sapi3FixedSavedSearchRepositoryTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use CultuurNet\UDB3\SavedSearches\ValueObject\CreatedByQueryMode;
 use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Sapi3FixedSavedSearchRepositoryTest extends TestCase
 {

--- a/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchRepositoryTest.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\ReadModel\SavedSearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UDB3SavedSearchRepositoryTest extends TestCase
 {

--- a/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
+++ b/tests/SavedSearches/UDB3SavedSearchesCommandHandlerTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\SavedSearches\Properties\QueryString;
 use CultuurNet\UDB3\SavedSearches\WriteModel\SavedSearchRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UDB3SavedSearchesCommandHandlerTest extends TestCase
 {

--- a/tests/Security/CommandAuthorizationExceptionTest.php
+++ b/tests/Security/CommandAuthorizationExceptionTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Security;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CommandAuthorizationExceptionTest extends TestCase
 {

--- a/tests/Security/Permission/PermissionSwitchVoterTest.php
+++ b/tests/Security/Permission/PermissionSwitchVoterTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\Permission;
 
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class PermissionSwitchVoterTest extends TestCase
 {

--- a/tests/Security/Permission/UserPermissionVoterTest.php
+++ b/tests/Security/Permission/UserPermissionVoterTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Role\ReadModel\Permissions\UserPermissionsReadRepositoryInte
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class UserPermissionVoterTest extends TestCase
 {

--- a/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
+++ b/tests/Security/ResourceOwner/CombinedResourceOwnerQueryTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\ResourceOwner;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CombinedResourceOwnerQueryTest extends TestCase
 {

--- a/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
+++ b/tests/Security/ResourceOwner/Doctrine/DBALResourceOwnerRepositoryTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Security\ResourceOwner\Doctrine;
 
 use CultuurNet\UDB3\DBALTestConnectionTrait;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class DBALResourceOwnerRepositoryTest extends TestCase
 {

--- a/tests/Security/Sapi3RoleConstraintVoterTest.php
+++ b/tests/Security/Sapi3RoleConstraintVoterTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Uri;
 use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Sapi3RoleConstraintVoterTest extends TestCase
 {

--- a/tests/UDB2/Actor/ActorEventCdbXmlEnricherTest.php
+++ b/tests/UDB2/Actor/ActorEventCdbXmlEnricherTest.php
@@ -22,7 +22,7 @@ use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorEventCdbXmlEnricherTest extends TestCase
 {

--- a/tests/UDB2/Actor/Events/ActorCreatedEnrichedWithCdbXmlTest.php
+++ b/tests/UDB2/Actor/Events/ActorCreatedEnrichedWithCdbXmlTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\Actor\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorCreatedEnrichedWithCdbXmlTest extends TestCase
 {

--- a/tests/UDB2/Actor/Events/ActorUpdatedEnrichedWithCdbXmlTest.php
+++ b/tests/UDB2/Actor/Events/ActorUpdatedEnrichedWithCdbXmlTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\Actor\Events;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorUpdatedEnrichedWithCdbXmlTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/ActorCreatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/ActorCreatedJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorCreatedJSONDeserializerTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/ActorCreatedTest.php
+++ b/tests/UDB2/DomainEvents/ActorCreatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorCreatedTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/ActorUpdatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/ActorUpdatedJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorUpdatedJSONDeserializerTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/ActorUpdatedTest.php
+++ b/tests/UDB2/DomainEvents/ActorUpdatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class ActorUpdatedTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/EventCreatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/EventCreatedJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCreatedJSONDeserializerTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/EventCreatedTest.php
+++ b/tests/UDB2/DomainEvents/EventCreatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCreatedTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/EventUpdatedJSONDeserializerTest.php
+++ b/tests/UDB2/DomainEvents/EventUpdatedJSONDeserializerTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventUpdatedJSONDeserializerTest extends TestCase
 {

--- a/tests/UDB2/DomainEvents/EventUpdatedTest.php
+++ b/tests/UDB2/DomainEvents/EventUpdatedTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\DomainEvents;
 
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventUpdatedTest extends TestCase
 {

--- a/tests/UDB2/Event/EventCdbXmlEnricherTest.php
+++ b/tests/UDB2/Event/EventCdbXmlEnricherTest.php
@@ -22,7 +22,7 @@ use Http\Client\HttpClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidFactory;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCdbXmlEnricherTest extends TestCase
 {

--- a/tests/UDB2/Event/EventXMLValidatorServiceTest.php
+++ b/tests/UDB2/Event/EventXMLValidatorServiceTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UDB2\Event;
 
 use CultuurNet\UDB3\UDB2\XML\XMLValidationError;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventXMLValidatorServiceTest extends TestCase
 {

--- a/tests/UDB2/Label/RelatedUDB3LabelApplierTest.php
+++ b/tests/UDB2/Label/RelatedUDB3LabelApplierTest.php
@@ -22,7 +22,7 @@ use CultuurNet\UDB3\Place\Place;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class RelatedUDB3LabelApplierTest extends TestCase
 {

--- a/tests/UiTID/CdbXmlCreatedByToUserIdResolverTest.php
+++ b/tests/UiTID/CdbXmlCreatedByToUserIdResolverTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\User\UserIdentityResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class CdbXmlCreatedByToUserIdResolverTest extends TestCase
 {

--- a/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/EventCardSystemsUpdatedDeserializerTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\UiTPAS\Event\Event;
 
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventCardSystemsUpdatedDeserializerTest extends TestCase
 {

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -16,7 +16,7 @@ use CultuurNet\UDB3\UiTPAS\Label\UiTPASLabelsRepository;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class EventProcessManagerTest extends TestCase
 {

--- a/tests/UiTPAS/ValueObject/IdTest.php
+++ b/tests/UiTPAS/ValueObject/IdTest.php
@@ -43,27 +43,4 @@ class IdTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         new Id('    ');
     }
-
-    /**
-     * @test
-     * @dataProvider emptyScalarValueDataProvider
-     *
-     */
-    public function it_should_throw_an_exception_for_a_casted_variable_that_evaluates_to_an_empty_string($emptyValue)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        new Id($emptyValue);
-    }
-
-    /**
-     * @return array
-     */
-    public function emptyScalarValueDataProvider()
-    {
-        return [
-            ['id' => 0],
-            ['id' => null],
-            ['id' => false],
-        ];
-    }
 }

--- a/tests/User/Auth0UserIdentityResolverTest.php
+++ b/tests/User/Auth0UserIdentityResolverTest.php
@@ -9,7 +9,7 @@ use Auth0\SDK\API\Management\Users;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\User\Auth0UserIdentityResolver;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class Auth0UserIdentityResolverTest extends TestCase
 {

--- a/tests/ValueObject/MultilingualStringTest.php
+++ b/tests/ValueObject/MultilingualStringTest.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
 use CultuurNet\UDB3\Model\ValueObject\Price\TariffName;
 use CultuurNet\UDB3\Model\ValueObject\Price\TranslatedTariffName;
 use PHPUnit\Framework\TestCase;
-use ValueObjects\StringLiteral\StringLiteral;
+use CultuurNet\UDB3\StringLiteral;
 
 class MultilingualStringTest extends TestCase
 {


### PR DESCRIPTION
### Changed
- Include `StringLiteral` inside UDB3

### Removed
- Remove the `ValueObjects\Number\Integer` dependency

---
Ticket: https://jira.uitdatabank.be/browse/III-4539
