### PR TITLE
III-4567 Refactor place labels importing

### DIFF
--- a/app/Event/EventImportServiceProvider.php
+++ b/app/Event/EventImportServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Event;
 
-use CultuurNet\UDB3\Model\Event\EventIDParser;
 use CultuurNet\UDB3\Model\Import\Event\EventDocumentImporter;
 use CultuurNet\UDB3\Model\Import\Event\EventCategoryResolver;
 use CultuurNet\UDB3\Model\Import\PreProcessing\LabelPreProcessingDocumentImporter;
@@ -27,13 +26,7 @@ class EventImportServiceProvider implements ServiceProviderInterface
         $app['event_denormalizer'] = $app->share(
             function (Application $app) {
                 return new EventDenormalizer(
-                    new EventImportValidator(
-                        $app['place_jsonld_repository'],
-                        new EventIDParser(),
-                        $app['current_user_id'],
-                        $app[LabelServiceProvider::JSON_READ_REPOSITORY],
-                        $app[LabelServiceProvider::RELATIONS_READ_REPOSITORY]
-                    )
+                    new EventImportValidator($app['place_jsonld_repository'])
                 );
             }
         );

--- a/app/Offer/OfferServiceProvider.php
+++ b/app/Offer/OfferServiceProvider.php
@@ -155,7 +155,10 @@ class OfferServiceProvider implements ServiceProviderInterface
             function (Application $app) {
                 return new ImportLabelsHandler(
                     $app[OfferRepository::class],
-                    $app['labels.constraint_aware_service']
+                    $app['labels.constraint_aware_service'],
+                    $app[LabelServiceProvider::JSON_READ_REPOSITORY],
+                    $app['labels.labels_locked_for_import_repository'],
+                    $app['current_user_id']
                 );
             }
         );

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Place;
 
-use CultuurNet\UDB3\Http\Import\ImportLabelVisibilityRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
 use CultuurNet\UDB3\Http\Place\ImportPlaceRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler;
 use CultuurNet\UDB3\Http\Place\EditPlaceRestController;
-use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Model\Import\Place\PlaceCategoryResolver;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
-use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
@@ -76,15 +73,7 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
                 $app['place_repository'],
                 $app['uuid_generator'],
                 new PlaceDenormalizer(),
-                new CombinedRequestBodyParser(
-                    new ImportLabelVisibilityRequestBodyParser(
-                        $app[LabelServiceProvider::JSON_READ_REPOSITORY],
-                        $app[LabelServiceProvider::RELATIONS_READ_REPOSITORY]
-                    ),
-                    new ImportTermRequestBodyParser(
-                        new PlaceCategoryResolver()
-                    )
-                ),
+                new ImportTermRequestBodyParser(new PlaceCategoryResolver()),
                 $app['place_iri_generator'],
                 $app['imports_command_bus'],
                 $app['import_image_collection_factory'],

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
 use CultuurNet\UDB3\Http\Place\ImportPlaceRequestHandler;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler;
 use CultuurNet\UDB3\Http\Place\EditPlaceRestController;
+use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Model\Import\Place\PlaceCategoryResolver;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use Silex\Application;
@@ -73,7 +74,9 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
                 $app['place_repository'],
                 $app['uuid_generator'],
                 new PlaceDenormalizer(),
-                new ImportTermRequestBodyParser(new PlaceCategoryResolver()),
+                new CombinedRequestBodyParser(
+                    new ImportTermRequestBodyParser(new PlaceCategoryResolver())
+                ),
                 $app['place_iri_generator'],
                 $app['imports_command_bus'],
                 $app['import_image_collection_factory'],

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -88,7 +88,6 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
                 $app['place_iri_generator'],
                 $app['imports_command_bus'],
                 $app['import_image_collection_factory'],
-                $app['labels.labels_locked_for_import_repository'],
                 $app['should_auto_approve_new_offer'],
                 $app['auth.api_key_reader'],
                 $app['auth.consumer_repository']

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -26,7 +26,6 @@ use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\Import\MediaObject\ImageCollectionFactory;
 use CultuurNet\UDB3\Model\Import\Place\Udb3ModelToLegacyPlaceAdapter;
-use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\Place\Place;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
 use CultuurNet\UDB3\Offer\Commands\UpdateCalendar;
@@ -69,8 +68,6 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
 
     private ConsumerSpecificationInterface $shouldApprove;
 
-    private LockedLabelRepository $lockedLabelRepository;
-
     private ApiKeyReaderInterface $apiKeyReader;
 
     private ConsumerReadRepositoryInterface $consumerReadRepository;
@@ -83,7 +80,6 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         IriGeneratorInterface $iriGenerator,
         CommandBus $commandBus,
         ImageCollectionFactory $imageCollectionFactory,
-        LockedLabelRepository $lockedLabelRepository,
         ConsumerSpecificationInterface $shouldApprove,
         ApiKeyReaderInterface $apiKeyReader,
         ConsumerReadRepositoryInterface $consumerReadRepository
@@ -95,7 +91,6 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         $this->iriGenerator = $iriGenerator;
         $this->commandBus = $commandBus;
         $this->imageCollectionFactory = $imageCollectionFactory;
-        $this->lockedLabelRepository = $lockedLabelRepository;
         $this->shouldApprove = $shouldApprove;
         $this->apiKeyReader = $apiKeyReader;
         $this->consumerReadRepository = $consumerReadRepository;
@@ -236,9 +231,7 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
             $commands[] = new UpdateAddress($placeId, $address, $language);
         }
 
-        $lockedLabels = $this->lockedLabelRepository->getLockedLabelsForItem($placeId);
-        $commands[] = (new ImportLabels($placeId, $place->getLabels()))
-            ->withLabelsToKeepIfAlreadyOnOffer($lockedLabels);
+        $commands[] = new ImportLabels($placeId, $place->getLabels());
 
         $images = $this->imageCollectionFactory->fromMediaObjectReferences($place->getMediaObjectReferences());
         $commands[] = new ImportImages($placeId, $images);

--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -191,11 +191,7 @@ class EventDocumentImporter implements DocumentImporterInterface
 
         $commands[] = new ImportVideos($id, $import->getVideos());
 
-        $lockedLabels = $this->lockedLabelRepository->getLockedLabelsForItem($id);
-        $unlockedLabels = $this->lockedLabelRepository->getUnlockedLabelsForItem($id);
-        $commands[] = (new ImportLabels($id, $import->getLabels()))
-            ->withLabelsToKeepIfAlreadyOnOffer($lockedLabels)
-            ->withLabelsToRemoveWhenOnOffer($unlockedLabels);
+        $commands[] = new ImportLabels($id, $import->getLabels());
 
         // Update the organizer only at the end, because it can trigger UiTPAS to send messages to another worker
         // which might cause race conditions if we're still dispatching other commands here as well.

--- a/src/Model/Import/Validation/Event/EventImportValidator.php
+++ b/src/Model/Import/Validation/Event/EventImportValidator.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Model\Import\Validation\Place\PlaceReferenceExistsValidator;
 use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\CategoriesExistValidator;
 use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\EventTypeCountValidator;
 use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\ThemeCountValidator;
-use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Label\DocumentLabelPermissionRule;
 use CultuurNet\UDB3\Model\Place\PlaceIDParser;
 use CultuurNet\UDB3\Model\Validation\Event\EventValidator;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
@@ -44,12 +43,6 @@ class EventImportValidator extends EventValidator
                     new ThemeCountValidator()
                 ),
                 false
-            ),
-            new DocumentLabelPermissionRule(
-                $uuidParser,
-                $userId,
-                $labelsRepository,
-                $labelRelationsRepository
             ),
         ];
 

--- a/src/Model/Import/Validation/Event/EventImportValidator.php
+++ b/src/Model/Import/Validation/Event/EventImportValidator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\Validation\Event;
 
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface as LabelsRepository;
-use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface as LabelRelationsRepository;
 use CultuurNet\UDB3\Model\Import\Event\EventCategoryResolver;
 use CultuurNet\UDB3\Model\Import\Validation\Place\PlaceReferenceExistsValidator;
 use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\CategoriesExistValidator;
@@ -13,20 +11,14 @@ use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\EventTypeCountVali
 use CultuurNet\UDB3\Model\Import\Validation\Taxonomy\Category\ThemeCountValidator;
 use CultuurNet\UDB3\Model\Place\PlaceIDParser;
 use CultuurNet\UDB3\Model\Validation\Event\EventValidator;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\Key;
 
 class EventImportValidator extends EventValidator
 {
-    public function __construct(
-        DocumentRepository $placeRepository,
-        UUIDParser $uuidParser,
-        string $userId,
-        LabelsRepository $labelsRepository,
-        LabelRelationsRepository $labelRelationsRepository
-    ) {
+    public function __construct(DocumentRepository $placeRepository)
+    {
         $extraRules = [
             new Key(
                 'location',

--- a/src/Offer/CommandHandlers/ImportLabelsHandler.php
+++ b/src/Offer/CommandHandlers/ImportLabelsHandler.php
@@ -51,23 +51,12 @@ final class ImportLabelsHandler implements CommandHandler
 
         $offer = $this->offerRepository->load($command->getItemId());
 
-        $labelsToImport = $command->getLabels();
-        $labelsToImport = $this->fixVisibility($labelsToImport);
-
-        $labelsOnOffer = new Labels();
-        foreach ($offer->getLabels()->asArray() as $labelOnOffer) {
-            $labelsOnOffer = $labelsOnOffer->with(
-                new Label(
-                    new LabelName($labelOnOffer->getName()->toNative()),
-                    $labelOnOffer->isVisible()
-                )
-            );
-        }
-
-        $labelsToKeepOnOffer = $this->lockedLabelRepository->getLockedLabelsForItem($command->getItemId());
+        $labelsToImport = $this->fixVisibility($command->getLabels());
+        $labelsOnOffer = $offer->getLabels();
 
         // Fix visibility that is sometimes incorrect on locked labels. This otherwise breaks comparisons in logic down
         // the line.
+        $labelsToKeepOnOffer = $this->lockedLabelRepository->getLockedLabelsForItem($command->getItemId());
         $labelsToKeepOnOffer = $this->fixVisibility($labelsToKeepOnOffer);
 
         // Always keep labels that the user has no permission to remove, whether they are included in the import or not.

--- a/src/Offer/CommandHandlers/ImportLabelsHandler.php
+++ b/src/Offer/CommandHandlers/ImportLabelsHandler.php
@@ -126,4 +126,20 @@ final class ImportLabelsHandler implements CommandHandler
 
         $this->offerRepository->save($offer);
     }
+
+    private function fixVisibility(Labels $labels): Labels
+    {
+        return new Labels(
+            ...array_map(
+                function (Label $label): Label {
+                    $readModel = $this->labelsPermissionRepository->getByName(
+                        new StringLiteral($label->getName()->toString())
+                    );
+                    $visible = !$readModel || $readModel->getVisibility()->sameAs(Visibility::VISIBLE());
+                    return new Label($label->getName(), $visible);
+                },
+                $labels->toArray()
+            )
+        );
+    }
 }

--- a/src/Offer/CommandHandlers/ImportLabelsHandler.php
+++ b/src/Offer/CommandHandlers/ImportLabelsHandler.php
@@ -6,29 +6,41 @@ namespace CultuurNet\UDB3\Offer\CommandHandlers;
 
 use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label as Udb3ModelLabel;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface as LabelsPermissionRepository;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
 use CultuurNet\UDB3\Offer\OfferRepository;
+use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabelsHandler implements CommandHandler
 {
-    /**
-     * @var OfferRepository
-     */
-    private $offerRepository;
+    private OfferRepository $offerRepository;
 
-    /**
-     * @var LabelServiceInterface
-     */
-    private $labelService;
+    private LabelServiceInterface $labelService;
+
+    private LabelsPermissionRepository $labelsPermissionRepository;
+
+    private LockedLabelRepository $lockedLabelRepository;
+
+    private string $currentUserId;
 
     public function __construct(
         OfferRepository $offerRepository,
-        LabelServiceInterface $labelService
+        LabelServiceInterface $labelService,
+        LabelsPermissionRepository $labelsPermissionRepository,
+        LockedLabelRepository $lockedLabelRepository,
+        string $currentUserId
     ) {
         $this->offerRepository = $offerRepository;
         $this->labelService = $labelService;
+        $this->labelsPermissionRepository = $labelsPermissionRepository;
+        $this->lockedLabelRepository = $lockedLabelRepository;
+        $this->currentUserId = $currentUserId;
     }
 
     public function handle($command): void
@@ -37,20 +49,81 @@ final class ImportLabelsHandler implements CommandHandler
             return;
         }
 
-        /** @var Udb3ModelLabel $importLabel */
-        foreach ($command->getLabelsToImport() as $importLabel) {
+        $offer = $this->offerRepository->load($command->getItemId());
+
+        $labelsToImport = $command->getLabels();
+        $labelsOnOffer = new Labels();
+        foreach ($offer->getLabels()->asArray() as $labelOnOffer) {
+            $labelsOnOffer = $labelsOnOffer->with(
+                new Label(
+                    new LabelName($labelOnOffer->getName()->toNative()),
+                    $labelOnOffer->isVisible()
+                )
+            );
+        }
+
+        $labelsToKeepOnOffer = $this->lockedLabelRepository->getLockedLabelsForItem($command->getItemId());
+
+        // Fix visibility that is sometimes incorrect on locked labels. This otherwise breaks comparisons in logic down
+        // the line.
+        $labelsToKeepOnOffer = new Labels(
+            ...array_map(
+                function (Label $label): Label {
+                    $readModel = $this->labelsPermissionRepository->getByName(
+                        new StringLiteral($label->getName()->toString())
+                    );
+                    $visible = !$readModel || $readModel->getVisibility()->sameAs(Visibility::VISIBLE());
+                    return new Label($label->getName(), $visible);
+                },
+                $labelsToKeepOnOffer->toArray()
+            )
+        );
+
+        // Always keep labels that the user has no permission to remove, whether they are included in the import or not.
+        // Do not throw an exception but just keep them, because the user might not have had up-to-date JSON from UDB
+        // with the extra labels when they sent their import.
+        /** @var Label $labelOnOffer */
+        foreach ($labelsOnOffer as $labelOnOffer) {
+            $canUseLabel = $this->labelsPermissionRepository->canUseLabel(
+                new StringLiteral($this->currentUserId),
+                new StringLiteral($labelOnOffer->getName()->toString())
+            );
+            if (!$canUseLabel && !$labelsToKeepOnOffer->contains($labelOnOffer)) {
+                $labelsToKeepOnOffer = $labelsToKeepOnOffer->with($labelOnOffer);
+            }
+        }
+
+        // Loop over the labels that are to be added and check if the user can use them or not. If they cannot use them
+        // just remove them from the list to import, because at this point we cannot return an error response anymore
+        // because the imports are handled async. Normally the AuthorizedCommandBus should have already returned an
+        // error response for this, but if not make sure we don't add them.
+        $labelNamesToImport = $labelsToImport->toArrayOfStringNames();
+        $labelNamesOnOffer = $labelsOnOffer->toArrayOfStringNames();
+        $labelNamesNotOnOffer = array_diff($labelNamesToImport, $labelNamesOnOffer);
+        foreach ($labelNamesNotOnOffer as $labelName) {
+            $canUseLabel = $this->labelsPermissionRepository->canUseLabel(
+                new StringLiteral($this->currentUserId),
+                new StringLiteral($labelName)
+            );
+
+            if (!$canUseLabel) {
+                $labelsToImport = $labelsToImport->filter(
+                    fn (Label $label) => $label->getName()->toString() !== $labelName
+                );
+            }
+        }
+
+        // Make sure every label that will get added has an existing Label aggregate.
+        /** @var Label $importLabel */
+        foreach ($labelsToImport as $importLabel) {
             $this->labelService->createLabelAggregateIfNew(
-                new LabelName($importLabel->getName()->toString()),
+                new LegacyLabelName($importLabel->getName()->toString()),
                 $importLabel->isVisible()
             );
         }
 
-        $offer = $this->offerRepository->load($command->getItemId());
-        $offer->importLabels(
-            $command->getLabelsToImport(),
-            $command->getLabelsToKeepIfAlreadyOnOffer(),
-            $command->getLabelsToRemoveWhenOnOffer()
-        );
+        $offer->importLabels($labelsToImport, $labelsToKeepOnOffer);
+
         $this->offerRepository->save($offer);
     }
 }

--- a/src/Offer/CommandHandlers/ImportLabelsHandler.php
+++ b/src/Offer/CommandHandlers/ImportLabelsHandler.php
@@ -11,7 +11,6 @@ use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
 use CultuurNet\UDB3\Offer\OfferRepository;

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -6,10 +6,9 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
-use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
 use CultuurNet\UDB3\StringLiteral;
 
-final class ImportLabels extends AbstractCommand implements AuthorizableLabelCommand
+final class ImportLabels extends AbstractCommand
 {
     /**
      * @var Labels

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -10,72 +10,17 @@ use CultuurNet\UDB3\StringLiteral;
 
 final class ImportLabels extends AbstractCommand
 {
-    /**
-     * @var Labels
-     */
-    private $labels;
-
-    /**
-     * @var Labels
-     */
-    private $labelsToKeepIfAlreadyOnOffer;
-
-    /**
-     * @var Labels
-     */
-    private $labelsToRemoveWhenOnOffer;
+    private Labels $labels;
 
     public function __construct(string $itemId, Labels $labels)
     {
         parent::__construct($itemId);
         $this->labels = $labels;
-        $this->labelsToKeepIfAlreadyOnOffer = new Labels();
-        $this->labelsToRemoveWhenOnOffer = new Labels();
     }
 
     public function getLabels(): Labels
     {
         return $this->labels;
-    }
-
-    public function withLabelsToKeepIfAlreadyOnOffer(Labels $labels): self
-    {
-        $c = clone $this;
-        $c->labelsToKeepIfAlreadyOnOffer = $labels;
-        return $c;
-    }
-
-    public function getLabelsToKeepIfAlreadyOnOffer(): Labels
-    {
-        return $this->labelsToKeepIfAlreadyOnOffer;
-    }
-
-    public function withLabelsToRemoveWhenOnOffer(Labels $labels): self
-    {
-        $c = clone $this;
-        $c->labelsToRemoveWhenOnOffer = $labels;
-        return $c;
-    }
-
-    public function getLabelsToRemoveWhenOnOffer(): Labels
-    {
-        return $this->labelsToRemoveWhenOnOffer;
-    }
-
-    public function getLabelsToImport(): Labels
-    {
-        $labelNamesToKeep = array_map(
-            function (Label $label) {
-                return $label->getName();
-            },
-            $this->labelsToKeepIfAlreadyOnOffer->toArray()
-        );
-
-        return $this->labels->filter(
-            function (Label $label) use ($labelNamesToKeep) {
-                return !in_array($label->getName(), $labelNamesToKeep);
-            }
-        );
     }
 
     public function getLabelNames(): array
@@ -84,7 +29,7 @@ final class ImportLabels extends AbstractCommand
             function (Label $label) {
                 return new StringLiteral($label->getName()->toString());
             },
-            $this->getLabelsToImport()->toArray()
+            $this->getLabels()->toArray()
         );
     }
 }

--- a/src/Offer/Commands/ImportLabels.php
+++ b/src/Offer/Commands/ImportLabels.php
@@ -34,6 +34,11 @@ final class ImportLabels extends AbstractCommand implements AuthorizableLabelCom
         $this->labelsToRemoveWhenOnOffer = new Labels();
     }
 
+    public function getLabels(): Labels
+    {
+        return $this->labels;
+    }
+
     public function withLabelsToKeepIfAlreadyOnOffer(Labels $labels): self
     {
         $c = clone $this;

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -144,6 +144,11 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     abstract public static function getOfferType(): OfferType;
 
+    public function getLabels(): LabelCollection
+    {
+        return $this->labels;
+    }
+
     public function changeOwner(string $newOwnerId): void
     {
         // Will always be true for the first call to changeOwner() since we have no way to know who the creator was

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -144,9 +144,20 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     abstract public static function getOfferType(): OfferType;
 
-    public function getLabels(): LabelCollection
+    public function getLabels(): Labels
     {
-        return $this->labels;
+        $labels = new Labels();
+
+        foreach ($this->labels->asArray() as $label) {
+            $labels = $labels->with(
+                new Label(
+                    new LabelName($label->getName()->toNative()),
+                    $label->isVisible()
+                )
+            );
+        }
+
+        return $labels;
     }
 
     public function changeOwner(string $newOwnerId): void

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -249,7 +249,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         }
     }
 
-    public function importLabels(Labels $labels, Labels $labelsToKeepIfAlreadyOnOffer, Labels $labelsToRemoveWhenOnOffer): void
+    public function importLabels(Labels $labels, Labels $labelsToKeepIfAlreadyOnOffer): void
     {
         $convertLabelClass = function (Label $label) {
             return new LegacyLabel(
@@ -266,11 +266,6 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         // Convert the labels to keep if already applied.
         $keepLabelsCollection = new LabelCollection(
             array_map($convertLabelClass, $labelsToKeepIfAlreadyOnOffer->toArray())
-        );
-
-        // Convert the labels to remove when on offer.
-        $removeLabelsCollection = new LabelCollection(
-            array_map($convertLabelClass, $labelsToRemoveWhenOnOffer->toArray())
         );
 
         // What are the added labels?
@@ -305,7 +300,17 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         // Labels which are inside the internal state but not inside imported labels or labels to keep.
         // For each deleted label fire a LabelDeleted event.
         foreach ($this->labels->asArray() as $label) {
-            if (!$importLabelsCollection->contains($label) && !$keepLabelsCollection->contains($label) && $removeLabelsCollection->contains($label)) {
+            $labelName = $label->getName()->toNative();
+            $importLabelNames = array_map(
+                fn (LegacyLabel $label) => $label->getName()->toNative(),
+                $importLabelsCollection->asArray()
+            );
+            $keepLabelNames = array_map(
+                fn (LegacyLabel $label) => $label->getName()->toNative(),
+                $keepLabelsCollection->asArray()
+            );
+
+            if (!in_array($labelName, $importLabelNames, true) && !in_array($labelName, $keepLabelNames, true)) {
                 $this->apply($this->createLabelRemovedEvent($label));
             }
         }

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -40,7 +40,6 @@ use CultuurNet\UDB3\Media\Properties\Description;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\Import\MediaObject\ImageCollectionFactory;
 use CultuurNet\UDB3\Model\Import\Place\PlaceCategoryResolver;
-use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
@@ -95,8 +94,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
 
     private MockObject $imageCollectionFactory;
 
-    private MockObject $lockedLabelRepository;
-
     private MockObject $consumerSpecification;
 
     private MockObject $apiReader;
@@ -112,7 +109,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->uuidFactory = $this->createMock(UuidFactoryInterface::class);
         $this->commandBus = new TraceableCommandBus();
         $this->imageCollectionFactory = $this->createMock(ImageCollectionFactory::class);
-        $this->lockedLabelRepository = $this->createMock(LockedLabelRepository::class);
         $this->consumerSpecification = $this->createMock(ConsumerSpecificationInterface::class);
         $this->apiReader = $this->createMock(ApiKeyReaderInterface::class);
         $this->consumerRepository = $this->createMock(ConsumerReadRepositoryInterface::class);
@@ -143,7 +139,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             new CallableIriGenerator(fn ($placeId) => 'https://io.uitdatabank.dev/places/' . $placeId),
             $this->commandBus,
             $this->imageCollectionFactory,
-            $this->lockedLabelRepository,
             $this->consumerSpecification,
             $this->apiReader,
             $this->consumerRepository
@@ -197,11 +192,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->imageCollectionFactory->expects($this->once())
             ->method('fromMediaObjectReferences')
             ->willReturn(new ImageCollection());
-
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getLockedLabelsForItem')
-            ->with($placeId)
-            ->willReturn(new Labels());
 
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray($givenPlace)
@@ -285,11 +275,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->imageCollectionFactory->expects($this->once())
             ->method('fromMediaObjectReferences')
             ->willReturn(new ImageCollection());
-
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getLockedLabelsForItem')
-            ->with($placeId)
-            ->willReturn(new Labels());
 
         $request = (new Psr7RequestBuilder())
             ->withJsonBodyFromArray($givenPlace)
@@ -445,11 +430,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                         new LegacyLanguage('nl')
                     ))
             );
-
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getLockedLabelsForItem')
-            ->with($placeId)
-            ->willReturn(new Labels());
 
         $videoId = \Ramsey\Uuid\Uuid::uuid4();
         $this->uuidFactory->expects($this->once())
@@ -626,11 +606,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->imageCollectionFactory->expects($this->once())
             ->method('fromMediaObjectReferences')
             ->willReturn(new ImageCollection());
-
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getLockedLabelsForItem')
-            ->with($placeId)
-            ->willReturn(new Labels());
 
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('placeId', $placeId)

--- a/tests/Model/Import/Event/EventDocumentImporterTest.php
+++ b/tests/Model/Import/Event/EventDocumentImporterTest.php
@@ -601,26 +601,6 @@ class EventDocumentImporterTest extends TestCase
         $this->expectEventIdExists($id);
         $this->expectNoImages();
 
-        $lockedLabels = new Labels(
-            new Label(new LabelName('locked1')),
-            new Label(new LabelName('locked2'))
-        );
-        $unlockedLabels = new Labels(
-            new Label(new LabelName('foo'), true),
-            new Label(new LabelName('bar'), true),
-            new Label(new LabelName('lorem'), false),
-            new Label(new LabelName('ipsum'), false)
-        );
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getLockedLabelsForItem')
-            ->with($id)
-            ->willReturn($lockedLabels);
-
-        $this->lockedLabelRepository->expects($this->once())
-            ->method('getUnlockedLabelsForItem')
-            ->with($id)
-            ->willReturn($unlockedLabels);
-
         $this->commandBus->record();
 
         $this->importer->import($document);
@@ -628,18 +608,15 @@ class EventDocumentImporterTest extends TestCase
         $recordedCommands = $this->commandBus->getRecordedCommands();
 
         $this->assertContainsObject(
-            (
-                new ImportLabels(
-                    $this->getEventId(),
-                    new Labels(
-                        new Label(new LabelName('foo'), true),
-                        new Label(new LabelName('bar'), true),
-                        new Label(new LabelName('lorem'), false),
-                        new Label(new LabelName('ipsum'), false)
-                    )
+            new ImportLabels(
+                $this->getEventId(),
+                new Labels(
+                    new Label(new LabelName('foo'), true),
+                    new Label(new LabelName('bar'), true),
+                    new Label(new LabelName('lorem'), false),
+                    new Label(new LabelName('ipsum'), false)
                 )
-            )->withLabelsToKeepIfAlreadyOnOffer($lockedLabels)
-                ->withLabelsToRemoveWhenOnOffer($unlockedLabels),
+            ),
             $recordedCommands
         );
     }

--- a/tests/Model/Import/Validation/Event/EventImportValidatorTest.php
+++ b/tests/Model/Import/Validation/Event/EventImportValidatorTest.php
@@ -4,46 +4,18 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\Validation\Event;
 
-use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface as LabelsRepository;
-use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface as LabelRelationsRepository;
-use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\AllOfException;
 
 class EventImportValidatorTest extends TestCase
 {
-    /**
-     * @var InMemoryDocumentRepository
-     */
-    private $placeRepository;
+    private InMemoryDocumentRepository $placeRepository;
 
-    /**
-     * @var UUIDParser|MockObject
-     */
-    private $uuidParser;
-
-    /**
-     * @var LabelsRepository|MockObject
-     */
-    private $labelsRepository;
-
-    /**
-     * @var LabelRelationsRepository|MockObject
-     */
-    private $labelRelationsRepository;
-
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->placeRepository = new InMemoryDocumentRepository();
-
-        $this->uuidParser = $this->createMock(UUIDParser::class);
-
-        $this->labelsRepository = $this->createMock(LabelsRepository::class);
-
-        $this->labelRelationsRepository = $this->createMock(LabelRelationsRepository::class);
     }
 
     /**
@@ -51,13 +23,7 @@ class EventImportValidatorTest extends TestCase
      */
     public function it_throws_if_a_referenced_place_does_not_exist(): void
     {
-        $eventDocumentValidator = new EventImportValidator(
-            $this->placeRepository,
-            $this->uuidParser,
-            'user_id',
-            $this->labelsRepository,
-            $this->labelRelationsRepository
-        );
+        $eventDocumentValidator = new EventImportValidator($this->placeRepository);
 
         $document = [
             '@id' => 'https://io-acc.uitdatabank.be/events/43171ff2-574c-4659-943a-d8f81049f544',
@@ -86,13 +52,7 @@ class EventImportValidatorTest extends TestCase
      */
     public function it_does_not_throw_for_a_valid_event_with_the_minimum_required_fields(): void
     {
-        $eventDocumentValidator = new EventImportValidator(
-            $this->placeRepository,
-            $this->uuidParser,
-            'user_id',
-            $this->labelsRepository,
-            $this->labelRelationsRepository
-        );
+        $eventDocumentValidator = new EventImportValidator($this->placeRepository);
 
         $this->placeRepository->save(new JsonDocument('5f3f89a0-1738-41b8-aad5-c449f3af19cc', '{}'));
 

--- a/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
+++ b/tests/Offer/CommandHandlers/ImportLabelsHandlerTest.php
@@ -18,34 +18,49 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\Import\Taxonomy\Label\LockedLabelRepository;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label as Udb3ModelsLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName as Udb3ModelsLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels as Udb3ModelsLabels;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Place\PlaceRepository;
+use CultuurNet\UDB3\StringLiteral;
 use CultuurNet\UDB3\Title;
 use PHPUnit\Framework\MockObject\MockObject;
 
 final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
 {
-    /**
-     * @var LabelServiceInterface|MockObject
-     */
-    private $labelService;
+    private MockObject $labelService;
+
+    private MockObject $lockedLabelRepository;
 
     protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): ImportLabelsHandler
     {
         $this->labelService = $this->createMock(LabelServiceInterface::class);
+        $this->lockedLabelRepository = $this->createMock(LockedLabelRepository::class);
+
+        $labelPermissionRepository = $this->createMock(ReadRepositoryInterface::class);
+        $labelPermissionRepository->expects($this->any())
+            ->method('canUseLabel')
+            ->willReturnCallback(
+                function (StringLiteral $userId, StringLiteral $labelName) {
+                    return $labelName->toNative() !== 'not_allowed';
+                }
+            );
 
         return new ImportLabelsHandler(
             new OfferRepository(
                 new EventRepository($eventStore, $eventBus),
                 new PlaceRepository($eventStore, $eventBus)
             ),
-            $this->labelService
+            $this->labelService,
+            $labelPermissionRepository,
+            $this->lockedLabelRepository,
+            'b4ac44f4-31d0-4dcd-968e-c01538f117d8'
         );
     }
 
@@ -106,10 +121,38 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
+    public function it_does_not_add_a_private_label_if_not_allowed(): void
+    {
+        $id = '39007d2d-acec-438d-a687-f2d8400d4c1e';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given(
+                [
+                    $this->eventCreated($id),
+                ]
+            )
+            ->when(
+                (new ImportLabels(
+                    $id,
+                    new Udb3ModelsLabels(new Udb3ModelsLabel(new Udb3ModelsLabelName('not_allowed')))
+                )
+                )
+            )
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_not_replace_private_labels_that_are_already_on_the_offer(): void
     {
         $this->labelService->expects($this->never())
             ->method('createLabelAggregateIfNew');
+
+        $this->lockedLabelRepository->expects($this->any())
+            ->method('getLockedLabelsForItem')
+            ->willReturn(new Udb3ModelsLabels(new Udb3ModelsLabel(new Udb3ModelsLabelName('private'))));
 
         $id = '39007d2d-acec-438d-a687-f2d8400d4c1e';
 
@@ -123,22 +166,7 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
                 ]
             )
             ->when(
-                (new ImportLabels($id, new Udb3ModelsLabels()))
-                    ->withLabelsToKeepIfAlreadyOnOffer(
-                        new Udb3ModelsLabels(
-                            new Udb3ModelsLabel(
-                                new Udb3ModelsLabelName('private'),
-                                true
-                            )
-                        )
-                    )->withLabelsToRemoveWhenOnOffer(
-                        new Udb3ModelsLabels(
-                            new Udb3ModelsLabel(
-                                new Udb3ModelsLabelName('not_private'),
-                                true
-                            )
-                        )
-                    )
+                new ImportLabels($id, new Udb3ModelsLabels())
             )
             ->then([new LabelRemoved($id, new Label('not_private'))]);
     }
@@ -152,6 +180,13 @@ final class ImportLabelsHandlerTest extends CommandHandlerScenarioTestCase
             ->method('createLabelAggregateIfNew');
 
         $id = '39007d2d-acec-438d-a687-f2d8400d4c1e';
+
+        $this->lockedLabelRepository->expects($this->any())
+            ->method('getLockedLabelsForItem')
+            ->willReturn(new Udb3ModelsLabels(
+                new Udb3ModelsLabel(new Udb3ModelsLabelName('label 1')),
+                new Udb3ModelsLabel(new Udb3ModelsLabelName('label 2'))
+            ));
 
         $this->scenario
             ->withAggregateId($id)

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -337,26 +337,19 @@ class OfferTest extends AggregateRootScenarioTestCase
         $itemId = '9538e4b6-2b8c-404c-93dc-e0dccf8eb175';
 
         $labels = new Labels(
-            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+            new Label(
                 new LabelName('new_label_1'),
                 true
             ),
-            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+            new Label(
                 new LabelName('existing_label_1'),
                 true
             )
         );
 
         $labelsToKeepIfApplied = new Labels(
-            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+            new Label(
                 new LabelName('existing_label_3'),
-                true
-            )
-        );
-
-        $labelsToRemoveWhenOnOffer = new Labels(
-            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                new LabelName('existing_label_2'),
                 true
             )
         );
@@ -369,16 +362,16 @@ class OfferTest extends AggregateRootScenarioTestCase
                 new LabelAdded($itemId, new LegacyLabel('existing_label_3')),
             ])
             ->when(
-                function (Item $item) use ($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer) {
-                    $item->importLabels($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer);
-                    $item->importLabels($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer);
+                function (Item $item) use ($labels, $labelsToKeepIfApplied) {
+                    $item->importLabels($labels, $labelsToKeepIfApplied);
+                    $item->importLabels($labels, $labelsToKeepIfApplied);
                 }
             )
             ->then([
                 new LabelsImported(
                     $itemId,
                     new Labels(
-                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                        new Label(
                             new LabelName('new_label_1'),
                             true
                         )


### PR DESCRIPTION
### Changed
- Refactored `ImportLabelsHandler` to take into account label visibility and privacy and the labels already present on the place or event
- Changed the `Offer::importLabels` method to handle a simple but correct list of labels
- Refactored the import of places to no longer use `ImportLabelVisibilityRequestBodyParser`
- Refactored the import of events to also work with the refactored `ImportLabelsHandler`

Note: In a follow-up PR it would even be possible to change the import label code from organizers to match the code from places and events closer. Once this is done `ImportLabelVisibilityRequestBodyParser` can be removed.

---
Ticket: https://jira.uitdatabank.be/browse/III-4567
