### PR TITLE
III-4664 Add migration to delete `is_canonical` column

### DIFF
--- a/app/Migrations/Version20220406090353.php
+++ b/app/Migrations/Version20220406090353.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220406090353 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $schema->getTable('duplicate_places')
+            ->dropColumn('is_canonical');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $schema->getTable('duplicate_places')
+            ->addColumn('is_canonical', Type::BOOLEAN)
+            ->setNotnull(true);
+    }
+}

--- a/app/Migrations/Version20220406090353.php
+++ b/app/Migrations/Version20220406090353.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Migrations;
 
@@ -8,13 +10,13 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20220406090353 extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $schema->getTable('duplicate_places')
             ->dropColumn('is_canonical');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $schema->getTable('duplicate_places')
             ->addColumn('is_canonical', Type::BOOLEAN)


### PR DESCRIPTION
### Changed
- Added migration to delete `is_canonical` column from `duplicate_places` table

---
Ticket: https://jira.uitdatabank.be/browse/III-4664
