### PR TITLE
III-4670 Allow importing events/places with missing calendar

### DIFF
--- a/src/Http/Offer/LegacyCalendarRequestBodyParser.php
+++ b/src/Http/Offer/LegacyCalendarRequestBodyParser.php
@@ -55,8 +55,8 @@ final class LegacyCalendarRequestBodyParser implements RequestBodyParser
             unset($data->calendar);
         }
 
-        if (!isset($data->calendar) && !isset($data->calendarType)) {
-            $data->calendarType = CalendarType::permanent()->toString();
+        if (!isset($data->calendarType)) {
+            $data->calendarType = $this->getCalendarType($data)->toString();
         }
 
         return $request->withParsedBody($data);
@@ -65,5 +65,22 @@ final class LegacyCalendarRequestBodyParser implements RequestBodyParser
     private function formatDateTime(string $dateTime): string
     {
         return (new DateTime($dateTime))->format(DateTimeInterface::ATOM);
+    }
+
+    private function getCalendarType(stdClass $data): CalendarType
+    {
+        if (isset($data->subEvent) && count($data->subEvent) > 1) {
+            return CalendarType::multiple();
+        }
+
+        if (isset($data->subEvent) && count($data->subEvent) === 1) {
+            return CalendarType::single();
+        }
+
+        if (isset($data->startDate, $data->endDate)) {
+            return CalendarType::periodic();
+        }
+
+        return CalendarType::permanent();
     }
 }

--- a/src/Http/Offer/LegacyCalendarRequestBodyParser.php
+++ b/src/Http/Offer/LegacyCalendarRequestBodyParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Offer;
 
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarType;
 use DateTime;
 use DateTimeInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -52,6 +53,10 @@ final class LegacyCalendarRequestBodyParser implements RequestBodyParser
             }
 
             unset($data->calendar);
+        }
+
+        if (!isset($data->calendar) && !isset($data->calendarType)) {
+            $data->calendarType = CalendarType::permanent()->toString();
         }
 
         return $request->withParsedBody($data);

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -1340,7 +1340,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/',
-                'The required properties (mainLanguage, name, terms, location, calendarType) are missing'
+                'The required properties (mainLanguage, name, terms, location) are missing'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -1085,7 +1085,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/',
-                'The required properties (mainLanguage, name, terms, calendarType, address) are missing'
+                'The required properties (mainLanguage, name, terms, address) are missing'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -476,6 +476,76 @@ final class ImportPlaceRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_imports_a_legacy_place_with_missing_calendar(): void
+    {
+        $placeId = 'c4f1515a-7a73-4e18-a53a-9bf201d6fc9b';
+
+        $givenPlace = [
+            'mainLanguage' => 'nl',
+            'name' => 'Cafe Den Hemel',
+            'type' => [
+                'id' => 'Yf4aZBfsUEu2NsQqsprngw',
+                'domain' => 'eventtype',
+                'label' => 'Cultuur- of ontmoetingscentrum',
+            ],
+            'address' => [
+                'addressCountry' => 'BE',
+                'addressLocality' => 'Scherpenheuvel-Zichem',
+                'postalCode' => '3271',
+                'streetAddress' => 'Hoornblaas 107',
+            ],
+        ];
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($placeId);
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save')
+            ->with(
+                $this->callback(
+                    fn (Place $place) => $place->getAggregateRootId() === $placeId
+                )
+            );
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromMediaObjectReferences')
+            ->willReturn(new ImageCollection());
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($givenPlace)
+            ->build('POST');
+
+        $response = $this->importPlaceRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode([
+                'id' => $placeId,
+                'placeId' => $placeId,
+                'url' => 'https://io.uitdatabank.dev/places/' . $placeId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
+            ]),
+            $response->getBody()->getContents()
+        );
+
+        $this->assertEquals(
+            [
+                new UpdateBookingInfo($placeId, new BookingInfo()),
+                new UpdateContactPoint($placeId, new ContactPoint()),
+                new DeleteTypicalAgeRange($placeId),
+                new ImportLabels($placeId, new Labels()),
+                new ImportImages($placeId, new ImageCollection()),
+                new ImportVideos($placeId, new VideoCollection()),
+                new DeleteCurrentOrganizer($placeId),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_updates_an_existing_place(): void
     {
         $placeId = 'c4f1515a-7a73-4e18-a53a-9bf201d6fc9b';


### PR DESCRIPTION
### Fixed
- Fixed importing events/places with incomplete calendar by converting them with a best guess to permanent, periodic, single or multiple.

Note: The unit tests don't verify the calendar from the create aggregate method, this is covered with acceptance tests, see https://github.com/cultuurnet/udb3-acceptance-tests/pull/103

---
Ticket: https://jira.uitdatabank.be/browse/III-4670 
