### PR TITLE
Add missing commandId expectations

### DIFF
--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -629,6 +629,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 'id' => $eventId,
                 'eventId' => $eventId,
                 'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
             ]),
             $response->getBody()->getContents()
         );
@@ -697,6 +698,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 'id' => $eventId,
                 'eventId' => $eventId,
                 'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
             ]),
             $response->getBody()->getContents()
         );
@@ -3050,6 +3052,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 'id' => $eventId,
                 'eventId' => $eventId,
                 'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
             ]),
             $response->getBody()->getContents()
         );


### PR DESCRIPTION
### Fixed

- Fixed tests that failed because they were not included in the branch of #954 and thus were not updated to also expected `commandId`

---
Ticket: https://jira.uitdatabank.be/browse/III-4645
