### PR TITLE
API-63 Use new publiq/udb3-json-schemas package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/stoplight-docs-uitdatabank": "dev-III-4503-imports",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "014b3c2caacf2cb4b2880bdf85c26dfd",
+    "content-hash": "42262857f22abcf90829a1428c51d901",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5061,38 +5061,6 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
-            "name": "publiq/stoplight-docs-uitdatabank",
-            "version": "dev-III-4503-imports",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cultuurnet/stoplight-docs-uitdatabank.git",
-                "reference": "70a22333fdc6c54a21bce798bae0e270bfc032e7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/stoplight-docs-uitdatabank/zipball/70a22333fdc6c54a21bce798bae0e270bfc032e7",
-                "reference": "70a22333fdc6c54a21bce798bae0e270bfc032e7",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "publiq vzw",
-                    "email": "info@publiq.be"
-                }
-            ],
-            "description": "UiTdatabank API documentation. Useful for including JSON schemas in your application to work with.",
-            "support": {
-                "issues": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/issues",
-                "source": "https://github.com/cultuurnet/stoplight-docs-uitdatabank/tree/III-4503-imports"
-            },
-            "time": "2022-03-29T14:00:54+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -10780,8 +10748,7 @@
     "stability-flags": {
         "chrisboulton/php-resque": 20,
         "cultuurnet/culturefeed-php": 20,
-        "doctrine/migrations": 20,
-        "publiq/stoplight-docs-uitdatabank": 20
+        "doctrine/migrations": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42262857f22abcf90829a1428c51d901",
+    "content-hash": "c4de21a40fdcb22e445b1dc9801c0740",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5061,6 +5061,39 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "publiq/udb3-json-schemas",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
+                "reference": "c2e44e1c8ead0eb609d70c6687ae6407e56a3171"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/c2e44e1c8ead0eb609d70c6687ae6407e56a3171",
+                "reference": "c2e44e1c8ead0eb609d70c6687ae6407e56a3171",
+                "shasum": ""
+            },
+            "default-branch": true,
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "publiq vzw",
+                    "email": "info@publiq.be"
+                }
+            ],
+            "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
+            "support": {
+                "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+            },
+            "time": "2022-04-13T13:51:07+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -10748,7 +10781,8 @@
     "stability-flags": {
         "chrisboulton/php-resque": 20,
         "cultuurnet/culturefeed-php": 20,
-        "doctrine/migrations": 20
+        "doctrine/migrations": 20,
+        "publiq/udb3-json-schemas": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3244,7 +3244,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/typicalAgeRange',
-                'The string should match pattern: \A[\d]*-[\d]*\z'
+                'The string should match pattern: ^[\d]*-[\d]*$'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -3220,7 +3220,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/typicalAgeRange',
-                'The string should match pattern: \A[\d]*-[\d]*\z'
+                'The string should match pattern: ^[\d]*-[\d]*$'
             ),
         ];
 

--- a/tests/Http/Request/Body/JsonSchemaLocatorTest.php
+++ b/tests/Http/Request/Body/JsonSchemaLocatorTest.php
@@ -32,7 +32,7 @@ class JsonSchemaLocatorTest extends TestCase
      */
     public function it_returns_the_schema_uri_for_a_file(): void
     {
-        $expected = Uri::create('file://' . realpath(__DIR__ . '/../../../../vendor/publiq/stoplight-docs-uitdatabank/models/') . '/event-subEvent-patch.json');
+        $expected = Uri::create('file://' . realpath(__DIR__ . '/../../../../vendor/publiq/udb3-json-schemas/') . '/event-subEvent-patch.json');
         $actual = JsonSchemaLocator::createSchemaUri(JsonSchemaLocator::EVENT_SUB_EVENT_PATCH);
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Http/Request/Body/JsonSchemaLocatorTest.php
+++ b/tests/Http/Request/Body/JsonSchemaLocatorTest.php
@@ -17,7 +17,7 @@ class JsonSchemaLocatorTest extends TestCase
      */
     public function it_returns_a_resolver_for_the_previously_set_schema_directory(): void
     {
-        $directory = realpath(__DIR__ . '/../../../../vendor/publiq/stoplight-docs-uitdatabank/models');
+        $directory = realpath(__DIR__ . '/../../../../vendor/publiq/udb3-json-schemas');
 
         $expectedResolver = new SchemaResolver();
         $expectedResolver->registerPrefix('file://' . $directory . '/', $directory);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/stoplight-docs-uitdatabank/models');
+JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/udb3-json-schemas');
 
 class_alias(TestCase::class, 'PHPUnit_Framework_TestCase');

--- a/web/index.php
+++ b/web/index.php
@@ -275,7 +275,7 @@ $app->after(
 
 $app->register(new LegacyRoutesServiceProvider());
 
-JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/stoplight-docs-uitdatabank/models');
+JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/udb3-json-schemas');
 
 try {
     $app->run();


### PR DESCRIPTION
### Changed

- Changed usage of `publiq/stoplight-docs-uitdatabank` to `publiq/udb3-json-schemas`, which is a read-only repository (https://github.com/cultuurnet/udb3-json-schemas/) that is split off automatically from https://github.com/cultuurnet/apidocs for every push to a branch

---
Ticket: https://jira.uitdatabank.be/browse/API-63
