### PR TITLE
III-4503 Align mediaObject / images JSON schema

### DIFF
--- a/app/Media/MediaControllerProvider.php
+++ b/app/Media/MediaControllerProvider.php
@@ -30,7 +30,8 @@ class MediaControllerProvider implements ControllerProviderInterface
         $app['media_editing_controller'] = $app->share(
             function (Application $app) {
                 return new EditMediaRestController(
-                    $app['image_uploader']
+                    $app['image_uploader'],
+                    $app['media_object_iri_generator']
                 );
             }
         );

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\EventFactory;
+use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
@@ -38,14 +39,6 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
             }
         );
 
-        $app['real_organizer_jsonld_repository'] = $app->share(
-            function ($app) {
-                return new CacheDocumentRepository(
-                    $app['organizer_jsonld_cache']
-                );
-            }
-        );
-
         $app[self::JSONLD_PROJECTED_EVENT_FACTORY] = $app->share(
             function ($app) {
                 return new EventFactory(
@@ -56,8 +49,11 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
 
         $app['organizer_jsonld_repository'] = $app->share(
             function ($app) {
+                $repository = new CacheDocumentRepository($app['organizer_jsonld_cache']);
+                $repository = new NewPropertyPolyfillOfferRepository($repository);
+
                 return new BroadcastingDocumentRepositoryDecorator(
-                    $app['real_organizer_jsonld_repository'],
+                    $repository,
                     $app['event_bus'],
                     $app[self::JSONLD_PROJECTED_EVENT_FACTORY]
                 );

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\EventFactory;
-use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\PropertyPolyfillRepository;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
@@ -50,7 +50,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
         $app['organizer_jsonld_repository'] = $app->share(
             function ($app) {
                 $repository = new CacheDocumentRepository($app['organizer_jsonld_cache']);
-                $repository = new NewPropertyPolyfillOfferRepository($repository);
+                $repository = new PropertyPolyfillRepository($repository);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-unreleased",
+    "publiq/stoplight-docs-uitdatabank": "dev-III-4503-organizer-images-imports",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75eb19a7f1b794d4b65c8ad9fd51ac04",
+    "content-hash": "9bf49f74738e3190eaa21ba4b5937ff7",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5064,16 +5064,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-unreleased",
+            "version": "dev-III-4503-organizer-images-imports",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "1122ee2087bdd614cf46ba58ecea8a5eaa61f218"
+                "reference": "abdf443ca6fd318ed24523c34f9ed5b4cfb89106"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/1122ee2087bdd614cf46ba58ecea8a5eaa61f218",
-                "reference": "1122ee2087bdd614cf46ba58ecea8a5eaa61f218",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/abdf443ca6fd318ed24523c34f9ed5b4cfb89106",
+                "reference": "abdf443ca6fd318ed24523c34f9ed5b4cfb89106",
                 "shasum": ""
             },
             "type": "library",
@@ -5090,9 +5090,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/unreleased"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/III-4503-organizer-images-imports"
             },
-            "time": "2022-03-22T10:43:31+00:00"
+            "time": "2022-03-29T11:27:08+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/Media/EditMediaRestController.php
+++ b/src/Http/Media/EditMediaRestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Media;
 
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -13,14 +14,13 @@ use CultuurNet\UDB3\StringLiteral;
 
 class EditMediaRestController
 {
-    /**
-     * @var ImageUploaderInterface
-     */
-    private $imageUploader;
+    private ImageUploaderInterface $imageUploader;
+    private IriGeneratorInterface $iriGenerator;
 
-    public function __construct(ImageUploaderInterface $imageUploader)
+    public function __construct(ImageUploaderInterface $imageUploader, IriGeneratorInterface $iriGenerator)
     {
         $this->imageUploader = $imageUploader;
+        $this->iriGenerator = $iriGenerator;
     }
 
     public function upload(Request $request): JsonResponse
@@ -56,6 +56,7 @@ class EditMediaRestController
 
         return new JsonResponse(
             [
+                '@id' => $this->iriGenerator->iri($imageId->toString()),
                 'imageId' => $imageId->toString(),
             ],
             201

--- a/src/Media/Serialization/MediaObjectSerializer.php
+++ b/src/Media/Serialization/MediaObjectSerializer.php
@@ -36,6 +36,7 @@ class MediaObjectSerializer
         return  [
             '@id' => $this->iriGenerator->iri($mediaObject->getMediaObjectId()->toString()),
             '@type' => $type,
+            'id' => $mediaObject->getMediaObjectId()->toString(),
             'contentUrl' => $mediaObject->getSourceLocation()->toString(),
             'thumbnailUrl' => $mediaObject->getSourceLocation()->toString(),
             'description' => (string) $mediaObject->getDescription(),

--- a/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
@@ -36,9 +36,9 @@ final class ImageNormalizer implements NormalizerInterface
             'id' => $image->getId()->toString(),
             'contentUrl' => $mediaObject->getSourceLocation()->toString(),
             'thumbnailUrl' => $mediaObject->getSourceLocation()->toString(),
-            'language' => $image->getLanguage()->toString(),
             'description' => $image->getDescription()->toString(),
             'copyrightHolder' => $image->getCopyrightHolder()->toString(),
+            'inLanguage' => $image->getLanguage()->toString(),
         ];
     }
 

--- a/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImageNormalizer.php
@@ -32,6 +32,7 @@ final class ImageNormalizer implements NormalizerInterface
 
         return [
             '@id' => $this->mediaIriGenerator->iri($image->getId()->toString()),
+            '@type' => 'schema:ImageObject',
             'id' => $image->getId()->toString(),
             'contentUrl' => $mediaObject->getSourceLocation()->toString(),
             'thumbnailUrl' => $mediaObject->getSourceLocation()->toString(),

--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -23,6 +23,7 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
     {
         return $jsonDocument->applyAssoc(
             function (array $json) {
+                $json = $this->polyfillMediaObjectId($json);
                 $json = $this->polyfillStatus($json);
                 $json = $this->polyfillBookingAvailability($json);
                 $json = $this->polyfillSubEventProperties($json);
@@ -30,6 +31,28 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
                 return $this->polyfillEmbeddedPlaceBookingAvailability($json);
             }
         );
+    }
+
+    private function polyfillMediaObjectId(array $json): array
+    {
+        if (!isset($json['mediaObject']) || !is_array($json['mediaObject'])) {
+            return $json;
+        }
+
+        $json['mediaObject'] = array_map(
+            function ($mediaObject) {
+                if (!is_array($mediaObject) || isset($mediaObject['id']) || !isset($mediaObject['@id'])) {
+                    return $mediaObject;
+                }
+                $urlParts = explode('/', $mediaObject['@id']);
+                $id = array_pop($urlParts);
+                $mediaObject['id'] = $id;
+                return $mediaObject;
+            },
+            $json['mediaObject']
+        );
+
+        return $json;
     }
 
     private function polyfillStatus(array $json): array

--- a/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
+++ b/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+
+final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
+{
+    public function fetch(string $id, bool $includeMetadata = false): JsonDocument
+    {
+        $document = parent::fetch($id, $includeMetadata);
+        $document = $this->polyfillNewProperties($document);
+        return $document;
+    }
+
+    private function polyfillNewProperties(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                $json = $this->polyfillImageType($json);
+                return $json;
+            }
+        );
+    }
+
+    private function polyfillImageType(array $json): array
+    {
+        if (!isset($json['images']) || !is_array($json['images'])) {
+            return $json;
+        }
+
+        $json['images'] = array_map(
+            function ($image) {
+                if (is_array($image) && !isset($image['@type'])) {
+                    $image['@type'] = 'schema:ImageObject';
+                }
+                return $image;
+            },
+            $json['images']
+        );
+
+        return $json;
+    }
+}

--- a/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
+++ b/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
@@ -21,6 +21,7 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
         return $jsonDocument->applyAssoc(
             function (array $json) {
                 $json = $this->polyfillImageType($json);
+                $json = $this->polyfillImageInLanguage($json);
                 return $json;
             }
         );
@@ -36,6 +37,26 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
             function ($image) {
                 if (is_array($image) && !isset($image['@type'])) {
                     $image['@type'] = 'schema:ImageObject';
+                }
+                return $image;
+            },
+            $json['images']
+        );
+
+        return $json;
+    }
+
+    private function polyfillImageInLanguage(array $json): array
+    {
+        if (!isset($json['images']) || !is_array($json['images'])) {
+            return $json;
+        }
+
+        $json['images'] = array_map(
+            function ($image) {
+                if (is_array($image) && !isset($image['inLanguage']) && isset($image['language'])) {
+                    $image['inLanguage'] = $image['language'];
+                    unset($image['language']);
                 }
                 return $image;
             },

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4428,46 +4428,6 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_if_mediaObject_has_invalid_type(): void
-    {
-        $event = [
-            'mainLanguage' => 'nl',
-            'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
-            ],
-            'terms' => [
-                [
-                    'id' => '1.50.0.0.0',
-                ],
-            ],
-            'location' => [
-                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
-            ],
-            'calendarType' => 'permanent',
-            'mediaObject' => [
-                [
-                    '@id' => 'http://io.uitdatabank.dev/images/5cdacc0b-a96b-4613-81e0-1748c179432f',
-                    '@type' => 'schema:invalid',
-                    'description' => 'Example description',
-                    'copyrightHolder' => 'Example copyright holder',
-                    'inLanguage' => 'nl',
-                ],
-            ],
-        ];
-
-        $expectedErrors = [
-            new SchemaError(
-                '/mediaObject/0/%40type',
-                'The data should match one item from enum'
-            ),
-        ];
-
-        $this->assertValidationErrors($event, $expectedErrors);
-    }
-
-    /**
-     * @test
-     */
     public function it_throws_if_mediaObject_description_is_empty(): void
     {
         $event = [

--- a/tests/Http/Media/EditMediaRestControllerTest.php
+++ b/tests/Http/Media/EditMediaRestControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Media;
 
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -16,17 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EditMediaRestControllerTest extends TestCase
 {
-    /**
-     * @var ImageUploaderInterface|MockObject
-     */
-    protected $imageUploader;
+    private MockObject $imageUploader;
+    private EditMediaRestController $controller;
 
-    /**
-     * @var EditMediaRestController
-     */
-    protected $controller;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->imageUploader = $this->createMock(ImageUploaderInterface::class);
 
@@ -43,13 +37,13 @@ class EditMediaRestControllerTest extends TestCase
     public function it_should_return_an_error_response_when_media_meta_data_is_missing_for_an_upload(
         Request $uploadRequest,
         Response $expectedErrorResponse
-    ) {
+    ): void {
         $response = $this->controller->upload($uploadRequest);
 
         $this->assertEquals($expectedErrorResponse->getContent(), $response->getContent());
     }
 
-    public function incompleteUploadRequestsProvider()
+    public function incompleteUploadRequestsProvider(): array
     {
         return [
             'missing description' => [
@@ -114,7 +108,7 @@ class EditMediaRestControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_pass_along_upload_data_to_the_image_uploader_create_a_job_and_return_a_command_id()
+    public function it_should_pass_along_upload_data_to_the_image_uploader_create_a_job_and_return_a_command_id(): void
     {
         $uploadRequest = new Request(
             [],
@@ -139,7 +133,7 @@ class EditMediaRestControllerTest extends TestCase
 
         $response = $this->controller->upload($uploadRequest);
 
-        $expectedResponseContent = json_encode([
+        $expectedResponseContent = Json::encode([
             '@id' => 'https://io.uitdatabank.dev/images/' . $imageId->toString(),
             'imageId' => $imageId->toString(),
         ]);

--- a/tests/Http/Media/EditMediaRestControllerTest.php
+++ b/tests/Http/Media/EditMediaRestControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Media;
 
+use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -29,7 +30,10 @@ class EditMediaRestControllerTest extends TestCase
     {
         $this->imageUploader = $this->createMock(ImageUploaderInterface::class);
 
-        $this->controller = new EditMediaRestController($this->imageUploader);
+        $this->controller = new EditMediaRestController(
+            $this->imageUploader,
+            new CallableIriGenerator(fn (string $item) => 'https://io.uitdatabank.dev/images/' . $item)
+        );
     }
 
     /**
@@ -136,6 +140,7 @@ class EditMediaRestControllerTest extends TestCase
         $response = $this->controller->upload($uploadRequest);
 
         $expectedResponseContent = json_encode([
+            '@id' => 'https://io.uitdatabank.dev/images/' . $imageId->toString(),
             'imageId' => $imageId->toString(),
         ]);
 

--- a/tests/Http/Media/ReadMediaRestControllerTest.php
+++ b/tests/Http/Media/ReadMediaRestControllerTest.php
@@ -72,6 +72,7 @@ class ReadMediaRestControllerTest extends TestCase
             Json::encode([
                 '@id' => 'https://io.uitdatabank.be/images/5624b810-c340-40a4-8f38-0393eca59bfe',
                 '@type' => 'schema:ImageObject',
+                'id' => '5624b810-c340-40a4-8f38-0393eca59bfe',
                 'contentUrl' => 'https://images.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg',
                 'thumbnailUrl' => 'https://images.uitdatabank.be/123/5624b810-c340-40a4-8f38-0393eca59bfe.jpg',
                 'description' => 'UDB2 image',

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -907,7 +907,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                             'contentUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
                             'thumbnailUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
                             'id' => '08805a3c-ffe0-4c94-a1bc-453a6dd9d01f',
-                            'language' => 'en',
+                            'inLanguage' => 'en',
                             'description' => '        ',
                             'copyrightHolder' => '      ',
                         ],

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -4623,54 +4623,6 @@ final class ImportPlaceRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_throw_an_exception_if_mediaObject_has_an_invalid_type(): void
-    {
-        $place = [
-            '@id' => 'http://io.uitdatabank.be/place/b19d4090-db47-4520-ac1a-880684357ec9',
-            'mainLanguage' => 'nl',
-            'name' => [
-                'nl' => 'Test place',
-            ],
-            'calendarType' => 'permanent',
-            'terms' => [
-                [
-                    'id' => 'Yf4aZBfsUEu2NsQqsprngw',
-                    'domain' => 'eventtype',
-                    'label' => 'Cultuur- of ontmoetingscentrum',
-                ],
-            ],
-            'address' => [
-                'nl' => [
-                    'streetAddress' => 'Henegouwenkaai 41-43',
-                    'postalCode' => '1080',
-                    'addressLocality' => 'Brussel',
-                    'addressCountry' => 'BE',
-                ],
-            ],
-            'mediaObject' => [
-                [
-                    '@id' => 'http://io.uitdatabank.be/media/5cdacc0b-a96b-4613-81e0-1748c179432f',
-                    '@type' => 'schema:foo',
-                    'description' => 'Example description',
-                    'copyrightHolder' => 'Example copyright holder',
-                    'inLanguage' => 'nl',
-                ],
-            ],
-        ];
-
-        $expectedErrors = [
-            new SchemaError(
-                '/mediaObject/0/%40type',
-                'The data should match one item from enum'
-            ),
-        ];
-
-        $this->assertValidationErrors($place, $expectedErrors);
-    }
-
-    /**
-     * @test
-     */
     public function it_should_throw_an_exception_if_videos_has_an_invalid_format(): void
     {
         $place = [

--- a/tests/Media/Serialization/MediaObjectSerializerTest.php
+++ b/tests/Media/Serialization/MediaObjectSerializerTest.php
@@ -57,6 +57,7 @@ class MediaObjectSerializerTest extends TestCase
         $expectedJsonld = [
             '@id' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014',
             '@type' => 'schema:ImageObject',
+            'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
             'thumbnailUrl' => 'http://foo.bar/media/my_pic.jpg',
             'contentUrl' => 'http://foo.bar/media/my_pic.jpg',
             'description' => 'my pic',
@@ -91,6 +92,7 @@ class MediaObjectSerializerTest extends TestCase
         $expectedJsonld = [
             '@id' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014',
             '@type' => 'schema:mediaObject',
+            'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
             'thumbnailUrl' => 'http://foo.bar/media/my_pic.jpg',
             'contentUrl' => 'http://foo.bar/media/my_pic.jpg',
             'description' => 'my pic',
@@ -125,6 +127,7 @@ class MediaObjectSerializerTest extends TestCase
         $expectedJsonld = [
             '@id' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014',
             '@type' => 'schema:ImageObject',
+            'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
             'thumbnailUrl' => 'http://foo.bar/media/my_pic.jpg',
             'contentUrl' => 'http://foo.bar/media/my_pic.jpg',
             'description' => 'my pic',

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -27,6 +27,79 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_should_polyfill_a_mediaObject_id_based_on_the_id_url_if_not_set(): void
+    {
+        $this
+            ->given(
+                [
+                    'mediaObject' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            'id' => '29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                        ],
+                        'invalid',
+                        [
+                            '@id_missing' => true,
+                        ],
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'mediaObject' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                            'id' => 'b01d92c0-5e53-4341-9625-c2264325d8c6',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            'id' => '29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                        ],
+                        'invalid',
+                        [
+                            '@id_missing' => true,
+                        ],
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_mediaObject_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('mediaObject');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_ignore_invalid_mediaObject_type(): void
+    {
+        $this
+            ->given(
+                [
+                    'mediaObject' => 'invalid!'
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'mediaObject' => 'invalid!'
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_polyfill_a_default_status_if_not_set(): void
     {
         $this

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -87,12 +87,12 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
         $this
             ->given(
                 [
-                    'mediaObject' => 'invalid!'
+                    'mediaObject' => 'invalid!',
                 ]
             )
             ->assertReturnedDocumentContains(
                 [
-                    'mediaObject' => 'invalid!'
+                    'mediaObject' => 'invalid!',
                 ]
             );
     }

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -517,6 +517,7 @@ class OfferLDProjectorTest extends TestCase
             (object) [
                 '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
                 '@type' => 'schema:ImageObject',
+                'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                 'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                 'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                 'description' => 'The Gleaners',
@@ -1685,6 +1686,7 @@ class OfferLDProjectorTest extends TestCase
             (object) [
                 '@id' => 'http://example.com/entity/ED5B9B25-8C16-48E5-9899-27BB2D110C57',
                 '@type' => 'schema:ImageObject',
+                'id' => 'ED5B9B25-8C16-48E5-9899-27BB2D110C57',
                 'contentUrl' => 'http://foo.bar/media/ED5B9B25-8C16-48E5-9899-27BB2D110C57.jpg',
                 'thumbnailUrl' => 'http://foo.bar/media/ED5B9B25-8C16-48E5-9899-27BB2D110C57.jpg',
                 'description' => 'epische panorama foto',
@@ -1694,6 +1696,7 @@ class OfferLDProjectorTest extends TestCase
             (object) [
                 '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
                 '@type' => 'schema:ImageObject',
+                'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                 'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                 'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                 'description' => 'The Gleaners',
@@ -1709,6 +1712,7 @@ class OfferLDProjectorTest extends TestCase
                     (object) [
                         '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
                         '@type' => 'schema:ImageObject',
+                        'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                         'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                         'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                         'description' => 'The Gleaners',
@@ -1756,6 +1760,7 @@ class OfferLDProjectorTest extends TestCase
                     (object)[
                         '@type' => 'schema:ImageObject',
                         '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
+                        'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                         'contentUrl' => 'http://foo.bar/media/my_pic.jpg',
                         'thumbnailUrl' => 'http://foo.bar/media/my_pic.jpg',
                         'description' => 'my pic',
@@ -1765,6 +1770,7 @@ class OfferLDProjectorTest extends TestCase
                     (object)[
                         '@type' => 'schema:ImageObject',
                         '@id' => 'http://example.com/entity/e56e8eb6-dcd7-47e7-8106-8a149f1d241b',
+                        'id' => 'e56e8eb6-dcd7-47e7-8106-8a149f1d241b',
                         'contentUrl' => 'http://foo.bar/media/img_182.jpg',
                         'thumbnailUrl' => 'http://foo.bar/media/img_182.jpg',
                         'description' => 'my favorite selfie',

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -233,6 +233,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
                 (object)[
                     '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',
                     '@type' => 'schema:ImageObject',
+                    'id' => 'de305d54-75b4-431b-adb2-eb6b9e546014',
                     'contentUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                     'thumbnailUrl' => 'http://foo.bar/media/de305d54-75b4-431b-adb2-eb6b9e546014.png',
                     'description' => (string) $description,

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -59,6 +59,54 @@ final class PropertyPolyfillRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_should_polyfill_an_image_inLanguage_if_not_set_but_language_is_set(): void
+    {
+        $this
+            ->given(
+                [
+                    'images' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                            '@type' => 'schema:ImageObject',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                            'language' => 'fr',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                            'inLanguage' => 'de',
+                        ],
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'images' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                            '@type' => 'schema:ImageObject',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                            'inLanguage' => 'fr',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                            'inLanguage' => 'de',
+                        ],
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_not_add_images_if_not_set(): void
     {
         $this

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
+
+use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
+use CultuurNet\UDB3\ReadModel\JsonDocument;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyPolyfillRepositoryTest extends TestCase
+{
+    private const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
+
+    private PropertyPolyfillRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = new PropertyPolyfillRepository(
+            new InMemoryDocumentRepository()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_polyfill_an_image_type_if_not_set(): void
+    {
+        $this
+            ->given(
+                [
+                    'images' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                        ],
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'images' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/b01d92c0-5e53-4341-9625-c2264325d8c6',
+                            '@type' => 'schema:ImageObject',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/29a88d72-2ec0-48ea-aa1c-5c083deea0c8',
+                            '@type' => 'schema:ImageObject',
+                        ],
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_images_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('images');
+    }
+
+    private function given(array $given): self
+    {
+        $this->repository->save(
+            new JsonDocument(
+                self::DOCUMENT_ID,
+                json_encode($given)
+            )
+        );
+        return $this;
+    }
+
+    private function assertReturnedDocumentContains(array $expected): void
+    {
+        $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
+        $this->assertArrayContainsExpectedKeys($expected, $actualFromFetch);
+    }
+
+    private function assertReturnedDocumentDoesNotContainKey(string $key): void
+    {
+        $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
+        $this->assertArrayNotHasKey($key, $actualFromFetch);
+    }
+
+    private function assertArrayContainsExpectedKeys(array $expected, array $actual): void
+    {
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $actual);
+            $this->assertEquals($value, $actual[$key]);
+        }
+    }
+}

--- a/tests/Organizer/Samples/organizer_with_image.json
+++ b/tests/Organizer/Samples/organizer_with_image.json
@@ -26,9 +26,9 @@
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
-      "language": "nl",
       "description": "Beschrijving van de afbeelding",
-      "copyrightHolder": "publiq"
+      "copyrightHolder": "publiq",
+      "inLanguage": "nl"
     }
   ],
   "mainImage": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",

--- a/tests/Organizer/Samples/organizer_with_image.json
+++ b/tests/Organizer/Samples/organizer_with_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "@type": "schema:ImageObject",
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",

--- a/tests/Organizer/Samples/organizer_with_two_images.json
+++ b/tests/Organizer/Samples/organizer_with_two_images.json
@@ -26,9 +26,9 @@
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
-      "language": "nl",
       "description": "Beschrijving van de afbeelding",
-      "copyrightHolder": "publiq"
+      "copyrightHolder": "publiq",
+      "inLanguage": "nl"
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
@@ -36,9 +36,9 @@
       "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
-      "language": "en",
       "description": "Extra image",
-      "copyrightHolder": "madewithlove"
+      "copyrightHolder": "madewithlove",
+      "inLanguage": "en"
     }
   ],
   "mainImage": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",

--- a/tests/Organizer/Samples/organizer_with_two_images.json
+++ b/tests/Organizer/Samples/organizer_with_two_images.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "@type": "schema:ImageObject",
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
@@ -31,6 +32,7 @@
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
+      "@type": "schema:ImageObject",
       "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",

--- a/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
+++ b/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
@@ -26,9 +26,9 @@
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
-      "language": "nl",
       "description": "Beschrijving van de afbeelding",
-      "copyrightHolder": "publiq"
+      "copyrightHolder": "publiq",
+      "inLanguage": "nl"
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
@@ -36,9 +36,9 @@
       "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
-      "language": "en",
       "description": "Extra image",
-      "copyrightHolder": "madewithlove"
+      "copyrightHolder": "madewithlove",
+      "inLanguage": "en"
     }
   ],
   "mainImage": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",

--- a/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
+++ b/tests/Organizer/Samples/organizer_with_two_images_and_updated_main_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "@type": "schema:ImageObject",
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
@@ -31,6 +32,7 @@
     },
     {
       "@id": "http://example.com/entity/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
+      "@type": "schema:ImageObject",
       "id": "dd45e5a1-f70c-48d7-83e5-dde9226c1dd6",
       "contentUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",
       "thumbnailUrl": "https://images.uitdatabank.be/dd45e5a1-f70c-48d7-83e5-dde9226c1dd6.png",

--- a/tests/Organizer/Samples/organizer_with_updated_image.json
+++ b/tests/Organizer/Samples/organizer_with_updated_image.json
@@ -22,6 +22,7 @@
   "images": [
     {
       "@id": "http://example.com/entity/03789a2f-5063-4062-b7cb-95a0a2280d92",
+      "@type": "schema:ImageObject",
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",

--- a/tests/Organizer/Samples/organizer_with_updated_image.json
+++ b/tests/Organizer/Samples/organizer_with_updated_image.json
@@ -26,9 +26,9 @@
       "id": "03789a2f-5063-4062-b7cb-95a0a2280d92",
       "contentUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
       "thumbnailUrl": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",
-      "language": "en",
       "description": "Updated description",
-      "copyrightHolder": "Updated copyright holder"
+      "copyrightHolder": "Updated copyright holder",
+      "inLanguage": "en"
     }
   ],
   "mainImage": "https://images.uitdatabank.be/03789a2f-5063-4062-b7cb-95a0a2280d92.jpg",


### PR DESCRIPTION
### Added

- Added `@id` in response of `POST /images`
- Added `id` to items inside `mediaObject` (on events/places) and in `GET /images/{imageId}`
- Added `@type` to items inside `images` (organizers)

### Changed

- Renamed `language` in items inside `images` (organizers) to `inLanguage`

---

Goal of this PR was to make `mediaObject` and `images` use exactly the same schema for items inside them, to make the import logic easier.

Ticket: https://jira.uitdatabank.be/browse/III-4503 (actual importing logic will be added in a next PR)
