### PR TITLE
III-4669 Fix errors on nullable properties

### DIFF
--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Http\Event\UpdateSubEventsRequestHandler;
 use CultuurNet\UDB3\Http\Event\UpdateThemeRequestHandler;
 use CultuurNet\UDB3\Http\Import\ImportPriceInfoRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
+use CultuurNet\UDB3\Http\Import\RemoveEmptyArraysRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\ImagesPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Model\Import\Event\EventCategoryResolver;
@@ -90,6 +91,7 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
                 new EventDenormalizer(),
                 new CombinedRequestBodyParser(
                     new LegacyEventRequestBodyParser($app['place_iri_generator']),
+                    RemoveEmptyArraysRequestBodyParser::createForEvents(),
                     new ImportTermRequestBodyParser(new EventCategoryResolver()),
                     new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations']),
                     ImagesPropertyPolyfillRequestBodyParser::createForEvents(

--- a/app/Organizer/OrganizerControllerProvider.php
+++ b/app/Organizer/OrganizerControllerProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Organizer;
 
+use CultuurNet\UDB3\Http\Import\RemoveEmptyArraysRequestBodyParser;
 use CultuurNet\UDB3\Http\Organizer\AddImageRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\AddLabelRequestHandler;
 use CultuurNet\UDB3\Http\Organizer\DeleteAddressRequestHandler;
@@ -81,6 +82,7 @@ class OrganizerControllerProvider implements ControllerProviderInterface, Servic
                 $app['organizer_iri_generator'],
                 new CombinedRequestBodyParser(
                     new LegacyOrganizerRequestBodyParser(),
+                    RemoveEmptyArraysRequestBodyParser::createForOrganizers(),
                     ImagesPropertyPolyfillRequestBodyParser::createForOrganizers(
                         $app['media_object_iri_generator'],
                         $app['media_object_repository']

--- a/app/Place/PlaceControllerProvider.php
+++ b/app/Place/PlaceControllerProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Place;
 
 use CultuurNet\UDB3\Http\Import\ImportPriceInfoRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
+use CultuurNet\UDB3\Http\Import\RemoveEmptyArraysRequestBodyParser;
 use CultuurNet\UDB3\Http\Place\ImportPlaceRequestHandler;
 use CultuurNet\UDB3\Http\Place\LegacyPlaceRequestBodyParser;
 use CultuurNet\UDB3\Http\Place\UpdateMajorInfoRequestHandler;
@@ -79,6 +80,7 @@ class PlaceControllerProvider implements ControllerProviderInterface, ServicePro
                 new PlaceDenormalizer(),
                 new CombinedRequestBodyParser(
                     new LegacyPlaceRequestBodyParser(),
+                    RemoveEmptyArraysRequestBodyParser::createForPlaces(),
                     new ImportTermRequestBodyParser(new PlaceCategoryResolver()),
                     new ImportPriceInfoRequestBodyParser($app['config']['base_price_translations']),
                     ImagesPropertyPolyfillRequestBodyParser::createForPlaces(

--- a/src/Http/Import/RemoveEmptyArraysRequestBodyParser.php
+++ b/src/Http/Import/RemoveEmptyArraysRequestBodyParser.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Import;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Model\Import\Taxonomy\Category\CategoryResolverInterface;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
+use JsonPath\JsonObject;
+use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
+
+/**
+ * Removes properties like labels, hiddenLabels and images that are an empty array. We the rest of the code expect
+ * those properties to have at least 1 value, or just not be present.
+ */
+final class RemoveEmptyArraysRequestBodyParser implements RequestBodyParser
+{
+    private const ORGANIZER_LIST_FIELDS = [
+        'labels',
+        'hiddenLabels',
+        'images',
+    ];
+
+    private const PLACE_LIST_FIELDS = [
+        'labels',
+        'hiddenLabels',
+        'mediaObject',
+        'openingHours',
+        'priceInfo',
+        'videos',
+    ];
+
+    private const EVENT_LIST_FIELDS = [
+        'labels',
+        'hiddenLabels',
+        'mediaObject',
+        'openingHours',
+        'priceInfo',
+        'videos',
+    ];
+
+    private array $fields;
+
+    private function __construct(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public static function createForOrganizers(): self
+    {
+        return new self(self::ORGANIZER_LIST_FIELDS);
+    }
+
+    public static function createForPlaces(): self
+    {
+        return new self(self::PLACE_LIST_FIELDS);
+    }
+
+    public static function createForEvents(): self
+    {
+        return new self(self::EVENT_LIST_FIELDS);
+    }
+
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $json = $request->getParsedBody();
+        if (!$json instanceof stdClass) {
+            return $request;
+        }
+
+        foreach ($this->fields as $field) {
+            if (isset($json->$field) && is_array($json->$field) && empty($json->$field)) {
+                unset($json->$field);
+            }
+        }
+
+        return $request->withParsedBody($json);
+    }
+}

--- a/src/Http/Import/RemoveEmptyArraysRequestBodyParser.php
+++ b/src/Http/Import/RemoveEmptyArraysRequestBodyParser.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Import;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
-use CultuurNet\UDB3\Model\Import\Taxonomy\Category\CategoryResolverInterface;
-use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
-use JsonPath\JsonObject;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
 

--- a/src/Http/Request/Body/RemoveNullPropertiesRequestBodyParser.php
+++ b/src/Http/Request/Body/RemoveNullPropertiesRequestBodyParser.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Request\Body;
+
+use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
+
+/**
+ * Recursively removes null properties from objects, and null values from arrays.
+ */
+final class RemoveNullPropertiesRequestBodyParser implements RequestBodyParser
+{
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $json = $request->getParsedBody();
+
+        // Even though we do not decode associatively, the JSON can still be an array because some endpoints expect a
+        // JSON array as body. (Not associative but an actual list.)
+        if ($json instanceof stdClass) {
+            $json = $this->removeNullPropertiesFromObject($json);
+        }
+        if (is_array($json)) {
+            $json = $this->removeNullValuesFromArray($json);
+        }
+
+        return $request->withParsedBody($json);
+    }
+
+    private function removeNullPropertiesFromObject(stdClass $data): stdClass
+    {
+        $newData = new stdClass();
+        foreach ($data as $property => $value) {
+            if ($value instanceof stdClass) {
+                $value = $this->removeNullPropertiesFromObject($value);
+            }
+            if (is_array($value)) {
+                $value = $this->removeNullValuesFromArray($value);
+            }
+            if ($value !== null) {
+                $newData->$property = $value;
+            }
+        }
+        return $newData;
+    }
+
+    private function removeNullValuesFromArray(array $data): array
+    {
+        $data = array_filter($data, fn ($value) => $value !== null);
+        $data = array_map(
+            function ($value) {
+                if ($value instanceof stdClass) {
+                    return $this->removeNullPropertiesFromObject($value);
+                }
+                if (is_array($value)) {
+                    return $this->removeNullValuesFromArray($value);
+                }
+                return $value;
+            },
+            $data
+        );
+        return $data;
+    }
+}

--- a/src/Http/Request/Body/RemoveNullPropertiesRequestBodyParser.php
+++ b/src/Http/Request/Body/RemoveNullPropertiesRequestBodyParser.php
@@ -31,7 +31,7 @@ final class RemoveNullPropertiesRequestBodyParser implements RequestBodyParser
     private function removeNullPropertiesFromObject(stdClass $data): stdClass
     {
         $newData = new stdClass();
-        foreach ($data as $property => $value) {
+        foreach ((array) $data as $property => $value) {
             if ($value instanceof stdClass) {
                 $value = $this->removeNullPropertiesFromObject($value);
             }

--- a/src/Http/Request/Body/RequestBodyParserFactory.php
+++ b/src/Http/Request/Body/RequestBodyParserFactory.php
@@ -17,6 +17,7 @@ final class RequestBodyParserFactory
     {
         return new CombinedRequestBodyParser(
             new JsonRequestBodyParser(),
+            new RemoveNullPropertiesRequestBodyParser(),
             ...$customParsers
         );
     }

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -189,7 +189,7 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_ignores_empty_list_properties(): void
+    public function it_ignores_empty_list_properties_and_null_values(): void
     {
         $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';
 
@@ -213,10 +213,15 @@ final class ImportEventRequestHandlerTest extends TestCase
             'calendarType' => 'permanent',
             'labels' => [],
             'hiddenLabels' => [],
-            'mediaObject' => [],
+            'mediaObject' => [null],
             'priceInfo' => [],
             'openingHours' => [],
             'videos' => [],
+            'contactPoint' => [
+                'email' => [null],
+                'phone' => null,
+            ],
+            'bookingInfo' => null,
         ];
 
         $request = (new Psr7RequestBuilder())

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -30,6 +30,7 @@ use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Import\ImportPriceInfoRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
+use CultuurNet\UDB3\Http\Import\RemoveEmptyArraysRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -98,6 +99,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new LegacyEventRequestBodyParser(
                     new CallableIriGenerator(fn (string $placeId) => 'https://io.uitdatabank.dev/places/' . $placeId)
                 ),
+                RemoveEmptyArraysRequestBodyParser::createForEvents(),
                 new ImportTermRequestBodyParser(new EventCategoryResolver()),
                 new ImportPriceInfoRequestBodyParser(
                     [
@@ -140,6 +142,81 @@ final class ImportEventRequestHandlerTest extends TestCase
                 '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
             ],
             'calendarType' => 'permanent',
+        ];
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($given)
+            ->build('PUT');
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromMediaObjectReferences')
+            ->willReturn(new ImageCollection());
+
+        $this->aggregateRepository->expects($this->never())
+            ->method('load');
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save');
+
+        $response = $this->importEventRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode([
+                'id' => $eventId,
+                'eventId' => $eventId,
+                'url' => 'https://io.uitdatabank.dev/events/' . $eventId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
+            ]),
+            $response->getBody()->getContents()
+        );
+
+        $this->assertEquals(
+            [
+                new UpdateAudience($eventId, AudienceType::everyone()),
+                new UpdateBookingInfo($eventId, new BookingInfo()),
+                new UpdateContactPoint($eventId, new ContactPoint()),
+                new DeleteTypicalAgeRange($eventId),
+                new ImportLabels($eventId, new Labels()),
+                new ImportImages($eventId, new ImageCollection()),
+                new ImportVideos($eventId, new VideoCollection()),
+                new DeleteCurrentOrganizer($eventId),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_empty_list_properties(): void
+    {
+        $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($eventId);
+
+        $given = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannekoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'labels' => [],
+            'hiddenLabels' => [],
+            'mediaObject' => [],
+            'priceInfo' => [],
+            'openingHours' => [],
+            'videos' => [],
         ];
 
         $request = (new Psr7RequestBuilder())
@@ -4421,38 +4498,6 @@ final class ImportEventRequestHandlerTest extends TestCase
             new SchemaError(
                 '/mediaObject',
                 'The data (string) must match the type: array'
-            ),
-        ];
-
-        $this->assertValidationErrors($event, $expectedErrors);
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_if_mediaObject_has_no_items(): void
-    {
-        $event = [
-            'mainLanguage' => 'nl',
-            'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
-            ],
-            'terms' => [
-                [
-                    'id' => '1.50.0.0.0',
-                ],
-            ],
-            'location' => [
-                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
-            ],
-            'calendarType' => 'permanent',
-            'mediaObject' => [],
-        ];
-
-        $expectedErrors = [
-            new SchemaError(
-                '/mediaObject',
-                'Array should have at least 1 items, 0 found'
             ),
         ];
 

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -190,7 +190,7 @@ class ImportOrganizerRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_ignores_empty_list_properties(): void
+    public function it_ignores_empty_list_properties_and_null_values(): void
     {
         $organizerId = '5829cdfb-21b1-4494-86da-f2dbd7c8d69c';
 
@@ -199,9 +199,12 @@ class ImportOrganizerRequestHandlerTest extends TestCase
             ->willReturn($organizerId);
 
         $given = $this->getOrganizerData() + [
-            'labels' => [],
-            'hiddenLabels' => [],
+            'labels' => [null],
+            'hiddenLabels' => null,
             'images' => [],
+            'contactPoint' => (object) [
+                'phone' => null,
+            ],
         ];
 
         $this->expectOrganizerDoesNotExist($organizerId);

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -227,7 +227,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_ignores_empty_list_properties(): void
+    public function it_ignores_empty_list_properties_and_null_values(): void
     {
         $placeId = 'c4f1515a-7a73-4e18-a53a-9bf201d6fc9b';
 
@@ -253,11 +253,16 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             'calendarType' => 'permanent',
             'mainLanguage' => 'nl',
             'labels' => [],
-            'hiddenLabels' => [],
+            'hiddenLabels' => [null],
             'mediaObject' => [],
             'priceInfo' => [],
             'openingHours' => [],
             'videos' => [],
+            'contactPoint' => [
+                'email' => [null],
+                'phone' => null,
+            ],
+            'bookingInfo' => null,
         ];
 
         $this->uuidGenerator->expects($this->once())

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -27,6 +27,7 @@ use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Import\ImportPriceInfoRequestBodyParser;
 use CultuurNet\UDB3\Http\Import\ImportTermRequestBodyParser;
+use CultuurNet\UDB3\Http\Import\RemoveEmptyArraysRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\CombinedRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -127,6 +128,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             ),
             new CombinedRequestBodyParser(
                 new LegacyPlaceRequestBodyParser(),
+                RemoveEmptyArraysRequestBodyParser::createForPlaces(),
                 new ImportTermRequestBodyParser(new PlaceCategoryResolver()),
                 new ImportPriceInfoRequestBodyParser(
                     [
@@ -173,6 +175,89 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             ],
             'calendarType' => 'permanent',
             'mainLanguage' => 'nl',
+        ];
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($placeId);
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save')
+            ->with(
+                $this->callback(
+                    fn (Place $place) => $place->getAggregateRootId() === $placeId
+                )
+            );
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromMediaObjectReferences')
+            ->willReturn(new ImageCollection());
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($givenPlace)
+            ->build('POST');
+
+        $response = $this->importPlaceRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            Json::encode([
+                'id' => $placeId,
+                'placeId' => $placeId,
+                'url' => 'https://io.uitdatabank.dev/places/' . $placeId,
+                'commandId' => '00000000-0000-0000-0000-000000000000',
+            ]),
+            $response->getBody()->getContents()
+        );
+
+        $this->assertEquals(
+            [
+                new UpdateBookingInfo($placeId, new BookingInfo()),
+                new UpdateContactPoint($placeId, new ContactPoint()),
+                new DeleteTypicalAgeRange($placeId),
+                new ImportLabels($placeId, new Labels()),
+                new ImportImages($placeId, new ImageCollection()),
+                new ImportVideos($placeId, new VideoCollection()),
+                new DeleteCurrentOrganizer($placeId),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_empty_list_properties(): void
+    {
+        $placeId = 'c4f1515a-7a73-4e18-a53a-9bf201d6fc9b';
+
+        $givenPlace = [
+            'name' => [
+                'nl' => 'Cafe Den Hemel',
+            ],
+            'terms' => [
+                [
+                    'id' => 'Yf4aZBfsUEu2NsQqsprngw',
+                    'domain' => 'eventtype',
+                    'label' => 'Cultuur- of ontmoetingscentrum',
+                ],
+            ],
+            'address' => [
+                'nl' => [
+                    'addressCountry' => 'BE',
+                    'addressLocality' => 'Scherpenheuvel-Zichem',
+                    'postalCode' => '3271',
+                    'streetAddress' => 'Hoornblaas 107',
+                ],
+            ],
+            'calendarType' => 'permanent',
+            'mainLanguage' => 'nl',
+            'labels' => [],
+            'hiddenLabels' => [],
+            'mediaObject' => [],
+            'priceInfo' => [],
+            'openingHours' => [],
+            'videos' => [],
         ];
 
         $this->uuidGenerator->expects($this->once())


### PR DESCRIPTION
### Fixed

- Fixed validation error when `labels` or `hiddenLabels` or another array is empty while it should technically have at least one item according to the schema (by simply removing the property)
- Fixed validation error when an (optional) property is set to `null` by recursively removing all `null` values from the JSON

---
Ticket: https://jira.uitdatabank.be/browse/III-4669
