### PR TITLE
III-4594 Broken contactpoints problems

### DIFF
--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -11,8 +11,6 @@ use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\UpdateableWithCdbXmlInterface;
 use CultuurNet\UDB3\LabelAwareAggregateRoot;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
-use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
-use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
@@ -29,10 +27,7 @@ use CultuurNet\UDB3\Model\ValueObject\Text\Description;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedDescription;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
-use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
-use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
-use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
@@ -101,7 +96,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         $this->contactPoint = [
             'phone' => [],
             'email' => [],
-            'url' => []
+            'url' => [],
         ];
         $this->images = new Images();
         $this->labels = new Labels();

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Organizer\Events\AddressRemoved;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
@@ -374,6 +375,45 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     new ContactPointUpdated($this->id, ['0444/444444']),
                     new ContactPointUpdated($this->id, ['0455/454545'], ['foo@bar.com']),
                     new ContactPointUpdated($this->id),
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_broken_contactpoints(): void
+    {
+        $this->scenario
+            ->given(
+                [
+                    $this->organizerCreatedWithUniqueWebsite,
+                    new ContactPointUpdated(
+                        $this->id,
+                        [],
+                        ['broken@email'],
+                        ['htps://.broken-site']
+                    ),
+                ]
+            )
+            ->when(
+                function (Organizer $organizer) {
+                    $organizer->updateContactPoint(
+                        new ContactPoint(
+                            new TelephoneNumbers(),
+                            new EmailAddresses(
+                                new EmailAddress('fixed@email.be')
+                            ),
+                            new Urls(
+                                new Url('https://fixed-site.be')
+                            )
+                        )
+                    );
+                }
+            )
+            ->then(
+                [
+                    new ContactPointUpdated($this->id, [], ['fixed@email.be'], ['https://fixed-site.be'])
                 ]
             );
     }

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -413,7 +413,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
             )
             ->then(
                 [
-                    new ContactPointUpdated($this->id, [], ['fixed@email.be'], ['https://fixed-site.be'])
+                    new ContactPointUpdated($this->id, [], ['fixed@email.be'], ['https://fixed-site.be']),
                 ]
             );
     }


### PR DESCRIPTION
### Changed

- Changed the aggregate `Organizer` to store the ContactPoint as `StringArray`

### Fixed

- Fixed the comparison of `ContactPoint` when an old `ContactPoint` was broken, so that `ContactPoint` can be updated.

---
Ticket: https://jira.uitdatabank.be/browse/III-4594
