### PR TITLE
III-4572 Handle empty time spans on event copy

### DIFF
--- a/src/Http/Offer/LegacyCalendarRequestBodyParser.php
+++ b/src/Http/Offer/LegacyCalendarRequestBodyParser.php
@@ -22,10 +22,8 @@ final class LegacyCalendarRequestBodyParser implements RequestBodyParser
         $data = clone $data;
 
         if (isset($data->calendar) && $data->calendar instanceof stdClass) {
-            if (isset($data->calendar->timeSpans) &&
-                is_array($data->calendar->timeSpans) &&
-                count($data->calendar->timeSpans) > 0) {
-                $calendar = (new LegacyTimeSpansParser())->parse($data->calendar);
+            $calendar = (new LegacyTimeSpansParser())->parse($data->calendar);
+            if (isset($calendar->subEvent)) {
                 $data->subEvent = $calendar->subEvent;
             }
 

--- a/src/Http/Offer/LegacyTimeSpansParser.php
+++ b/src/Http/Offer/LegacyTimeSpansParser.php
@@ -16,22 +16,25 @@ final class LegacyTimeSpansParser
 
         // Rename timeSpans to subEvent
         if (isset($data->timeSpans) && is_array($data->timeSpans) && !isset($data->subEvent)) {
-            $data->subEvent = array_map(
-                function ($timeSpan) {
-                    // Rename start to startDate
-                    if ($timeSpan instanceof stdClass && isset($timeSpan->start)) {
-                        $timeSpan->startDate = $this->formatDateTime($timeSpan->start);
-                        unset($timeSpan->start);
-                    }
-                    // Rename end to endDate
-                    if ($timeSpan instanceof stdClass && isset($timeSpan->end)) {
-                        $timeSpan->endDate = $this->formatDateTime($timeSpan->end);
-                        unset($timeSpan->end);
-                    }
-                    return $timeSpan;
-                },
-                $data->timeSpans
-            );
+            if (count($data->timeSpans) > 0) {
+                $data->subEvent = array_map(
+                    function ($timeSpan) {
+                        // Rename start to startDate
+                        if ($timeSpan instanceof stdClass && isset($timeSpan->start)) {
+                            $timeSpan->startDate = $this->formatDateTime($timeSpan->start);
+                            unset($timeSpan->start);
+                        }
+                        // Rename end to endDate
+                        if ($timeSpan instanceof stdClass && isset($timeSpan->end)) {
+                            $timeSpan->endDate = $this->formatDateTime($timeSpan->end);
+                            unset($timeSpan->end);
+                        }
+                        return $timeSpan;
+                    },
+                    $data->timeSpans
+                );
+            }
+
             unset($data->timeSpans);
         }
 

--- a/tests/Http/Event/CopyEventRequestHandlerTest.php
+++ b/tests/Http/Event/CopyEventRequestHandlerTest.php
@@ -149,6 +149,17 @@ class CopyEventRequestHandlerTest extends TestCase
                     )
                 ),
             ],
+            'periodic_deprecated_empty_timeSpans' => [
+                'data' => (object) [
+                    'calendarType' => 'permanent',
+                    'timeSpans' => [],
+                ],
+                'expected_command' => new CopyEvent(
+                    self::ORIGINAL_EVENT_ID,
+                    self::NEW_EVENT_ID,
+                    new PermanentCalendar(new OpeningHours())
+                ),
+            ],
             'single_startDate_and_endDate_instead_of_subEvent' => [
                 'data' => (object) [
                     'calendarType' => 'single',


### PR DESCRIPTION
### Fixed
- Handled empty time spans also on event copy

---
Ticket: https://jira.uitdatabank.be/browse/III-4572
