### PR TITLE
III-4503 Organizer images imports

### DIFF
--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Http\Event\UpdateThemeRequestHandler;
 use CultuurNet\UDB3\Http\Import\ImportPriceInfoRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Model\Import\Event\EventCategoryResolver;
 use CultuurNet\UDB3\Model\Serializer\Event\EventDenormalizer;
 use Ramsey\Uuid\UuidFactory;
@@ -90,7 +91,11 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
                 new CombinedRequestBodyParser(
                     new LegacyEventRequestBodyParser($app['place_iri_generator']),
                     new ImportTermRequestBodyParser(new EventCategoryResolver()),
-                    new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations'])
+                    new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations']),
+                    ImagesPropertyPolyfillRequestBodyParser::createForEvents(
+                        $app['media_object_iri_generator'],
+                        $app['media_object_repository']
+                    )
                 ),
                 $app['imports_command_bus'],
                 $app['import_image_collection_factory']

--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddLabelHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteDescriptionHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\ImportImagesHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\ImportLabelsHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveImageHandler;
@@ -112,6 +113,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[RemoveImageHandler::class] = $app->share(
             fn (Application $application) => new RemoveImageHandler($app['organizer_repository'])
+        );
+
+        $app[ImportImagesHandler::class] = $app->share(
+            fn (Application $application) => new ImportImagesHandler($app['organizer_repository'])
         );
     }
 

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -22,6 +22,7 @@ use CultuurNet\UDB3\Http\Organizer\UpdateMainImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateTitleRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\UpdateUrlRequestHandler;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use CultuurNet\UDB3\Http\Offer\OfferPermissionsController;
 use Silex\Application;
@@ -79,7 +80,11 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
                 $app['uuid_generator'],
                 $app['organizer_iri_generator'],
                 new CombinedRequestBodyParser(
-                    new LegacyOrganizerRequestBodyParser()
+                    new LegacyOrganizerRequestBodyParser(),
+                    ImagesPropertyPolyfillRequestBodyParser::createForOrganizers(
+                        $app['media_object_iri_generator'],
+                        $app['media_object_repository']
+                    )
                 )
             )
         );

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Http\Place\LegacyPlaceRequestBodyParser;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler;
 use CultuurNet\UDB3\Http\Place\EditPlaceRestController;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Model\Import\Place\PlaceCategoryResolver;
 use CultuurNet\UDB3\Model\Serializer\Place\PlaceDenormalizer;
 use Silex\Application;
@@ -79,7 +80,11 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
                 new CombinedRequestBodyParser(
                     new LegacyPlaceRequestBodyParser(),
                     new ImportTermRequestBodyParser(new PlaceCategoryResolver()),
-                    new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations'])
+                    new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations']),
+                    ImagesPropertyPolyfillRequestBodyParser::createForPlaces(
+                        $app['media_object_iri_generator'],
+                        $app['media_object_repository']
+                    )
                 ),
                 $app['place_iri_generator'],
                 $app['imports_command_bus'],

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -41,6 +41,7 @@ use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataProjector;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteDescriptionHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\ImportImagesHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveAddressHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\RemoveImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\UpdateAddressHandler;
@@ -632,6 +633,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[UpdateMainImageHandler::class]);
         $commandBus->subscribe($app[UpdateImageHandler::class]);
         $commandBus->subscribe($app[RemoveImageHandler::class]);
+        $commandBus->subscribe($app[ImportImagesHandler::class]);
 
         $commandBus->subscribe($app[LabelServiceProvider::COMMAND_HANDLER]);
     };

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-III-4503-organizer-images-imports",
+    "publiq/stoplight-docs-uitdatabank": "dev-III-4503-imports",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bf49f74738e3190eaa21ba4b5937ff7",
+    "content-hash": "014b3c2caacf2cb4b2880bdf85c26dfd",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5064,16 +5064,16 @@
         },
         {
             "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-III-4503-organizer-images-imports",
+            "version": "dev-III-4503-imports",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "abdf443ca6fd318ed24523c34f9ed5b4cfb89106"
+                "reference": "70a22333fdc6c54a21bce798bae0e270bfc032e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/abdf443ca6fd318ed24523c34f9ed5b4cfb89106",
-                "reference": "abdf443ca6fd318ed24523c34f9ed5b4cfb89106",
+                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/70a22333fdc6c54a21bce798bae0e270bfc032e7",
+                "reference": "70a22333fdc6c54a21bce798bae0e270bfc032e7",
                 "shasum": ""
             },
             "type": "library",
@@ -5090,9 +5090,9 @@
             "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
             "support": {
                 "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/III-4503-organizer-images-imports"
+                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/III-4503-imports"
             },
-            "time": "2022-03-29T11:27:08+00:00"
+            "time": "2022-03-29T14:00:54+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -467,13 +467,15 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
         StringLiteral $description,
-        CopyrightHolder $copyrightHolder
+        CopyrightHolder $copyrightHolder,
+        string $language
     ): ImageUpdated {
         return new ImageUpdated(
             $this->eventId,
             $mediaObjectId,
             $description,
-            $copyrightHolder
+            $copyrightHolder,
+            $language
         );
     }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -468,7 +468,7 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
         UUID $mediaObjectId,
         StringLiteral $description,
         CopyrightHolder $copyrightHolder,
-        string $language
+        ?string $language = null
     ): ImageUpdated {
         return new ImageUpdated(
             $this->eventId,

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -110,6 +110,11 @@ final class ApiProblem extends Exception
         return $this->schemaErrors;
     }
 
+    public function appendSchemaErrors(SchemaError ...$schemaErrors): void
+    {
+        $this->schemaErrors = array_merge($this->schemaErrors, $schemaErrors);
+    }
+
     /**
      * @deprecated
      *   Remove once all usages of this are removed

--- a/src/Http/Organizer/ImportOrganizerRequestHandler.php
+++ b/src/Http/Organizer/ImportOrganizerRequestHandler.php
@@ -25,6 +25,7 @@ use CultuurNet\UDB3\Model\Organizer\Organizer;
 use CultuurNet\UDB3\Model\Serializer\Organizer\OrganizerDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use CultuurNet\UDB3\Organizer\Commands\ImportImages;
 use CultuurNet\UDB3\Organizer\Commands\ImportLabels;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateAddress;
@@ -163,6 +164,7 @@ final class ImportOrganizerRequestHandler implements RequestHandlerInterface
         }
 
         $commands[] = new ImportLabels($organizerId, $data->getLabels());
+        $commands[] = new ImportImages($organizerId, $data->getImages());
 
         $lastCommandId = null;
         foreach ($commands as $command) {

--- a/src/Http/Request/Body/ImagesPropertyPolyfillRequestBodyParser.php
+++ b/src/Http/Request/Body/ImagesPropertyPolyfillRequestBodyParser.php
@@ -26,16 +26,16 @@ final class ImagesPropertyPolyfillRequestBodyParser implements RequestBodyParser
     private const PLACES = 'mediaObject';
     private const ORGANIZERS = 'images';
 
-    private string $propertyName;
+    private string $imagesPropertyName;
     private IriGeneratorInterface $iriGenerator;
     private MediaObjectRepository $mediaObjectRepository;
 
     private function __construct(
-        string $propertyName,
+        string $imagesPropertyName,
         IriGeneratorInterface $imagesIriGenerator,
         MediaObjectRepository $mediaObjectRepository
     ) {
-        $this->propertyName = $propertyName;
+        $this->imagesPropertyName = $imagesPropertyName;
         $this->iriGenerator = $imagesIriGenerator;
         $this->mediaObjectRepository = $mediaObjectRepository;
     }
@@ -72,7 +72,7 @@ final class ImagesPropertyPolyfillRequestBodyParser implements RequestBodyParser
             return $request;
         }
 
-        $propertyName = $this->propertyName;
+        $propertyName = $this->imagesPropertyName;
         if (!isset($data->$propertyName) || !is_array($data->$propertyName)) {
             return $request;
         }
@@ -131,7 +131,7 @@ final class ImagesPropertyPolyfillRequestBodyParser implements RequestBodyParser
         } catch (InvalidArgumentException $e) {
             throw ApiProblem::bodyInvalidData(
                 new SchemaError(
-                    '/' . $this->propertyName . '/' . $index . '/@id',
+                    '/' . $this->imagesPropertyName . '/' . $index . '/@id',
                     sprintf('Image with @id "%s" does not exist.', $imageIdUrl->toString())
                 )
             );
@@ -146,7 +146,7 @@ final class ImagesPropertyPolyfillRequestBodyParser implements RequestBodyParser
         } catch (AggregateNotFoundException $e) {
             throw ApiProblem::bodyInvalidData(
                 new SchemaError(
-                    '/' . $this->propertyName . '/' . $index . '/@id',
+                    '/' . $this->imagesPropertyName . '/' . $index . '/@id',
                     sprintf(
                         'Image with @id "%s" (id "%s") does not exist.',
                         $imageIdUrl->toString(),

--- a/src/Http/Request/Body/ImagesPropertyPolyfillRequestBodyParser.php
+++ b/src/Http/Request/Body/ImagesPropertyPolyfillRequestBodyParser.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request\Body;
+
+use Broadway\Repository\AggregateNotFoundException;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Iri\IriGeneratorInterface;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\MediaObjectRepository;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\MediaObjectIDParser;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
+
+/**
+ * Polyfills the mediaObject/images properties on incoming JSON-LD of events, places and organizers that need to be
+ * imported if they only contain an @id. Also generates an @id if missing but id is given.
+ */
+final class ImagesPropertyPolyfillRequestBodyParser implements RequestBodyParser
+{
+    private const EVENTS = 'mediaObject';
+    private const PLACES = 'mediaObject';
+    private const ORGANIZERS = 'images';
+
+    private string $propertyName;
+    private IriGeneratorInterface $iriGenerator;
+    private MediaObjectRepository $mediaObjectRepository;
+
+    private function __construct(
+        string $propertyName,
+        IriGeneratorInterface $imagesIriGenerator,
+        MediaObjectRepository $mediaObjectRepository
+    ) {
+        $this->propertyName = $propertyName;
+        $this->iriGenerator = $imagesIriGenerator;
+        $this->mediaObjectRepository = $mediaObjectRepository;
+    }
+
+    public static function createForEvents(
+        IriGeneratorInterface $imagesIriGenerator,
+        MediaObjectRepository $mediaObjectRepository
+    ): self {
+        return new self(self::EVENTS, $imagesIriGenerator, $mediaObjectRepository);
+    }
+
+    public static function createForPlaces(
+        IriGeneratorInterface $imagesIriGenerator,
+        MediaObjectRepository $mediaObjectRepository
+    ): self {
+        return new self(self::PLACES, $imagesIriGenerator, $mediaObjectRepository);
+    }
+
+    public static function createForOrganizers(
+        IriGeneratorInterface $imagesIriGenerator,
+        MediaObjectRepository $mediaObjectRepository
+    ): self {
+        return new self(self::ORGANIZERS, $imagesIriGenerator, $mediaObjectRepository);
+    }
+
+    /**
+     * @uses polyfillImageData
+     */
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $data = $request->getParsedBody();
+
+        if (!$data instanceof stdClass) {
+            return $request;
+        }
+
+        $propertyName = $this->propertyName;
+        if (!isset($data->$propertyName) || !is_array($data->$propertyName)) {
+            return $request;
+        }
+
+        /** @var ApiProblem[] $apiProblems */
+        $apiProblems = [];
+
+        $data->$propertyName = array_map(
+            function ($imageData, int $index) use (&$apiProblems) {
+                if ($imageData instanceof stdClass) {
+                    try {
+                        $imageData = $this->polyfillImageData($imageData, $index);
+                    } catch (ApiProblem $e) {
+                        $apiProblems[] = $e;
+                    }
+                }
+                return $imageData;
+            },
+            $data->$propertyName,
+            array_keys($data->$propertyName)
+        );
+
+        // If multiple ApiProblems are thrown, we can merge them since they will also be of the type
+        // https://api.publiq.be/probs/body/invalid-data in this case.
+        if (count($apiProblems) > 0) {
+            $first = array_shift($apiProblems);
+            foreach ($apiProblems as $apiProblem) {
+                $schemaErrors = $apiProblem->getSchemaErrors();
+                $first->appendSchemaErrors(...$schemaErrors);
+            }
+            throw $first;
+        }
+
+        return $request->withParsedBody($data);
+    }
+
+    private function polyfillImageData(stdClass $imageData, int $index): stdClass
+    {
+        // Polyfill @id if missing but id is set.
+        if (!isset($imageData->{'@id'}) && isset($imageData->id)) {
+            $imageData->{'@id'} = $this->iriGenerator->iri($imageData->id);
+        }
+
+        // If we have no @id or it's not valid at this point, we cannot polyfill any missing properties so return early.
+        // These errors will be handled later by the JSON schema validation.
+        if (!isset($imageData->{'@id'})) {
+            return $imageData;
+        }
+        try {
+            $imageIdUrl = new Url($imageData->{'@id'});
+        } catch (InvalidArgumentException $e) {
+            return $imageData;
+        }
+        try {
+            $imageId = (new MediaObjectIDParser())->fromUrl($imageIdUrl);
+        } catch (InvalidArgumentException $e) {
+            throw ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/' . $this->propertyName . '/' . $index . '/@id',
+                    sprintf('Image with @id "%s" does not exist.', $imageIdUrl->toString())
+                )
+            );
+        }
+
+        // Images do not have a read model at the time of writing, so we need to read the image aggregate from the
+        // event store to read its properties. If the image does not exist an ApiProblem should be thrown to avoid that
+        // we import non-existing images.
+        try {
+            /** @var MediaObject $image */
+            $image = $this->mediaObjectRepository->load($imageId->toString());
+        } catch (AggregateNotFoundException $e) {
+            throw ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/' . $this->propertyName . '/' . $index . '/@id',
+                    sprintf(
+                        'Image with @id "%s" (id "%s") does not exist.',
+                        $imageIdUrl->toString(),
+                        $imageId->toString()
+                    )
+                )
+            );
+        }
+
+        // Only set missing properties, so a client can also include overwrites for specific properties if wanted.
+        // Included properties will only be overwritten on the event/place/organizer, not on the image aggregate.
+        if (!isset($imageData->description)) {
+            $imageData->description = $image->getDescription()->toNative();
+        }
+        if (!isset($imageData->copyrightHolder)) {
+            $imageData->copyrightHolder = $image->getCopyrightHolder()->toString();
+        }
+        if (!isset($imageData->inLanguage)) {
+            $imageData->inLanguage = $image->getLanguage()->getCode();
+        }
+
+        return $imageData;
+    }
+}

--- a/src/Model/Organizer/ImmutableOrganizer.php
+++ b/src/Model/Organizer/ImmutableOrganizer.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedDescription;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
@@ -34,6 +35,8 @@ class ImmutableOrganizer implements Organizer
 
     private ContactPoint $contactPoint;
 
+    private Images $images;
+
     /**
      * @param Url|null $url
      *  When creating a new organizer a url is required.
@@ -53,6 +56,7 @@ class ImmutableOrganizer implements Organizer
 
         $this->labels = new Labels();
         $this->contactPoint = new ContactPoint();
+        $this->images = new Images();
     }
 
     public function getId(): UUID
@@ -161,6 +165,18 @@ class ImmutableOrganizer implements Organizer
     {
         $c = clone $this;
         $c->contactPoint = $contactPoint;
+        return $c;
+    }
+
+    public function getImages(): Images
+    {
+        return $this->images;
+    }
+
+    public function withImages(Images $images): ImmutableOrganizer
+    {
+        $c = clone $this;
+        $c->images = $images;
         return $c;
     }
 }

--- a/src/Model/Organizer/Organizer.php
+++ b/src/Model/Organizer/Organizer.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedDescription;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
@@ -33,4 +34,6 @@ interface Organizer
     public function getLabels(): Labels;
 
     public function getContactPoint(): ContactPoint;
+
+    public function getImages(): Images;
 }

--- a/src/Model/Serializer/Organizer/OrganizerDenormalizer.php
+++ b/src/Model/Serializer/Organizer/OrganizerDenormalizer.php
@@ -11,12 +11,14 @@ use CultuurNet\UDB3\Model\Organizer\OrganizerIDParser;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Contact\ContactPointDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Geography\CoordinatesDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Geography\TranslatedAddressDenormalizer;
+use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImagesDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Taxonomy\Label\LabelsDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Text\TranslatedDescriptionDenormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Text\TranslatedTitleDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Geography\TranslatedAddress;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedDescription;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
@@ -41,6 +43,8 @@ class OrganizerDenormalizer implements DenormalizerInterface
 
     private DenormalizerInterface $geoCoordinatesDenormalizer;
 
+    private DenormalizerInterface $imagesDenormalizer;
+
     public function __construct(
         UUIDParser $organizerIDParser = null,
         DenormalizerInterface $titleDenormalizer = null,
@@ -48,7 +52,8 @@ class OrganizerDenormalizer implements DenormalizerInterface
         DenormalizerInterface $addressDenormalizer = null,
         DenormalizerInterface $labelsDenormalizer = null,
         DenormalizerInterface $contactPointDenormalizer = null,
-        DenormalizerInterface $geoCoordinatesDenormalizer = null
+        DenormalizerInterface $geoCoordinatesDenormalizer = null,
+        DenormalizerInterface $imagesDenormalizer = null
     ) {
         if (!$organizerIDParser) {
             $organizerIDParser = new OrganizerIDParser();
@@ -78,6 +83,10 @@ class OrganizerDenormalizer implements DenormalizerInterface
             $geoCoordinatesDenormalizer = new CoordinatesDenormalizer();
         }
 
+        if (!$imagesDenormalizer) {
+            $imagesDenormalizer = new ImagesDenormalizer();
+        }
+
         $this->organizerIDParser = $organizerIDParser;
         $this->titleDenormalizer = $titleDenormalizer;
         $this->descriptionDenormalizer = $descriptionDenormalizer;
@@ -85,6 +94,7 @@ class OrganizerDenormalizer implements DenormalizerInterface
         $this->labelsDenormalizer = $labelsDenormalizer;
         $this->contactPointDenormalizer = $contactPointDenormalizer;
         $this->geoCoordinatesDenormalizer = $geoCoordinatesDenormalizer;
+        $this->imagesDenormalizer = $imagesDenormalizer;
     }
 
     /**
@@ -131,6 +141,7 @@ class OrganizerDenormalizer implements DenormalizerInterface
         $organizer = $this->denormalizeLabels($data, $organizer);
         $organizer = $this->denormalizeContactPoint($data, $organizer);
         $organizer = $this->denormalizeGeoCoordinates($data, $organizer);
+        $organizer = $this->denormalizeImages($data, $organizer);
 
         return $organizer;
     }
@@ -188,6 +199,15 @@ class OrganizerDenormalizer implements DenormalizerInterface
             $organizer = $organizer->withContactPoint($contactPoint);
         }
 
+        return $organizer;
+    }
+
+    private function denormalizeImages(array $data, ImmutableOrganizer $organizer): ImmutableOrganizer
+    {
+        if (isset($data['images'])) {
+            $images = $this->imagesDenormalizer->denormalize($data['images'], Images::class);
+            $organizer = $organizer->withImages($images);
+        }
         return $organizer;
     }
 

--- a/src/Model/Serializer/ValueObject/MediaObject/ImageDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImageDenormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject;
+
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\MediaObjectIDParser;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Web\Url;
+use Symfony\Component\Serializer\Exception\UnsupportedException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class ImageDenormalizer implements DenormalizerInterface
+{
+    /**
+     * @var UUIDParser
+     */
+    private $imageIdParser;
+
+    public function __construct(UUIDParser $imageIdParser = null)
+    {
+        if (!$imageIdParser) {
+            $imageIdParser = new MediaObjectIDParser();
+        }
+        $this->imageIdParser = $imageIdParser;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        if (!$this->supportsDenormalization($data, $class, $format)) {
+            throw new UnsupportedException("ImageDenormalizer does not support {$class}.");
+        }
+
+        if (!is_array($data)) {
+            throw new UnsupportedException('Images data should be an array.');
+        }
+
+        $id = $this->imageIdParser->fromUrl(new Url($data['@id']));
+        $description = new Description($data['description']);
+        $copyrightHolder = new CopyrightHolder($data['copyrightHolder']);
+        $language = new Language($data['inLanguage']);
+
+        return new Image($id, $language, $description, $copyrightHolder);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === Image::class;
+    }
+}

--- a/src/Model/Serializer/ValueObject/MediaObject/ImagesDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/MediaObject/ImagesDenormalizer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject;
+
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
+use Symfony\Component\Serializer\Exception\UnsupportedException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class ImagesDenormalizer implements DenormalizerInterface
+{
+    private DenormalizerInterface $imageDenormalizer;
+
+    public function __construct(DenormalizerInterface $imageDenormalizer = null)
+    {
+        if (!$imageDenormalizer) {
+            $imageDenormalizer = new ImageDenormalizer();
+        }
+        $this->imageDenormalizer = $imageDenormalizer;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        if (!$this->supportsDenormalization($data, $class, $format)) {
+            throw new UnsupportedException("ImagesDenormalizer does not support {$class}.");
+        }
+
+        if (!is_array($data)) {
+            throw new UnsupportedException('Images data should be an array.');
+        }
+
+        $images = array_map(
+            fn ($imageData) => $this->imageDenormalizer->denormalize($imageData, Image::class),
+            $data
+        );
+        return new Images(...$images);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === Images::class;
+    }
+}

--- a/src/Offer/Events/Image/AbstractImageUpdated.php
+++ b/src/Offer/Events/Image/AbstractImageUpdated.php
@@ -23,18 +23,26 @@ abstract class AbstractImageUpdated extends AbstractEvent
      */
     protected $copyrightHolder;
 
+    /**
+     * Nullable because this was missing in the past, so we don't have historical data for this.
+     * Also we cannot default it to `nl`, because an image could have been added in another language and that language
+     * needs to be respected.
+     */
+    private ?string $language;
+
     final public function __construct(
         string $itemId,
         UUID $mediaObjectId,
         StringLiteral $description,
-        CopyrightHolder $copyrightHolder
+        CopyrightHolder $copyrightHolder,
+        ?string $language = null
     ) {
         parent::__construct($itemId);
         $this->mediaObjectId = $mediaObjectId;
         $this->description = $description;
         $this->copyrightHolder = $copyrightHolder;
+        $this->language = $language;
     }
-
 
     public function getMediaObjectId(): UUID
     {
@@ -51,12 +59,18 @@ abstract class AbstractImageUpdated extends AbstractEvent
         return $this->copyrightHolder;
     }
 
+    public function getLanguage(): ?string
+    {
+        return $this->language;
+    }
+
     public function serialize(): array
     {
         return parent::serialize() +  [
             'media_object_id' => $this->mediaObjectId->toString(),
             'description' => (string) $this->description,
             'copyright_holder' => $this->copyrightHolder->toString(),
+            'language' => $this->language,
         ];
     }
 
@@ -66,7 +80,8 @@ abstract class AbstractImageUpdated extends AbstractEvent
             $data['item_id'],
             new UUID($data['media_object_id']),
             new StringLiteral($data['description']),
-            new CopyrightHolder($data['copyright_holder'])
+            new CopyrightHolder($data['copyright_holder']),
+            $data['language'] ?? null
         );
     }
 }

--- a/src/Offer/Events/Image/AbstractImageUpdated.php
+++ b/src/Offer/Events/Image/AbstractImageUpdated.php
@@ -66,12 +66,15 @@ abstract class AbstractImageUpdated extends AbstractEvent
 
     public function serialize(): array
     {
-        return parent::serialize() +  [
+        $data = parent::serialize() +  [
             'media_object_id' => $this->mediaObjectId->toString(),
             'description' => (string) $this->description,
             'copyright_holder' => $this->copyrightHolder->toString(),
-            'language' => $this->language,
         ];
+        if ($this->language) {
+            $data['language'] = $this->language;
+        }
+        return $data;
     }
 
     public static function deserialize(array $data): AbstractImageUpdated

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -653,7 +653,8 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
                 $this->createImageUpdatedEvent(
                     $updatedImage->getMediaObjectId(),
                     $updatedImage->getDescription(),
-                    $updatedImage->getCopyrightHolder()
+                    $updatedImage->getCopyrightHolder(),
+                    $updatedImage->getLanguage()->getCode()
                 )
             );
         }
@@ -1061,7 +1062,8 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
     abstract protected function createImageUpdatedEvent(
         UUID $uuid,
         StringLiteral $description,
-        CopyrightHolder $copyrightHolder
+        CopyrightHolder $copyrightHolder,
+        string $language
     ): AbstractImageUpdated;
 
     abstract protected function createMainImageSelectedEvent(Image $image): AbstractMainImageSelected;

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -1063,7 +1063,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         UUID $uuid,
         StringLiteral $description,
         CopyrightHolder $copyrightHolder,
-        string $language
+        ?string $language = null
     ): AbstractImageUpdated;
 
     abstract protected function createMainImageSelectedEvent(Image $image): AbstractMainImageSelected;

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -378,7 +378,9 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             if ($mediaObjectMatches) {
                 $mediaObject->description = (string) $imageUpdated->getDescription();
                 $mediaObject->copyrightHolder = $imageUpdated->getCopyrightHolder()->toString();
-                $mediaObject->inLanguage = $imageUpdated->getLanguage();
+                if ($imageUpdated->getLanguage()) {
+                    $mediaObject->inLanguage = $imageUpdated->getLanguage();
+                }
 
                 $updatedMediaObjects[] = $mediaObject;
             }

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -376,8 +376,9 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             );
 
             if ($mediaObjectMatches) {
-                $mediaObject->description = (string)$imageUpdated->getDescription();
+                $mediaObject->description = (string) $imageUpdated->getDescription();
                 $mediaObject->copyrightHolder = $imageUpdated->getCopyrightHolder()->toString();
+                $mediaObject->inLanguage = $imageUpdated->getLanguage();
 
                 $updatedMediaObjects[] = $mediaObject;
             }

--- a/src/Organizer/CommandHandler/ImportImagesHandler.php
+++ b/src/Organizer/CommandHandler/ImportImagesHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\ImportImages;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class ImportImagesHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof ImportImages) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getItemId());
+        $organizer->importImages($command->getImages());
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/Commands/ImportImages.php
+++ b/src/Organizer/Commands/ImportImages.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class ImportImages implements AuthorizableCommand
+{
+    private string $organizerId;
+    private Images $images;
+
+    public function __construct(string $organizerId, Images $images)
+    {
+        $this->organizerId = $organizerId;
+        $this->images = $images;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getImages(): Images
+    {
+        return $this->images;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::organisatiesBewerken();
+    }
+}

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -340,6 +340,42 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         );
     }
 
+    public function importImages(Images $images): void
+    {
+        $currentImages = $this->images->toArray();
+        $importImages = $images->toArray();
+
+        $compareImages = static function (Image $a, Image $b) {
+            $idA = $a->getId()->toString();
+            $idB = $b->getId()->toString();
+            return strcmp($idA, $idB);
+        };
+
+        /* @var Image[] $addedImages */
+        $addedImages = array_udiff($importImages, $currentImages, $compareImages);
+
+        /* @var Image[] $updatedImages */
+        $updatedImages = array_uintersect($importImages, $currentImages, $compareImages);
+
+        /* @var Image[] $removedImages */
+        $removedImages = array_udiff($currentImages, $importImages, $compareImages);
+
+        foreach ($addedImages as $addedImage) {
+            $this->addImage($addedImage);
+        }
+        foreach ($updatedImages as $updatedImage) {
+            $this->updateImage(
+                $updatedImage->getId(),
+                $updatedImage->getLanguage(),
+                $updatedImage->getDescription(),
+                $updatedImage->getCopyrightHolder()
+            );
+        }
+        foreach ($removedImages as $removedImage) {
+            $this->removeImage($removedImage->getId());
+        }
+    }
+
     public function updateMainImage(UUID $imageId): void
     {
         if ($this->needsUpdateMainImage($imageId)) {

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -345,11 +345,7 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
         $currentImages = $this->images->toArray();
         $importImages = $images->toArray();
 
-        $compareImages = static function (Image $a, Image $b) {
-            $idA = $a->getId()->toString();
-            $idB = $b->getId()->toString();
-            return strcmp($idA, $idB);
-        };
+        $compareImages = static fn (Image $a, Image $b) => strcmp($a->getId()->toString(), $b->getId()->toString());
 
         /* @var Image[] $addedImages */
         $addedImages = array_udiff($importImages, $currentImages, $compareImages);

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -400,7 +400,7 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
         UUID $mediaObjectId,
         StringLiteral $description,
         CopyrightHolder $copyrightHolder,
-        string $language
+        ?string $language = null
     ): ImageUpdated {
         return new ImageUpdated(
             $this->placeId,

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -399,13 +399,15 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
         StringLiteral $description,
-        CopyrightHolder $copyrightHolder
+        CopyrightHolder $copyrightHolder,
+        string $language
     ): ImageUpdated {
         return new ImageUpdated(
             $this->placeId,
             $mediaObjectId,
             $description,
-            $copyrightHolder
+            $copyrightHolder,
+            $language
         );
     }
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4462,7 +4462,7 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_if_mediaObject_is_missing_a_required_property(): void
+    public function it_throws_if_mediaObject_is_missing_id(): void
     {
         $event = [
             'mainLanguage' => 'nl',
@@ -4488,7 +4488,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/mediaObject/0',
-                'The required properties (@id, description, copyrightHolder, inLanguage) are missing'
+                'The required properties (@id) are missing'
             ),
         ];
 

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
 use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
@@ -35,6 +36,7 @@ use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Model\ValueObject\Web\Urls;
 use CultuurNet\UDB3\Organizer\Commands\DeleteDescription;
+use CultuurNet\UDB3\Organizer\Commands\ImportImages;
 use CultuurNet\UDB3\Organizer\Commands\ImportLabels;
 use CultuurNet\UDB3\Organizer\Commands\RemoveAddress;
 use CultuurNet\UDB3\Organizer\Commands\UpdateAddress;
@@ -108,6 +110,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             new DeleteDescription($organizerId, new Language('en')),
             new RemoveAddress($organizerId),
             new ImportLabels($organizerId, new Labels()),
+            new ImportImages($organizerId, new Images()),
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -245,6 +248,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                     new Label(new LabelName('bar'), false),
                 )
             ),
+            new ImportImages($id, new Images()),
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -311,6 +315,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             new DeleteDescription($id, new Language('en')),
             new RemoveAddress($id),
             new ImportLabels($id, new Labels()),
+            new ImportImages($id, new Images()),
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -373,6 +378,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             new DeleteDescription($organizerId, new Language('en')),
             new RemoveAddress($organizerId),
             new ImportLabels($organizerId, new Labels()),
+            new ImportImages($organizerId, new Images()),
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -457,6 +463,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                 new Language('nl')
             ),
             new ImportLabels($id, new Labels()),
+            new ImportImages($id, new Images()),
         ];
 
         $request = (new Psr7RequestBuilder())

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -13,9 +13,13 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
+use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\Language as LegacyLanguage;
+use CultuurNet\UDB3\Media\MediaObject;
+use CultuurNet\UDB3\Media\MediaObjectRepository;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumbers;
@@ -24,6 +28,9 @@ use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
 use CultuurNet\UDB3\Model\ValueObject\Geography\PostalCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Street;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
@@ -46,24 +53,31 @@ use CultuurNet\UDB3\Organizer\Commands\UpdateTitle;
 use CultuurNet\UDB3\Organizer\Commands\UpdateWebsite;
 use CultuurNet\UDB3\Organizer\Organizer;
 use CultuurNet\UDB3\Organizer\Organizer as OrganizerAggregate;
+use CultuurNet\UDB3\StringLiteral;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ImportOrganizerRequestHandlerTest extends TestCase
 {
+    private const EXISTING_IMAGE_ID = '6b547d1e-a2d9-493c-a8e6-d8eb35984390';
+
     use AssertApiProblemTrait;
 
     private MockObject $aggregateRepository;
     private TraceableCommandBus $commandBus;
     private MockObject $uuidGenerator;
     private ImportOrganizerRequestHandler $importOrganizerRequestHandler;
+    private MediaObjectRepository $mediaObjectRepository;
+
+    private array $mediaObjects;
 
     protected function setUp(): void
     {
         $this->aggregateRepository = $this->createMock(Repository::class);
         $this->commandBus = new TraceableCommandBus();
         $this->uuidGenerator = $this->createMock(UuidGeneratorInterface::class);
+        $this->mediaObjectRepository = $this->createMock(MediaObjectRepository::class);
 
         $this->importOrganizerRequestHandler = new ImportOrganizerRequestHandler(
             $this->aggregateRepository,
@@ -71,11 +85,47 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             $this->uuidGenerator,
             new CallableIriGenerator(fn (string $id) => 'https://mock.uitdatabank.be/organizers/' . $id),
             new CombinedRequestBodyParser(
-                new LegacyOrganizerRequestBodyParser()
+                new LegacyOrganizerRequestBodyParser(),
+                ImagesPropertyPolyfillRequestBodyParser::createForOrganizers(
+                    new CallableIriGenerator(fn (string $id) => 'https://io.uitdatabank.dev/images/' . $id),
+                    $this->mediaObjectRepository
+                )
             )
         );
 
+        $this->mediaObjectRepository->expects($this->any())
+            ->method('load')
+            ->willReturnCallback(
+                function (string $id): MediaObject {
+                    if (!isset($this->mediaObjects[$id])) {
+                        throw new AggregateNotFoundException();
+                    }
+                    return $this->mediaObjects[$id];
+                }
+            );
+
+        $this->mockMediaObject(self::EXISTING_IMAGE_ID, 'I exist', 'John Doe', 'en');
+
         $this->commandBus->record();
+    }
+
+    private function mockMediaObject(string $id, string $description, string $copyrightHolder, string $language): void
+    {
+        $mediaObject = $this->createMock(MediaObject::class);
+
+        $mediaObject
+            ->method('getDescription')
+            ->willReturn(new StringLiteral($description));
+
+        $mediaObject
+            ->method('getCopyrightHolder')
+            ->willReturn(new CopyrightHolder($copyrightHolder));
+
+        $mediaObject
+            ->method('getLanguage')
+            ->willReturn(new LegacyLanguage($language));
+
+        $this->mediaObjects[$id] = $mediaObject;
     }
 
     /**
@@ -316,6 +366,120 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             new RemoveAddress($id),
             new ImportLabels($id, new Labels()),
             new ImportImages($id, new Images()),
+        ];
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('organizerId', $id)
+            ->withJsonBodyFromArray($given)
+            ->build('PUT');
+
+        $response = $this->importOrganizerRequestHandler->handle($request);
+
+        $actualCommands = $this->commandBus->getRecordedCommands();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode(
+                [
+                    'id' => $id,
+                    'organizerId' => $id,
+                    'url' => 'https://mock.uitdatabank.be/organizers/' . $id,
+                    'commandId' => '00000000-0000-0000-0000-000000000000',
+                ]
+            ),
+            $response->getBody()->getContents()
+        );
+        $this->assertEquals($expectedCommands, $actualCommands);
+    }
+
+    /**
+     * @test
+     */
+    public function it_imports_an_organizer_with_images(): void
+    {
+        $id = '5829cdfb-21b1-4494-86da-f2dbd7c8d69c';
+
+        $this->mockMediaObject(
+            '1a11c93c-3fd6-4d59-abb9-e8df724a3894',
+            'beschrijving1',
+            'copyrightholder1',
+            'nl'
+        );
+
+        $this->mockMediaObject(
+            '67171a6a-031d-4040-88aa-556e85165e33',
+            'beschrijving2',
+            'copyrightholder2',
+            'nl'
+        );
+
+        $this->mockMediaObject(
+            '5ab13b22-a913-4c8e-aa3b-a32279a771da',
+            'beschrijving3',
+            'copyrightholder3',
+            'nl'
+        );
+
+        $given = $this->getOrganizerData() +
+            [
+                'images' => [
+                    [
+                        '@id' => 'https://io.uitdatabank.dev/images/1a11c93c-3fd6-4d59-abb9-e8df724a3894',
+                    ],
+                    [
+                        'id' => '67171a6a-031d-4040-88aa-556e85165e33',
+                        'description' => 'overwritten!',
+                    ],
+                    [
+                        'id' => '5ab13b22-a913-4c8e-aa3b-a32279a771da',
+                        'copyrightHolder' => 'overwritten!',
+                        'inLanguage' => 'en',
+                    ]
+                ],
+            ];
+
+        $this->expectOrganizerExists($id);
+
+        $expectedCommands = [
+            new UpdateTitle(
+                $id,
+                new Title('Mock organizer'),
+                new Language('nl')
+            ),
+            new UpdateWebsite(
+                $id,
+                new Url('https://www.mock-organizer.be')
+            ),
+            new UpdateContactPoint($id, new ContactPoint(new TelephoneNumbers(), new EmailAddresses(), new Urls())),
+            new DeleteDescription($id, new Language('nl')),
+            new DeleteDescription($id, new Language('fr')),
+            new DeleteDescription($id, new Language('de')),
+            new DeleteDescription($id, new Language('en')),
+            new RemoveAddress($id),
+            new ImportLabels($id, new Labels()),
+            new ImportImages(
+                $id,
+                new Images(
+                    new Image(
+                        new UUID('1a11c93c-3fd6-4d59-abb9-e8df724a3894'),
+                        new Language('nl'),
+                        new Description('beschrijving1'),
+                        new CopyrightHolder('copyrightholder1')
+                    ),
+                    new Image(
+                        new UUID('67171a6a-031d-4040-88aa-556e85165e33'),
+                        new Language('nl'),
+                        new Description('overwritten!'),
+                        new CopyrightHolder('copyrightholder2')
+                    ),
+                    new Image(
+                        new UUID('5ab13b22-a913-4c8e-aa3b-a32279a771da'),
+                        new Language('en'),
+                        new Description('beschrijving3'),
+                        new CopyrightHolder('overwritten!')
+                    )
+                )
+            ),
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -903,6 +1067,56 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                     new SchemaError('/description/en', 'The string should match pattern: \S'),
                 ],
             ],
+            'images_missing_id' => [
+                'given' => [
+                    'mainLanguage' => 'nl',
+                    'name' => ['nl' => 'Test'],
+                    'url' => 'https://www.organizer.be',
+                    'images' => [
+                        [
+                            'contentUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
+                            'thumbnailUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
+                            'inLanguage' => 'en',
+                            'description' => 'Bla',
+                            'copyrightHolder' => 'foo',
+                        ],
+                    ],
+                ],
+                'schemaErrors' => [
+                    new SchemaError('/images/0', 'The required properties (@id) are missing'),
+                ],
+            ],
+            'images_do_not_exist' => [
+                'given' => [
+                    'mainLanguage' => 'nl',
+                    'name' => ['nl' => 'Test'],
+                    'url' => 'https://www.organizer.be',
+                    'images' => [
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/2a079b5f-e84d-4152-96a9-2e41631f5ca3',
+                        ],
+                        [
+                            '@id' => 'https://io.uitdatabank.dev/images/invalid',
+                        ],
+                        [
+                            '@id' => 'https://www.google.com',
+                        ],
+                        [
+                            'id' => '115b61c4-1cdd-46c4-8006-9099725a6211',
+                        ],
+                        [
+                            'id' => 'invalid',
+                        ],
+                    ],
+                ],
+                'schemaErrors' => [
+                    new SchemaError('/images/0/@id', 'Image with @id "https://io.uitdatabank.dev/images/2a079b5f-e84d-4152-96a9-2e41631f5ca3" (id "2a079b5f-e84d-4152-96a9-2e41631f5ca3") does not exist.'),
+                    new SchemaError('/images/1/@id', 'Image with @id "https://io.uitdatabank.dev/images/invalid" does not exist.'),
+                    new SchemaError('/images/2/@id', 'Image with @id "https://www.google.com" does not exist.'),
+                    new SchemaError('/images/3/@id', 'Image with @id "https://io.uitdatabank.dev/images/115b61c4-1cdd-46c4-8006-9099725a6211" (id "115b61c4-1cdd-46c4-8006-9099725a6211") does not exist.'),
+                    new SchemaError('/images/4/@id', 'Image with @id "https://io.uitdatabank.dev/images/invalid" does not exist.'),
+                ],
+            ],
             'images_properties_whitespace' => [
                 'given' => [
                     'mainLanguage' => 'nl',
@@ -910,10 +1124,10 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                     'url' => 'https://www.organizer.be',
                     'images' => [
                         [
-                            '@id' => 'https://io.uitdatabank.be/images/546a90cd-a238-417b-aa98-1b6c50c1345c',
-                            'contentUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
-                            'thumbnailUrl' => 'https://images.uitdatabank.be/546a90cd-a238-417b-aa98-1b6c50c1345c.jpeg',
-                            'id' => '08805a3c-ffe0-4c94-a1bc-453a6dd9d01f',
+                            '@id' => 'https://io.uitdatabank.be/images/' . self::EXISTING_IMAGE_ID,
+                            'contentUrl' => 'https://images.uitdatabank.be/' . self::EXISTING_IMAGE_ID . '.jpeg',
+                            'thumbnailUrl' => 'https://images.uitdatabank.be/' . self::EXISTING_IMAGE_ID . '.jpeg',
+                            'id' => self::EXISTING_IMAGE_ID,
                             'inLanguage' => 'en',
                             'description' => '        ',
                             'copyrightHolder' => '      ',

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -67,7 +67,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
     private TraceableCommandBus $commandBus;
     private MockObject $uuidGenerator;
     private ImportOrganizerRequestHandler $importOrganizerRequestHandler;
-    private MediaObjectRepository $mediaObjectRepository;
+    private MockObject $mediaObjectRepository;
 
     private array $mediaObjects;
 

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -60,9 +60,8 @@ use PHPUnit\Framework\TestCase;
 
 class ImportOrganizerRequestHandlerTest extends TestCase
 {
-    private const EXISTING_IMAGE_ID = '6b547d1e-a2d9-493c-a8e6-d8eb35984390';
-
     use AssertApiProblemTrait;
+    private const EXISTING_IMAGE_ID = '6b547d1e-a2d9-493c-a8e6-d8eb35984390';
 
     private MockObject $aggregateRepository;
     private TraceableCommandBus $commandBus;
@@ -434,7 +433,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                         'id' => '5ab13b22-a913-4c8e-aa3b-a32279a771da',
                         'copyrightHolder' => 'overwritten!',
                         'inLanguage' => 'en',
-                    ]
+                    ],
                 ],
             ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -4473,7 +4473,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_throw_an_exception_if_mediaObject_is_missing_a_required_property(): void
+    public function it_should_throw_an_exception_if_mediaObject_is_missing_id(): void
     {
         $place = [
             '@id' => 'http://io.uitdatabank.be/place/b19d4090-db47-4520-ac1a-880684357ec9',
@@ -4507,7 +4507,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/mediaObject/0',
-                'The required properties (@id, description, copyrightHolder, inLanguage) are missing'
+                'The required properties (@id) are missing'
             ),
         ];
 

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -124,7 +124,7 @@ class Item extends Offer
         UUID $mediaObjectId,
         StringLiteral $description,
         CopyrightHolder $copyrightHolder,
-        string $language
+        ?string $language = null
     ): ImageUpdated {
         return new ImageUpdated(
             $this->id,

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -123,13 +123,15 @@ class Item extends Offer
     protected function createImageUpdatedEvent(
         UUID $mediaObjectId,
         StringLiteral $description,
-        CopyrightHolder $copyrightHolder
+        CopyrightHolder $copyrightHolder,
+        string $language
     ): ImageUpdated {
         return new ImageUpdated(
             $this->id,
             $mediaObjectId,
             $description,
-            $copyrightHolder
+            $copyrightHolder,
+            $language
         );
     }
 

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -283,7 +283,7 @@ trait OfferCommandHandlerTestTrait
                 $image->getMediaObjectId(),
                 $image->getDescription(),
                 $image->getCopyrightHolder(),
-                $image->getLanguage()
+                $image->getLanguage()->getCode()
             );
         };
 

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -282,7 +282,8 @@ trait OfferCommandHandlerTestTrait
                 $itemId,
                 $image->getMediaObjectId(),
                 $image->getDescription(),
-                $image->getCopyrightHolder()
+                $image->getCopyrightHolder(),
+                $image->getLanguage()
             );
         };
 

--- a/tests/Organizer/CommandHandler/ImportImagesHandlerTest.php
+++ b/tests/Organizer/CommandHandler/ImportImagesHandlerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Image;
+use CultuurNet\UDB3\Model\ValueObject\MediaObject\Images;
+use CultuurNet\UDB3\Model\ValueObject\Text\Description;
+use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Organizer\Commands\ImportImages;
+use CultuurNet\UDB3\Organizer\Events\ImageAdded;
+use CultuurNet\UDB3\Organizer\Events\ImageRemoved;
+use CultuurNet\UDB3\Organizer\Events\ImageUpdated;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+class ImportImagesHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new ImportImagesHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_importing_a_new_image_and_updating_an_existing_one_and_deleting_an_existing_one(): void
+    {
+        $id = '5e360b25-fd85-4dac-acf4-0571e0b57dce';
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given(
+                [
+                    $this->organizerCreatedWithUniqueWebsite($id),
+                    new ImageAdded(
+                        $id,
+                        '2361bfcb-a786-44a2-8e85-87e194c7b12b',
+                        'nl',
+                        'beschrijving1',
+                        'copyrightholder1',
+                    ),
+                    new ImageAdded(
+                        $id,
+                        'd3d085db-dbd7-4663-b3c3-56bf9a54a025',
+                        'nl',
+                        'beschrijving2',
+                        'copyrightholder2',
+                    ),
+                ]
+            )
+            ->when(
+                new ImportImages(
+                    $id,
+                    new Images(
+                        new Image(
+                            new UUID('d3d085db-dbd7-4663-b3c3-56bf9a54a025'),
+                            new Language('en'),
+                            new Description('beschrijving2 - updated'),
+                            new CopyrightHolder('copyrightholder2 - updated')
+                        ),
+                        new Image(
+                            new UUID('cf539408-bba9-4e77-9f85-72019013db37'),
+                            new Language('nl'),
+                            new Description('beschrijving3'),
+                            new CopyrightHolder('copyrightholder3')
+                        )
+                    )
+                )
+            )
+            ->then([
+                new ImageAdded(
+                    $id,
+                    'cf539408-bba9-4e77-9f85-72019013db37',
+                    'nl',
+                    'beschrijving3',
+                    'copyrightholder3'
+                ),
+                new ImageUpdated(
+                    $id,
+                    'd3d085db-dbd7-4663-b3c3-56bf9a54a025',
+                    'en',
+                    'beschrijving2 - updated',
+                    'copyrightholder2 - updated'
+                ),
+                new ImageRemoved(
+                    $id,
+                    '2361bfcb-a786-44a2-8e85-87e194c7b12b'
+                ),
+            ]);
+    }
+
+    private function organizerCreatedWithUniqueWebsite(string $id): OrganizerCreatedWithUniqueWebsite
+    {
+        return new OrganizerCreatedWithUniqueWebsite(
+            $id,
+            'nl',
+            'https://www.publiq.be',
+            'publiq'
+        );
+    }
+}


### PR DESCRIPTION
### Added

- Image "import" functionality for organizers

### Changed

- `description`, `copyrightHolder`, `inLanguage` are now optional in mediaObject when "importing" events and places

---
Ticket: https://jira.uitdatabank.be/browse/III-4503