### PR TITLE
III-4640 Ignore empty time spans

### DIFF
--- a/src/Http/Offer/LegacyCalendarRequestBodyParser.php
+++ b/src/Http/Offer/LegacyCalendarRequestBodyParser.php
@@ -22,7 +22,9 @@ final class LegacyCalendarRequestBodyParser implements RequestBodyParser
         $data = clone $data;
 
         if (isset($data->calendar) && $data->calendar instanceof stdClass) {
-            if (isset($data->calendar->timeSpans)) {
+            if (isset($data->calendar->timeSpans) &&
+                is_array($data->calendar->timeSpans) &&
+                count($data->calendar->timeSpans) > 0) {
                 $calendar = (new LegacyTimeSpansParser())->parse($data->calendar);
                 $data->subEvent = $calendar->subEvent;
             }

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -576,6 +576,77 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_ignores_an_empty_timeSpan(): void
+    {
+        $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($eventId);
+
+        $given = [
+            'mainLanguage' => 'nl',
+            'name' => 'Pannekoeken voor het goede doel',
+            'type' => [
+                'id' => '0.5.0.0.0',
+            ],
+            'theme' => [
+                'id' => '0.52.0.0.0',
+                'label' => 'Circus',
+            ],
+            'location' => [
+                'id' => '5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendar' => [
+                'calendarType' => 'permanent',
+                'timeSpans' => [],
+            ],
+        ];
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($given)
+            ->build('PUT');
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromMediaObjectReferences')
+            ->willReturn(new ImageCollection());
+
+        $this->aggregateRepository->expects($this->never())
+            ->method('load');
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save');
+
+        $response = $this->importEventRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode([
+                'id' => $eventId,
+                'eventId' => $eventId,
+                'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+            ]),
+            $response->getBody()->getContents()
+        );
+
+        $this->assertEquals(
+            [
+                new UpdateAudience($eventId, AudienceType::everyone()),
+                new UpdateBookingInfo($eventId, new BookingInfo()),
+                new UpdateContactPoint($eventId, new ContactPoint()),
+                new DeleteTypicalAgeRange($eventId),
+                new ImportLabels($eventId, new Labels()),
+                new ImportImages($eventId, new ImageCollection()),
+                new ImportVideos($eventId, new VideoCollection()),
+                new DeleteCurrentOrganizer($eventId),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_a_new_event_from_legacy_format_with_permanent_calendar(): void
     {
         $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';


### PR DESCRIPTION
### Fixed
- Ignored empty `timeSpans` array to avoid creating an empty `subEvent` array

---
Ticket: https://jira.uitdatabank.be/browse/III-4640
