### PR TITLE
III-4638 Validate age range from before to

### DIFF
--- a/src/Http/Event/AgeRangeValidatingRequestBodyParser.php
+++ b/src/Http/Event/AgeRangeValidatingRequestBodyParser.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Event;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\Audience\AgeRangeDenormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AgeRangeValidatingRequestBodyParser implements RequestBodyParser
+{
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $data = $request->getParsedBody();
+        if (!isset($data->typicalAgeRange) || !is_string($data->typicalAgeRange)) {
+            return $request;
+        }
+
+        $ageRangeDenormalizer = new AgeRangeDenormalizer();
+        $from = $ageRangeDenormalizer->denormalizeFrom($data->typicalAgeRange, AgeRange::class);
+        $to = $ageRangeDenormalizer->denormalizeTo($data->typicalAgeRange, AgeRange::class);
+
+        if ($from && $to && $from->gt($to)) {
+            throw ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/typicalAgeRange',
+                    '"From" age should not be greater than the "to" age.'
+                )
+            );
+        }
+
+        return $request;
+    }
+}

--- a/src/Http/Event/ImportEventRequestHandler.php
+++ b/src/Http/Event/ImportEventRequestHandler.php
@@ -103,6 +103,7 @@ final class ImportEventRequestHandler implements RequestHandlerInterface
             $this->combinedRequestBodyParser,
             new IdPropertyPolyfillRequestBodyParser($this->eventIriGenerator, $eventId),
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::EVENT),
+            new AgeRangeValidatingRequestBodyParser(),
             new CalendarValidationRequestBodyParser(),
             new BookingInfoValidationRequestBodyParser(),
             MainLanguageValidatingRequestBodyParser::createForPlace(),

--- a/src/Model/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
@@ -11,10 +11,24 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class AgeRangeDenormalizer implements DenormalizerInterface
 {
-    /**
-     * @inheritdoc
-     */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): AgeRange
+    {
+        $parts = $this->getParts($data, $class, $format);
+
+        return new AgeRange($parts['from'], $parts['to']);
+    }
+
+    public function denormalizeFrom($data, $class, $format = null): ?Age
+    {
+        return $this->getParts($data, $class, $format)['from'];
+    }
+
+    public function denormalizeTo($data, $class, $format = null): ?Age
+    {
+        return $this->getParts($data, $class, $format)['to'];
+    }
+
+    private function getParts($data, $class, $format): array
     {
         if (!$this->supportsDenormalization($data, $class, $format)) {
             throw new UnsupportedException("AgeRangeDenormalizer does not support {$class}.");
@@ -30,13 +44,16 @@ class AgeRangeDenormalizer implements DenormalizerInterface
         $from = empty($from) ? new Age(0) : new Age((int) $from);
         $to = empty($to) ? null : new Age((int) $to);
 
-        return new AgeRange($from, $to);
+        return [
+            'from' => $from,
+            'to' => $to,
+        ];
     }
 
     /**
      * @inheritdoc
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return $type === AgeRange::class;
     }

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -2973,6 +2973,38 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_if_typicalAgeRange_to_value_is_smaller(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannekoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'typicalAgeRange' => '12-8',
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/typicalAgeRange',
+                '"From" age should not be greater than the "to" age.'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_if_workflowStatus_has_unknown_value(): void
     {
         $event = [


### PR DESCRIPTION
### Fixed
- Validated age range to make sure from is before to

Note: follow-up ticket [III-4647](https://jira.uitdatabank.be/browse/III-4647) to convert `InvalidArgumentException` to Internal server error

---
Ticket: https://jira.uitdatabank.be/browse/III-4638
