### PR TITLE
III-4609 Manual workflowStatus when creating/updating a place

### DIFF
--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -51,10 +51,7 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
 
         $app['auth.api_key_authenticator'] = $app->share(
             function (Application $app) {
-                return new CultureFeedApiKeyAuthenticator(
-                    $app['culturefeed'],
-                    $app['auth.consumer_repository']
-                );
+                return new CultureFeedApiKeyAuthenticator($app['auth.consumer_repository']);
             }
         );
 

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -7,8 +7,8 @@ namespace CultuurNet\UDB3\Silex\Authentication;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CompositeApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CustomHeaderApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\QueryParameterApiKeyReader;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\CultureFeedConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
@@ -110,9 +110,9 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
                     (string) $app['auth.api_key.group_id']
                 );
 
-                /* @var ConsumerReadRepositoryInterface $consumerRepository */
+                /* @var ConsumerReadRepository $consumerRepository */
                 $consumerRepository = $app['auth.consumer_repository'];
-                /** @var ConsumerInterface $consumer */
+                /** @var Consumer $consumer */
                 $consumer = $consumerRepository->getConsumer($app['auth.api_key']);
 
                 if (!$permissionCheck->satisfiedBy($consumer)) {

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\CustomHeaderApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\QueryParameterApiKeyReader;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
 use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\CultureFeedConsumerReadRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
 use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
 use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedApiKeyAuthenticator;
@@ -42,7 +43,9 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
 
         $app['auth.consumer_repository'] = $app->share(
             function (Application $app) {
-                return new InMemoryConsumerRepository();
+                return new InMemoryConsumerRepository(
+                    new CultureFeedConsumerReadRepository($app['culturefeed'], true)
+                );
             }
         );
 

--- a/app/Authentication/UitidApiKeyServiceProvider.php
+++ b/app/Authentication/UitidApiKeyServiceProvider.php
@@ -42,7 +42,7 @@ class UitidApiKeyServiceProvider implements ServiceProviderInterface
         );
 
         $app['auth.consumer_repository'] = $app->share(
-            function (Application $app) {
+            function (Application $app): ConsumerReadRepository {
                 return new InMemoryConsumerRepository(
                     new CultureFeedConsumerReadRepository($app['culturefeed'], true)
                 );

--- a/app/CommandHandling/ContextFactory.php
+++ b/app/CommandHandling/ContextFactory.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Silex\CommandHandling;
 
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\Jwt\Symfony\Authentication\JsonWebToken;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +20,7 @@ final class ContextFactory
         ?ApiKey $apiKey = null,
         ?string $apiName = null,
         ?Request $request = null,
-        ?ConsumerInterface $consumer = null
+        ?Consumer $consumer = null
     ): Metadata {
         $contextValues = [];
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -35,6 +35,7 @@ use CultuurNet\UDB3\Offer\CommandHandlers\UpdateStatusHandler;
 use CultuurNet\UDB3\Offer\CommandHandlers\UpdateTypeHandler;
 use CultuurNet\UDB3\Offer\CommandHandlers\UpdateVideoHandler;
 use CultuurNet\UDB3\Offer\OfferLocator;
+use CultuurNet\UDB3\Offer\ProcessManagers\AutoApproveForUiTIDv1ApiKeysProcessManager;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
@@ -463,6 +464,7 @@ $app['event_bus'] = function ($app) {
             'curators_news_article_process_manager',
             LocationMarkedAsDuplicateProcessManager::class,
             RelocateEventToCanonicalPlace::class,
+            AutoApproveForUiTIDv1ApiKeysProcessManager::class,
         ];
 
         $initialSubscribersCount = count($subscribers);

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "cultuurnet/calendar-summary-v3": "^3.4",
     "cultuurnet/cdb": "~2.2.0",
     "cultuurnet/culturefeed-php": "dev-master",
-    "cultuurnet/udb3-api-guard": "^v4.0",
+    "cultuurnet/udb3-api-guard": "dev-repository-that-fetches-consumer-from-culturefeed as 5.0",
     "danielstjules/stringy": "^3.1",
     "doctrine/cache": "~1.3",
     "doctrine/dbal": "~2.4",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "cultuurnet/calendar-summary-v3": "^3.4",
     "cultuurnet/cdb": "~2.2.0",
     "cultuurnet/culturefeed-php": "dev-master",
-    "cultuurnet/udb3-api-guard": "dev-repository-that-fetches-consumer-from-culturefeed as 5.0",
+    "cultuurnet/udb3-api-guard": "^5.0",
     "danielstjules/stringy": "^3.1",
     "doctrine/cache": "~1.3",
     "doctrine/dbal": "~2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5536950b8e7871361b1fab64a510b4ee",
+    "content-hash": "a65c4ad0048589214ce6dda7e4295045",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -840,16 +840,16 @@
         },
         {
             "name": "cultuurnet/udb3-api-guard",
-            "version": "dev-repository-that-fetches-consumer-from-culturefeed",
+            "version": "v5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-api-guard.git",
-                "reference": "2646b1133888a8a3b424ca572ef3eb260169ea67"
+                "reference": "cd33bc120ed1a11d5c3a69b4aba6f7c90eca1823"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/2646b1133888a8a3b424ca572ef3eb260169ea67",
-                "reference": "2646b1133888a8a3b424ca572ef3eb260169ea67",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/cd33bc120ed1a11d5c3a69b4aba6f7c90eca1823",
+                "reference": "cd33bc120ed1a11d5c3a69b4aba6f7c90eca1823",
                 "shasum": ""
             },
             "require": {
@@ -889,9 +889,9 @@
             ],
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-api-guard/issues",
-                "source": "https://github.com/cultuurnet/udb3-api-guard/tree/repository-that-fetches-consumer-from-culturefeed"
+                "source": "https://github.com/cultuurnet/udb3-api-guard/tree/v5.0"
             },
-            "time": "2022-03-08T16:53:25+00:00"
+            "time": "2022-03-09T12:58:13+00:00"
         },
         {
             "name": "danielstjules/stringy",
@@ -10770,12 +10770,6 @@
             "alias_normalized": "1.2.0.0"
         },
         {
-            "package": "cultuurnet/udb3-api-guard",
-            "version": "dev-repository-that-fetches-consumer-from-culturefeed",
-            "alias": "5.0",
-            "alias_normalized": "5.0.0.0"
-        },
-        {
             "package": "jeremykendall/php-domain-parser",
             "version": "4.0.3.0-alpha",
             "alias": "1.3.1",
@@ -10786,7 +10780,6 @@
     "stability-flags": {
         "chrisboulton/php-resque": 20,
         "cultuurnet/culturefeed-php": 20,
-        "cultuurnet/udb3-api-guard": 20,
         "doctrine/migrations": 20,
         "publiq/stoplight-docs-uitdatabank": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ead51eb7afdfea2f824a40e0587fafdc",
+    "content-hash": "5536950b8e7871361b1fab64a510b4ee",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -840,19 +840,20 @@
         },
         {
             "name": "cultuurnet/udb3-api-guard",
-            "version": "v4.0",
+            "version": "dev-repository-that-fetches-consumer-from-culturefeed",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-api-guard.git",
-                "reference": "713d831b03ae379d6dadc4976043c9afbebbb3f9"
+                "reference": "2646b1133888a8a3b424ca572ef3eb260169ea67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/713d831b03ae379d6dadc4976043c9afbebbb3f9",
-                "reference": "713d831b03ae379d6dadc4976043c9afbebbb3f9",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-api-guard/zipball/2646b1133888a8a3b424ca572ef3eb260169ea67",
+                "reference": "2646b1133888a8a3b424ca572ef3eb260169ea67",
                 "shasum": ""
             },
             "require": {
+                "php": ">=7.4",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
@@ -886,7 +887,11 @@
                     "email": "info@2publiq.be"
                 }
             ],
-            "time": "2021-03-05T11:49:45+00:00"
+            "support": {
+                "issues": "https://github.com/cultuurnet/udb3-api-guard/issues",
+                "source": "https://github.com/cultuurnet/udb3-api-guard/tree/repository-that-fetches-consumer-from-culturefeed"
+            },
+            "time": "2022-03-08T16:53:25+00:00"
         },
         {
             "name": "danielstjules/stringy",
@@ -10765,6 +10770,12 @@
             "alias_normalized": "1.2.0.0"
         },
         {
+            "package": "cultuurnet/udb3-api-guard",
+            "version": "dev-repository-that-fetches-consumer-from-culturefeed",
+            "alias": "5.0",
+            "alias_normalized": "5.0.0.0"
+        },
+        {
             "package": "jeremykendall/php-domain-parser",
             "version": "4.0.3.0-alpha",
             "alias": "1.3.1",
@@ -10775,6 +10786,7 @@
     "stability-flags": {
         "chrisboulton/php-resque": 20,
         "cultuurnet/culturefeed-php": 20,
+        "cultuurnet/udb3-api-guard": 20,
         "doctrine/migrations": 20,
         "publiq/stoplight-docs-uitdatabank": 20
     },

--- a/src/Http/Event/EditEventRestController.php
+++ b/src/Http/Event/EditEventRestController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Event;
 
-use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReader;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\Event\EventEditingServiceInterface;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Media\MediaManagerInterface;
@@ -45,20 +45,9 @@ class EditEventRestController extends OfferRestBaseController
      */
     protected $calendarDeserializer;
 
-    /**
-     * @var ApiKeyReaderInterface
-     */
-    private $apiKeyReader;
-
-    /**
-     * @var ConsumerReadRepositoryInterface
-     */
-    private $consumerReadRepository;
-
-    /**
-     * @var ConsumerSpecificationInterface
-     */
-    private $shouldApprove;
+    private ApiKeyReader $apiKeyReader;
+    private ConsumerReadRepository $consumerReadRepository;
+    private ConsumerSpecification $shouldApprove;
 
     /**
      * Constructs a RestController.
@@ -70,9 +59,9 @@ class EditEventRestController extends OfferRestBaseController
         EventEditingServiceInterface $eventEditor,
         MediaManagerInterface $mediaManager,
         IriGeneratorInterface $iriGenerator,
-        ApiKeyReaderInterface $apiKeyReader,
-        ConsumerReadRepositoryInterface $consumerReadRepository,
-        ConsumerSpecificationInterface $shouldApprove
+        ApiKeyReader $apiKeyReader,
+        ConsumerReadRepository $consumerReadRepository,
+        ConsumerSpecification $shouldApprove
     ) {
         parent::__construct($eventEditor, $mediaManager);
         $this->iriGenerator = $iriGenerator;

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -35,6 +35,7 @@ use CultuurNet\UDB3\Offer\Commands\Video\ImportVideos;
 use CultuurNet\UDB3\Place\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Place\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Place\Commands\ImportImages;
+use CultuurNet\UDB3\Place\Commands\Moderation\Publish;
 use CultuurNet\UDB3\Place\Commands\UpdateAddress;
 use CultuurNet\UDB3\Place\Commands\UpdateBookingInfo;
 use CultuurNet\UDB3\Place\Commands\UpdateContactPoint;
@@ -177,6 +178,10 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
 
             $this->aggregateRepository->save($placeAggregate);
         } else {
+            if ($workflowStatus->sameAs(WorkflowStatus::READY_FOR_VALIDATION())) {
+                $commands[] = new Publish($placeId, $publishDate);
+            }
+
             $commands[] = new UpdateTitle(
                 $placeId,
                 $mainLanguage,

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -28,6 +28,7 @@ use CultuurNet\UDB3\Model\Import\MediaObject\ImageCollectionFactory;
 use CultuurNet\UDB3\Model\Import\Place\Udb3ModelToLegacyPlaceAdapter;
 use CultuurNet\UDB3\Model\Place\Place;
 use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
+use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
 use CultuurNet\UDB3\Offer\Commands\UpdateCalendar;
 use CultuurNet\UDB3\Offer\Commands\UpdateType;
@@ -242,6 +243,10 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         $commands[] = new ImportImages($placeId, $images);
 
         $commands[] = new ImportVideos($placeId, $place->getVideos());
+
+        if ($workflowStatus->sameAs(WorkflowStatus::DELETED())) {
+            $commands[] = new DeleteOffer($placeId);
+        }
 
         $lastCommandId = null;
         foreach ($commands as $command) {

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -8,10 +8,10 @@ use Broadway\CommandHandling\CommandBus;
 use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
-use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReader;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\Http\Offer\CalendarValidationRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\IdPropertyPolyfillRequestBodyParser;
@@ -68,11 +68,11 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
 
     private ImageCollectionFactory $imageCollectionFactory;
 
-    private ConsumerSpecificationInterface $shouldApprove;
+    private ConsumerSpecification $shouldApprove;
 
-    private ApiKeyReaderInterface $apiKeyReader;
+    private ApiKeyReader $apiKeyReader;
 
-    private ConsumerReadRepositoryInterface $consumerReadRepository;
+    private ConsumerReadRepository $consumerReadRepository;
 
     public function __construct(
         Repository $aggregateRepository,
@@ -82,9 +82,9 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         IriGeneratorInterface $iriGenerator,
         CommandBus $commandBus,
         ImageCollectionFactory $imageCollectionFactory,
-        ConsumerSpecificationInterface $shouldApprove,
-        ApiKeyReaderInterface $apiKeyReader,
-        ConsumerReadRepositoryInterface $consumerReadRepository
+        ConsumerSpecification $shouldApprove,
+        ApiKeyReader $apiKeyReader,
+        ConsumerReadRepository $consumerReadRepository
     ) {
         $this->aggregateRepository = $aggregateRepository;
         $this->uuidGenerator = $uuidGenerator;
@@ -265,7 +265,7 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
         return new JsonResponse($responseBody, $responseStatus);
     }
 
-    private function getConsumer(ServerRequestInterface $request): ?ConsumerInterface
+    private function getConsumer(ServerRequestInterface $request): ?Consumer
     {
         $apiKey = $this->apiKeyReader->read($request);
 

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -104,7 +104,6 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
 
         $placeId = $this->uuidGenerator->generate();
         $responseStatus = StatusCodeInterface::STATUS_CREATED;
-        $placeAggregate = null;
         $placeExists = false;
 
         if ($routeParameters->hasPlaceId()) {
@@ -112,8 +111,7 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
             $responseStatus = StatusCodeInterface::STATUS_OK;
 
             try {
-                /** @var \CultuurNet\UDB3\Place\Place $aggregate */
-                $placeAggregate = $this->aggregateRepository->load($placeId);
+                $this->aggregateRepository->load($placeId);
                 $placeExists = true;
             } catch (AggregateNotFoundException $e) {
             }

--- a/src/Model/Import/DocumentImporterInterface.php
+++ b/src/Model/Import/DocumentImporterInterface.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import;
 
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 
 /**
  * @deprecated Should be removed when all implementations have been removed (see deprecated tags on implementations)
  */
 interface DocumentImporterInterface
 {
-    public function import(DecodedDocument $decodedDocument, ConsumerInterface $consumer = null): ?string;
+    public function import(DecodedDocument $decodedDocument, Consumer $consumer = null): ?string;
 }

--- a/src/Model/Import/Event/EventDocumentImporter.php
+++ b/src/Model/Import/Event/EventDocumentImporter.php
@@ -7,8 +7,8 @@ namespace CultuurNet\UDB3\Model\Import\Event;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\Event\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Event\Commands\ImportImages;
@@ -50,7 +50,7 @@ class EventDocumentImporter implements DocumentImporterInterface
 
     private CommandBus $commandBus;
 
-    private ConsumerSpecificationInterface $shouldApprove;
+    private ConsumerSpecification $shouldApprove;
 
     private LoggerInterface $logger;
 
@@ -59,7 +59,7 @@ class EventDocumentImporter implements DocumentImporterInterface
         DenormalizerInterface $eventDenormalizer,
         ImageCollectionFactory $imageCollectionFactory,
         CommandBus $commandBus,
-        ConsumerSpecificationInterface $shouldApprove,
+        ConsumerSpecification $shouldApprove,
         LoggerInterface $logger
     ) {
         $this->aggregateRepository = $aggregateRepository;
@@ -70,7 +70,7 @@ class EventDocumentImporter implements DocumentImporterInterface
         $this->logger = $logger;
     }
 
-    public function import(DecodedDocument $decodedDocument, ConsumerInterface $consumer = null): ?string
+    public function import(DecodedDocument $decodedDocument, Consumer $consumer = null): ?string
     {
         $id = $decodedDocument->getId();
 

--- a/src/Model/Import/PreProcessing/LabelPreProcessingDocumentImporter.php
+++ b/src/Model/Import/PreProcessing/LabelPreProcessingDocumentImporter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\PreProcessing;
 
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface as LabelRepository;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\LabelRelation;
 use CultuurNet\UDB3\Label\ReadModels\Relations\Repository\ReadRepositoryInterface as LabelRelationsRepository;
@@ -44,7 +44,7 @@ class LabelPreProcessingDocumentImporter implements DocumentImporterInterface
         $this->labelRelationsRepository = $labelRelationsRepository;
     }
 
-    public function import(DecodedDocument $decodedDocument, ConsumerInterface $consumer = null): ?string
+    public function import(DecodedDocument $decodedDocument, Consumer $consumer = null): ?string
     {
         $data = $decodedDocument->getBody();
         $id = $decodedDocument->getId();

--- a/src/Model/Import/PreProcessing/TermPreProcessingDocumentImporter.php
+++ b/src/Model/Import/PreProcessing/TermPreProcessingDocumentImporter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Import\PreProcessing;
 
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\Model\Import\DecodedDocument;
 use CultuurNet\UDB3\Model\Import\DocumentImporterInterface;
 use CultuurNet\UDB3\Model\Import\Taxonomy\Category\CategoryResolverInterface;
@@ -37,7 +37,7 @@ class TermPreProcessingDocumentImporter implements DocumentImporterInterface
     /**
      * Pre-processes the JSON to polyfill missing term properties if possible.
      */
-    public function import(DecodedDocument $decodedDocument, ConsumerInterface $consumer = null): ?string
+    public function import(DecodedDocument $decodedDocument, Consumer $consumer = null): ?string
     {
         $data = $decodedDocument->getBody();
 

--- a/src/Offer/ProcessManagers/AutoApproveForUiTIDv1ApiKeysProcessManager.php
+++ b/src/Offer/ProcessManagers/AutoApproveForUiTIDv1ApiKeysProcessManager.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ProcessManagers;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListener;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
+use CultuurNet\UDB3\Offer\Events\Moderation\AbstractPublished;
+use CultuurNet\UDB3\Offer\OfferRepository;
+
+final class AutoApproveForUiTIDv1ApiKeysProcessManager implements EventListener
+{
+    private OfferRepository $offerRepository;
+    private ConsumerReadRepository $apiConsumerReadRepository;
+    private ConsumerSpecification $shouldAutoApprove;
+
+    public function __construct(
+        OfferRepository $offerRepository,
+        ConsumerReadRepository $apiConsumerReadRepository,
+        ConsumerSpecification $shouldAutoApprove
+    ) {
+        $this->offerRepository = $offerRepository;
+        $this->apiConsumerReadRepository = $apiConsumerReadRepository;
+        $this->shouldAutoApprove = $shouldAutoApprove;
+    }
+
+    /**
+     * Listens to Published events on Offer classes, and check if the API key that was used to publish the Offer is
+     * allowed to have their offers auto-approved and if so approves it.
+     * Ideally this would dispatch an Approve command instead of working on the aggregate directly, but that's not
+     * possible because the user/API client does not have the AANBOD_BEHEREN permission in this context.
+     */
+    public function handle(DomainMessage $domainMessage): void
+    {
+        $event = $domainMessage->getPayload();
+        if (!($event instanceof AbstractPublished)) {
+            return;
+        }
+
+        $metadata = $domainMessage->getMetadata()->serialize();
+        if (!isset($metadata['auth_api_key'])) {
+            return;
+        }
+
+        $consumer = $this->apiConsumerReadRepository->getConsumer(new ApiKey($metadata['auth_api_key']));
+        if ($consumer === null) {
+            return;
+        }
+
+        $shouldAutoApprove = $this->shouldAutoApprove->satisfiedBy($consumer);
+        if ($shouldAutoApprove) {
+            $offer = $this->offerRepository->load($event->getItemId());
+            $offer->approve();
+            $this->offerRepository->save($offer);
+        }
+    }
+}

--- a/tests/Http/Event/EditEventRestControllerTest.php
+++ b/tests/Http/Event/EditEventRestControllerTest.php
@@ -6,9 +6,9 @@ namespace CultuurNet\UDB3\Http\Event;
 
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\QueryParameterApiKeyReader;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\Event\EventEditingServiceInterface;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
@@ -60,12 +60,12 @@ class EditEventRestControllerTest extends TestCase
     private $apiKey;
 
     /**
-     * @var ConsumerInterface|MockObject
+     * @var Consumer|MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|MockObject
+     * @var ConsumerSpecification|MockObject
      */
     private $shouldApprove;
 
@@ -76,10 +76,10 @@ class EditEventRestControllerTest extends TestCase
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
         $this->apiKeyReader = new QueryParameterApiKeyReader('apiKey');
         $this->consumerRepository = new InMemoryConsumerRepository();
-        $this->shouldApprove = $this->createMock(ConsumerSpecificationInterface::class);
+        $this->shouldApprove = $this->createMock(ConsumerSpecification::class);
 
         $this->apiKey = new ApiKey('f5278146-3133-48b8-ace4-7e3f0a49328a');
-        $this->consumer = $this->createMock(ConsumerInterface::class);
+        $this->consumer = $this->createMock(Consumer::class);
         $this->consumerRepository->setConsumer($this->apiKey, $this->consumer);
 
         $this->shouldApprove->expects($this->any())

--- a/tests/Http/Place/EditPlaceRestControllerTest.php
+++ b/tests/Http/Place/EditPlaceRestControllerTest.php
@@ -9,9 +9,9 @@ use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
 use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\Event\ReadModel\Relations\RepositoryInterface;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Language;
@@ -60,12 +60,12 @@ class EditPlaceRestControllerTest extends TestCase
     private $apiKey;
 
     /**
-     * @var ConsumerInterface|MockObject
+     * @var Consumer|MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|MockObject
+     * @var ConsumerSpecification|MockObject
      */
     private $shouldApprove;
 
@@ -76,10 +76,10 @@ class EditPlaceRestControllerTest extends TestCase
         $this->mediaManager  = $this->createMock(MediaManagerInterface::class);
         $this->iriGenerator = $this->createMock(IriGeneratorInterface::class);
         $this->consumerRepository = new InMemoryConsumerRepository();
-        $this->shouldApprove = $this->createMock(ConsumerSpecificationInterface::class);
+        $this->shouldApprove = $this->createMock(ConsumerSpecification::class);
 
         $this->apiKey = new ApiKey('f5278146-3133-48b8-ace4-7e3f0a49328a');
-        $this->consumer = $this->createMock(ConsumerInterface::class);
+        $this->consumer = $this->createMock(Consumer::class);
         $this->consumerRepository->setConsumer($this->apiKey, $this->consumer);
 
         $this->shouldApprove->expects($this->any())

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -12,9 +12,9 @@ use CultuurNet\UDB3\Address\Address;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
-use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReaderInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepositoryInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\ApiKey\Reader\ApiKeyReader;
+use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerReadRepository;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\Calendar\DayOfWeek;
@@ -113,9 +113,9 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->uuidFactory = $this->createMock(UuidFactoryInterface::class);
         $this->commandBus = new TraceableCommandBus();
         $this->imageCollectionFactory = $this->createMock(ImageCollectionFactory::class);
-        $this->consumerSpecification = $this->createMock(ConsumerSpecificationInterface::class);
-        $this->apiReader = $this->createMock(ApiKeyReaderInterface::class);
-        $this->consumerRepository = $this->createMock(ConsumerReadRepositoryInterface::class);
+        $this->consumerSpecification = $this->createMock(ConsumerSpecification::class);
+        $this->apiReader = $this->createMock(ApiKeyReader::class);
+        $this->consumerRepository = $this->createMock(ConsumerReadRepository::class);
 
         $this->importPlaceRequestHandler = new ImportPlaceRequestHandler(
             $this->aggregateRepository,

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Place;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
-use Broadway\Domain\DomainMessage;
 use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Address\Address;

--- a/tests/Model/Import/Event/EventDocumentImporterTest.php
+++ b/tests/Model/Import/Event/EventDocumentImporterTest.php
@@ -7,8 +7,8 @@ namespace CultuurNet\UDB3\Model\Import\Event;
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
-use CultuurNet\UDB3\ApiGuard\Consumer\ConsumerInterface;
-use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecificationInterface;
+use CultuurNet\UDB3\ApiGuard\Consumer\Consumer;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerSpecification;
 use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
@@ -87,12 +87,12 @@ class EventDocumentImporterTest extends TestCase
     private TraceableCommandBus $commandBus;
 
     /**
-     * @var ConsumerInterface|MockObject
+     * @var Consumer|MockObject
      */
     private $consumer;
 
     /**
-     * @var ConsumerSpecificationInterface|MockObject
+     * @var ConsumerSpecification|MockObject
      */
     private $shouldApprove;
 
@@ -103,8 +103,8 @@ class EventDocumentImporterTest extends TestCase
         $this->repository = $this->createMock(Repository::class);
         $this->imageCollectionFactory = $this->createMock(ImageCollectionFactory::class);
         $this->commandBus = new TraceableCommandBus();
-        $this->consumer = $this->createMock(ConsumerInterface::class);
-        $this->shouldApprove = $this->createMock(ConsumerSpecificationInterface::class);
+        $this->consumer = $this->createMock(Consumer::class);
+        $this->shouldApprove = $this->createMock(ConsumerSpecification::class);
 
         $eventDocumentImporter = new EventDocumentImporter(
             $this->repository,

--- a/tests/Offer/ProcessManagers/AutoApproveForUiTIDv1ApiKeysProcessManagerTest.php
+++ b/tests/Offer/ProcessManagers/AutoApproveForUiTIDv1ApiKeysProcessManagerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Offer\ProcessManagers;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
+use CultuurNet\UDB3\ApiGuard\Consumer\InMemoryConsumerRepository;
+use CultuurNet\UDB3\ApiGuard\Consumer\Specification\ConsumerIsInPermissionGroup;
+use CultuurNet\UDB3\ApiGuard\CultureFeed\CultureFeedConsumerAdapter;
+use CultuurNet\UDB3\Offer\Offer;
+use CultuurNet\UDB3\Offer\OfferRepository;
+use CultuurNet\UDB3\Place\Events\Moderation\Published;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AutoApproveForUiTIDv1ApiKeysProcessManagerTest extends TestCase
+{
+    private const AUTO_APPROVE_GROUP_ID = '123';
+
+    private MockObject $offerRepository;
+    private InMemoryConsumerRepository $consumerRepository;
+    private AutoApproveForUiTIDv1ApiKeysProcessManager $autoApproveForUiTIDv1ApiKeysProcessManager;
+
+    protected function setUp(): void
+    {
+        $this->offerRepository = $this->createMock(OfferRepository::class);
+        $this->consumerRepository = new InMemoryConsumerRepository();
+
+        $this->autoApproveForUiTIDv1ApiKeysProcessManager = new AutoApproveForUiTIDv1ApiKeysProcessManager(
+            $this->offerRepository,
+            $this->consumerRepository,
+            new ConsumerIsInPermissionGroup(self::AUTO_APPROVE_GROUP_ID)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_the_published_offer_if_there_is_no_api_key_in_the_metadata(): void
+    {
+        $id = 'df9dd502-b1bf-4d3d-aeab-f9155c98de42';
+        $date = new DateTimeImmutable('2024-01-01T16:00:00+01:00');
+        $domainMessage = DomainMessage::recordNow(1, 0, new Metadata([]), new Published($id, $date));
+
+        $this->offerRepository->expects($this->never())
+            ->method('load');
+
+        $this->offerRepository->expects($this->never())
+            ->method('save');
+
+        $this->autoApproveForUiTIDv1ApiKeysProcessManager->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_the_published_offer_if_there_is_no_consumer_for_the_api_key(): void
+    {
+        $id = 'df9dd502-b1bf-4d3d-aeab-f9155c98de42';
+        $date = new DateTimeImmutable('2024-01-01T16:00:00+01:00');
+        $metadata = ['auth_api_key' => '8af5f13f-a80f-4642-bdb6-bdc323dcb7eb'];
+        $domainMessage = DomainMessage::recordNow(1, 0, new Metadata($metadata), new Published($id, $date));
+
+        $this->offerRepository->expects($this->never())
+            ->method('load');
+
+        $this->offerRepository->expects($this->never())
+            ->method('save');
+
+        $this->autoApproveForUiTIDv1ApiKeysProcessManager->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_the_published_offer_if_the_consumer_is_not_in_the_auto_approve_group(): void
+    {
+        $id = 'df9dd502-b1bf-4d3d-aeab-f9155c98de42';
+        $date = new DateTimeImmutable('2024-01-01T16:00:00+01:00');
+        $metadata = ['auth_api_key' => '8af5f13f-a80f-4642-bdb6-bdc323dcb7eb'];
+        $domainMessage = DomainMessage::recordNow(1, 0, new Metadata($metadata), new Published($id, $date));
+
+        $cfConsumer = new \CultureFeed_Consumer();
+        $cfConsumer->apiKeySapi3 = '8af5f13f-a80f-4642-bdb6-bdc323dcb7eb';
+        $cfConsumer->group = ['456'];
+        $consumer = new CultureFeedConsumerAdapter($cfConsumer);
+
+        $this->consumerRepository->setConsumer(new ApiKey('8af5f13f-a80f-4642-bdb6-bdc323dcb7eb'), $consumer);
+
+        $this->offerRepository->expects($this->never())
+            ->method('load');
+
+        $this->offerRepository->expects($this->never())
+            ->method('save');
+
+        $this->autoApproveForUiTIDv1ApiKeysProcessManager->handle($domainMessage);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_approve_the_published_offer_if_the_consumer_is_in_the_auto_approve_group(): void
+    {
+        $id = 'df9dd502-b1bf-4d3d-aeab-f9155c98de42';
+        $date = new DateTimeImmutable('2024-01-01T16:00:00+01:00');
+        $metadata = ['auth_api_key' => '8af5f13f-a80f-4642-bdb6-bdc323dcb7eb'];
+        $domainMessage = DomainMessage::recordNow(1, 0, new Metadata($metadata), new Published($id, $date));
+
+        $cfConsumer = new \CultureFeed_Consumer();
+        $cfConsumer->apiKeySapi3 = '8af5f13f-a80f-4642-bdb6-bdc323dcb7eb';
+        $cfConsumer->group = [self::AUTO_APPROVE_GROUP_ID, '456'];
+        $consumer = new CultureFeedConsumerAdapter($cfConsumer);
+
+        $this->consumerRepository->setConsumer(new ApiKey('8af5f13f-a80f-4642-bdb6-bdc323dcb7eb'), $consumer);
+
+        $offer = $this->createMock(Offer::class);
+
+        $this->offerRepository->expects($this->once())
+            ->method('load')
+            ->with($id)
+            ->willReturn($offer);
+
+        $offer->expects($this->once())
+            ->method('approve');
+
+        $this->offerRepository->expects($this->once())
+            ->method('save')
+            ->with($offer);
+
+        $this->autoApproveForUiTIDv1ApiKeysProcessManager->handle($domainMessage);
+    }
+}


### PR DESCRIPTION
### Added

- Added support for `workflowStatus` property to explicitly set the desired workflow status when creating or updating a place

### Changed

- Auto-approval of places now happens via a process manager. This will also work for events, but events also still have auto-approval logic inside `EditEventRestController` and `EventDocumentImporter` for now.

---
Ticket: https://jira.uitdatabank.be/browse/III-4609
