### PR TITLE
III-4641 Allow location as plain string inside event

### DIFF
--- a/src/Http/Event/LegacyEventRequestBodyParser.php
+++ b/src/Http/Event/LegacyEventRequestBodyParser.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Http\Request\Body\LegacyNameRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
 
 final class LegacyEventRequestBodyParser implements RequestBodyParser
 {
@@ -35,8 +36,17 @@ final class LegacyEventRequestBodyParser implements RequestBodyParser
     {
         $data = $this->parser->parse($request)->getParsedBody();
 
-        if (is_object($data) && isset($data->location) && !isset($data->location->{'@id'}) && is_string($data->location->id)) {
-            $data->location->{'@id'} = $this->placeIriGenerator->iri($data->location->id);
+        if (is_object($data) && isset($data->location) && !isset($data->location->{'@id'})) {
+            if (is_object($data->location) && is_string($data->location->id)) {
+                $data->location->{'@id'} = $this->placeIriGenerator->iri($data->location->id);
+            }
+
+            // Added to handle the angular UI which passes the location as a string.
+            if (is_string($data->location)) {
+                $locationId = $data->location;
+                $data->location = new stdClass();
+                $data->location->{'@id'} = $this->placeIriGenerator->iri($locationId);
+            }
         }
 
         return $request->withParsedBody($data);

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -647,6 +647,74 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_location_in_string_format(): void
+    {
+        $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($eventId);
+
+        $given = [
+            'mainLanguage' => 'nl',
+            'name' => 'Pannekoeken voor het goede doel',
+            'type' => [
+                'id' => '0.5.0.0.0',
+            ],
+            'theme' => [
+                'id' => '0.52.0.0.0',
+                'label' => 'Circus',
+            ],
+            'location' => '5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            'calendar' => [
+                'calendarType' => 'permanent',
+            ],
+        ];
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($given)
+            ->build('PUT');
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromMediaObjectReferences')
+            ->willReturn(new ImageCollection());
+
+        $this->aggregateRepository->expects($this->never())
+            ->method('load');
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save');
+
+        $response = $this->importEventRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode([
+                'id' => $eventId,
+                'eventId' => $eventId,
+                'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+            ]),
+            $response->getBody()->getContents()
+        );
+
+        $this->assertEquals(
+            [
+                new UpdateAudience($eventId, AudienceType::everyone()),
+                new UpdateBookingInfo($eventId, new BookingInfo()),
+                new UpdateContactPoint($eventId, new ContactPoint()),
+                new DeleteTypicalAgeRange($eventId),
+                new ImportLabels($eventId, new Labels()),
+                new ImportImages($eventId, new ImageCollection()),
+                new ImportVideos($eventId, new VideoCollection()),
+                new DeleteCurrentOrganizer($eventId),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_a_new_event_from_legacy_format_with_permanent_calendar(): void
     {
         $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';


### PR DESCRIPTION
### Changed
- Allowed location as plain string inside event

Note: I did not add this to the docs because it was never documented and it seems that only the angular UI passes it as a plain string.

---
Ticket: https://jira.uitdatabank.be/browse/III-4641
