### PR TITLE
III-4667 Support creating/importing attendance mode

### DIFF
--- a/app/Event/EventCommandHandlerProvider.php
+++ b/app/Event/EventCommandHandlerProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Event;
 
 use CultuurNet\UDB3\Event\CommandHandlers\CopyEventHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\RemoveThemeHandler;
+use CultuurNet\UDB3\Event\CommandHandlers\UpdateAttendanceModeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAudienceHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateSubEventsHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateThemeHandler;
@@ -27,6 +28,10 @@ final class EventCommandHandlerProvider implements ServiceProviderInterface
 
         $app[RemoveThemeHandler::class] = $app->share(
             fn (Application $application) => new RemoveThemeHandler($app['event_repository'])
+        );
+
+        $app[UpdateAttendanceModeHandler::class] = $app->share(
+            fn (Application $application) => new UpdateAttendanceModeHandler($app['event_repository'])
         );
 
         $app[UpdateAudienceHandler::class] = $app->share(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Clock\SystemClock;
 use CultuurNet\UDB3\Event\CommandHandlers\CopyEventHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\RemoveThemeHandler;
+use CultuurNet\UDB3\Event\CommandHandlers\UpdateAttendanceModeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAudienceHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateSubEventsHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateThemeHandler;
@@ -616,6 +617,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[UpdateSubEventsHandler::class]);
         $commandBus->subscribe($app[UpdateThemeHandler::class]);
         $commandBus->subscribe($app[RemoveThemeHandler::class]);
+        $commandBus->subscribe($app[UpdateAttendanceModeHandler::class]);
         $commandBus->subscribe($app[UpdateAudienceHandler::class]);
         $commandBus->subscribe($app[CopyEventHandler::class]);
 

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/virtual-events",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4de21a40fdcb22e445b1dc9801c0740",
+    "content-hash": "1640240ab0488653aa547800d3257774",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5064,19 +5064,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/virtual-events",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "c2e44e1c8ead0eb609d70c6687ae6407e56a3171"
+                "reference": "aef7f2285606d78958fc12cb51f91ee40f1cc4de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/c2e44e1c8ead0eb609d70c6687ae6407e56a3171",
-                "reference": "c2e44e1c8ead0eb609d70c6687ae6407e56a3171",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/aef7f2285606d78958fc12cb51f91ee40f1cc4de",
+                "reference": "aef7f2285606d78958fc12cb51f91ee40f1cc4de",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5091,9 +5090,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/virtual-events"
             },
-            "time": "2022-04-13T13:51:07+00:00"
+            "time": "2022-04-13T14:48:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Event/CommandHandlers/UpdateAttendanceModeHandler.php
+++ b/src/Event/CommandHandlers/UpdateAttendanceModeHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
+use CultuurNet\UDB3\Event\Event;
+use CultuurNet\UDB3\Event\EventRepository;
+
+final class UpdateAttendanceModeHandler implements CommandHandler
+{
+    private EventRepository $eventRepository;
+
+    public function __construct(EventRepository $eventRepository)
+    {
+        $this->eventRepository = $eventRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof UpdateAttendanceMode) {
+            return;
+        }
+
+        /** @var Event $event */
+        $event = $this->eventRepository->load($command->getItemId());
+
+        $event->updateAttendanceMode($command->getAttendanceMode());
+
+        $this->eventRepository->save($event);
+    }
+}

--- a/src/Event/Commands/UpdateAttendanceMode.php
+++ b/src/Event/Commands/UpdateAttendanceMode.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Commands;
+
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class UpdateAttendanceMode implements AuthorizableCommand
+{
+    private string $eventId;
+
+    private AttendanceMode $attendanceMode;
+
+    public function __construct(string $eventId, AttendanceMode $attendanceMode)
+    {
+        $this->eventId = $eventId;
+        $this->attendanceMode = $attendanceMode;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getAttendanceMode(): AttendanceMode
+    {
+        return $this->attendanceMode;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::aanbodBewerken();
+    }
+}

--- a/src/Event/Events/AttendanceModeUpdated.php
+++ b/src/Event/Events/AttendanceModeUpdated.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use Broadway\Serializer\Serializable;
+
+final class AttendanceModeUpdated implements Serializable
+{
+    private string $eventId;
+
+    private string $attendanceMode;
+
+    public function __construct(string $eventId, string $attendanceMode)
+    {
+        $this->eventId = $eventId;
+        $this->attendanceMode = $attendanceMode;
+    }
+
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getAttendanceMode(): string
+    {
+        return $this->attendanceMode;
+    }
+
+    public static function deserialize(array $data): AttendanceModeUpdated
+    {
+        return new AttendanceModeUpdated(
+            $data['eventId'],
+            $data['attendanceMode']
+        );
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'eventId' => $this->eventId,
+            'attendanceMode' => $this->attendanceMode,
+        ];
+    }
+}

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\EntityNotFoundException;
+use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
 use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
 use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
@@ -63,6 +64,7 @@ use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Offer\AvailableTo;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferLDProjector;
@@ -266,6 +268,8 @@ class EventLDProjector extends OfferLDProjector implements
 
         $jsonLD->workflowStatus = WorkflowStatus::DRAFT()->toString();
 
+        $jsonLD->attendanceMode = AttendanceMode::offline()->toString();
+
         $defaultAudience = new Audience(AudienceType::everyone());
         $jsonLD->audience = $defaultAudience->serialize();
 
@@ -415,6 +419,16 @@ class EventLDProjector extends OfferLDProjector implements
         ];
 
         return $document->withBody($eventLd);
+    }
+
+    protected function applyAttendanceModeUpdated(AttendanceModeUpdated $attendanceModeUpdated): JsonDocument
+    {
+        $document = $this->loadDocumentFromRepositoryByItemId($attendanceModeUpdated->getEventId());
+        $jsonLD = $document->getBody();
+
+        $jsonLD->attendanceMode = $attendanceModeUpdated->getAttendanceMode();
+
+        return $document->withBody($jsonLD);
     }
 
     protected function applyAudienceUpdated(AudienceUpdated $audienceUpdated): JsonDocument

--- a/src/Http/Event/ImportEventRequestHandler.php
+++ b/src/Http/Event/ImportEventRequestHandler.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Event\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Event\Commands\ImportImages;
 use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
+use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
 use CultuurNet\UDB3\Event\Commands\UpdateAudience;
 use CultuurNet\UDB3\Event\Commands\UpdateBookingInfo;
 use CultuurNet\UDB3\Event\Commands\UpdateContactPoint;
@@ -164,6 +165,8 @@ final class ImportEventRequestHandler implements RequestHandlerInterface
                 $commands[] = new UpdateTheme($eventId, $theme->getId());
             }
         }
+
+        $commands[] = new UpdateAttendanceMode($eventId, $event->getAttendanceMode());
 
         if ($location->isDummyPlaceForEducation()) {
             $audienceType = AudienceType::education();

--- a/src/Model/Event/Event.php
+++ b/src/Model/Event/Event.php
@@ -7,9 +7,12 @@ namespace CultuurNet\UDB3\Model\Event;
 use CultuurNet\UDB3\Model\Offer\Offer;
 use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 
 interface Event extends Offer
 {
+    public function getAttendanceMode(): AttendanceMode;
+
     public function getAudienceType(): AudienceType;
 
     public function getPlaceReference(): PlaceReference;

--- a/src/Model/Event/ImmutableEvent.php
+++ b/src/Model/Event/ImmutableEvent.php
@@ -12,11 +12,14 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Categories;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use InvalidArgumentException;
 
 class ImmutableEvent extends ImmutableOffer implements Event
 {
     private PlaceReference $placeReference;
+
+    private AttendanceMode $attendanceMode;
 
     private AudienceType $audience;
 
@@ -39,6 +42,7 @@ class ImmutableEvent extends ImmutableOffer implements Event
 
         parent::__construct($id, $mainLanguage, $title, $calendar, $categories);
         $this->placeReference = $placeReference;
+        $this->attendanceMode = AttendanceMode::offline();
         $this->audience = AudienceType::everyone();
     }
 
@@ -51,6 +55,17 @@ class ImmutableEvent extends ImmutableOffer implements Event
     {
         $c = clone $this;
         $c->placeReference = $placeReference;
+        return $c;
+    }
+
+    public function getAttendanceMode(): AttendanceMode
+    {
+        return $this->attendanceMode;
+    }
+    public function withAttendanceMode(AttendanceMode $attendanceMode): ImmutableEvent
+    {
+        $c = clone $this;
+        $c->attendanceMode = $attendanceMode;
         return $c;
     }
 

--- a/src/Model/Serializer/Event/EventDenormalizer.php
+++ b/src/Model/Serializer/Event/EventDenormalizer.php
@@ -18,6 +18,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUIDParser;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Categories;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use Symfony\Component\Serializer\Exception\UnsupportedException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -103,7 +104,18 @@ class EventDenormalizer extends OfferDenormalizer
 
         /* @var ImmutableEvent $offer */
         $offer = $this->denormalizeOffer($data);
+        $offer = $this->denormalizeAttendanceMode($data, $offer);
         return $this->denormalizeAudienceType($data, $offer);
+    }
+
+    private function denormalizeAttendanceMode(array $data, ImmutableEvent $event): ImmutableEvent
+    {
+        if (isset($data['attendanceMode'])) {
+            $attendanceMode = new AttendanceMode($data['attendanceMode']);
+            $event = $event->withAttendanceMode($attendanceMode);
+        }
+
+        return $event;
     }
 
     private function denormalizeAudienceType(array $data, ImmutableEvent $event): ImmutableEvent

--- a/src/Model/ValueObject/Virtual/AttendanceMode.php
+++ b/src/Model/ValueObject/Virtual/AttendanceMode.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Virtual;
+
+use CultuurNet\UDB3\Model\ValueObject\String\Enum;
+
+/**
+ * @method static AttendanceMode offline()
+ * @method static AttendanceMode online()
+ * @method static AttendanceMode mixed()
+ */
+final class AttendanceMode extends Enum
+{
+    public static function getAllowedValues(): array
+    {
+        return [
+            'offline',
+            'online',
+            'mixed',
+        ];
+    }
+}

--- a/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
+use CultuurNet\UDB3\Event\EventRepository;
+use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
+use CultuurNet\UDB3\Theme;
+use CultuurNet\UDB3\Title;
+
+final class UpdateAttendanceModeHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new UpdateAttendanceModeHandler(new EventRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_updating_the_attendanceMode(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([$this->getEventCreated($eventId)])
+            ->when(new UpdateAttendanceMode($eventId, AttendanceMode::online()))
+            ->then([new AttendanceModeUpdated($eventId, AttendanceMode::online()->toString())]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_same_attendanceMode(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([$this->getEventCreated($eventId)])
+            ->when(new UpdateAttendanceMode($eventId, AttendanceMode::offline()))
+            ->then([]);
+    }
+
+
+    private function getEventCreated(string $id): EventCreated
+    {
+        return new EventCreated(
+            $id,
+            new Language('nl'),
+            new Title('some representative title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            new LocationId('bfc60a14-6208-4372-942e-86e63744769a'),
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.1.0.0', 'Rock')
+        );
+    }
+}

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\BookingInfo;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\ContactPoint;
+use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AudienceUpdated;
 use CultuurNet\UDB3\Event\Events\BookingInfoUpdated;
 use CultuurNet\UDB3\Event\Events\CalendarUpdated;
@@ -42,6 +43,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\AgeRange;
 use CultuurNet\UDB3\PriceInfo\BasePrice;
@@ -107,6 +109,23 @@ class EventTest extends AggregateRootScenarioTestCase
             new Calendar(CalendarType::PERMANENT()),
             new Theme('1.8.3.1.0', 'Pop en rock')
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_update_attendanceMode(): void
+    {
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+            ])
+            ->when(
+                fn (Event $event) => $event->updateAttendanceMode(AttendanceMode::online())
+            )
+            ->then([
+                new AttendanceModeUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', AttendanceMode::online()->toString()),
+            ]);
     }
 
     /**

--- a/tests/Event/Events/AttendanceModeUpdatedTest.php
+++ b/tests/Event/Events/AttendanceModeUpdatedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
+use PHPUnit\Framework\TestCase;
+
+final class AttendanceModeUpdatedTest extends TestCase
+{
+    private AttendanceModeUpdated $attendanceModeUpdated;
+
+    protected function setUp(): void
+    {
+        $this->attendanceModeUpdated = new AttendanceModeUpdated(
+            '21ade1c1-6bdb-4cc5-ad34-2028b60dcfbd',
+            AttendanceMode::online()->toString()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            [
+                'eventId' => '21ade1c1-6bdb-4cc5-ad34-2028b60dcfbd',
+                'attendanceMode' => 'online',
+            ],
+            $this->attendanceModeUpdated->serialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deserialize(): void
+    {
+        $this->assertEquals(
+            $this->attendanceModeUpdated,
+            AttendanceModeUpdated::deserialize(
+                [
+                    'eventId' => '21ade1c1-6bdb-4cc5-ad34-2028b60dcfbd',
+                    'attendanceMode' => 'online',
+                ]
+            )
+        );
+    }
+}

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
@@ -51,6 +52,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Minute;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
@@ -1244,6 +1246,27 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
     /**
      * @test
      */
+    public function it_projects_updating_attendanceMode(): void
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $attendanceModeUpdated = new AttendanceModeUpdated($eventId, AttendanceMode::online()->toString());
+
+        $body = $this->project($attendanceModeUpdated, $eventId, null, $this->recordedOn->toBroadwayDateTime());
+
+        $expectedJson = (object) [
+            '@id' => 'http://example.com/entity/' . $eventId,
+            '@context' => '/contexts/event',
+            'attendanceMode' => AttendanceMode::online()->toString(),
+            'modified' => $this->recordedOn->toString(),
+        ];
+
+        $this->assertEquals($expectedJson, $body);
+    }
+
+    /**
+     * @test
+     */
     public function it_projects_updating_audience(): void
     {
         $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
@@ -1511,6 +1534,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $jsonLD->created = '2015-01-20T13:25:21+01:00';
         $jsonLD->modified = '2015-01-20T13:25:21+01:00';
         $jsonLD->workflowStatus = 'DRAFT';
+        $jsonLD->attendanceMode = AttendanceMode::offline()->toString();
         $jsonLD->audience = (object)['audienceType' => 'everyone'];
         $jsonLD->languages = [$mainLanguage->getCode()];
         $jsonLD->completedLanguages = [$mainLanguage->getCode()];

--- a/tests/Event/ReadModel/JSONLD/copied_event.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event.json
@@ -22,6 +22,7 @@
     }
   ],
   "workflowStatus": "DRAFT",
+  "attendanceMode": "offline",
   "audience": {
     "audienceType": "everyone"
   },

--- a/tests/Event/ReadModel/JSONLD/copied_event_with_place_type.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event_with_place_type.json
@@ -22,6 +22,7 @@
     }
   ],
   "workflowStatus": "DRAFT",
+  "attendanceMode": "offline",
   "audience": {
     "audienceType": "everyone"
   },

--- a/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
@@ -22,6 +22,7 @@
     }
   ],
   "workflowStatus": "DRAFT",
+  "attendanceMode": "offline",
   "audience": {
     "audienceType": "everyone"
   },

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -2551,6 +2551,104 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_if_attendanceMode_has_wrong_format(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannekoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'attendanceMode' => [
+                'mode' => 'offline',
+            ],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/attendanceMode',
+                'The data (object) must match the type: string'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_attendanceMode_is_empty(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannekoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'attendanceMode' => '   ',
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/attendanceMode',
+                'The data should match one item from enum'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_attendanceMode_has_an_invalid_value(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannekoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'attendanceMode' => 'remote',
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/attendanceMode',
+                'The data should match one item from enum'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_if_terms_is_empty(): void
     {
         $event = [

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\DeleteCurrentOrganizer;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Event\Commands\ImportImages;
+use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
 use CultuurNet\UDB3\Event\Commands\UpdateAudience;
 use CultuurNet\UDB3\Event\Commands\UpdateBookingInfo;
 use CultuurNet\UDB3\Event\Commands\UpdateContactPoint;
@@ -52,6 +53,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Commands\DeleteOffer;
 use CultuurNet\UDB3\Offer\Commands\ImportLabels;
@@ -173,6 +175,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -253,6 +256,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -370,6 +374,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -443,6 +448,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new UpdateType($eventId, '1.50.0.0.0'),
                 new UpdateLocation($eventId, new LocationId('5cf42d51-3a4f-46f0-a8af-1cf672be8c84')),
                 new UpdateCalendar($eventId, new Calendar(CalendarType::PERMANENT())),
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -516,6 +522,7 @@ final class ImportEventRequestHandlerTest extends TestCase
             'availableFrom' => '2021-05-17T22:00:00+00:00',
             'availableTo' => '2021-05-17T22:00:00+00:00',
             'workflowStatus' => 'DRAFT',
+            'attendanceMode' => 'online',
             'audience' => [
                 'audienceType' => 'everyone',
             ],
@@ -630,6 +637,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::online()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo(
                     $eventId,
@@ -765,6 +773,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -834,6 +843,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -918,6 +928,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -986,6 +997,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1064,6 +1076,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1140,6 +1153,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1215,6 +1229,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1294,6 +1309,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1367,6 +1383,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1444,6 +1461,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1515,6 +1533,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1792,6 +1811,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -3541,6 +3561,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -3867,6 +3888,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint([], ['info@publiq.be'], [])),
@@ -4238,6 +4260,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
+                new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -133,7 +133,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -203,7 +203,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -284,7 +284,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -330,7 +330,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -401,7 +401,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -444,7 +444,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $this->assertEquals(
             [
-                new UpdateTitle($eventId, new LegacyLanguage('nl'), new Title('Pannekoeken voor het goede doel')),
+                new UpdateTitle($eventId, new LegacyLanguage('nl'), new Title('Pannenkoeken voor het goede doel')),
                 new UpdateType($eventId, '1.50.0.0.0'),
                 new UpdateLocation($eventId, new LocationId('5cf42d51-3a4f-46f0-a8af-1cf672be8c84')),
                 new UpdateCalendar($eventId, new Calendar(CalendarType::PERMANENT())),
@@ -727,7 +727,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '0.5.0.0.0',
             ],
@@ -800,7 +800,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '0.5.0.0.0',
             ],
@@ -870,7 +870,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'address' => [
                 'addressCountry' => 'BE',
                 'addressLocality' => '',
@@ -955,7 +955,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '0.5.0.0.0',
             ],
@@ -1024,7 +1024,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '0.5.0.0.0',
             ],
@@ -1103,7 +1103,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '1.50.0.0.0',
             ],
@@ -1180,7 +1180,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '1.50.0.0.0',
             ],
@@ -1256,7 +1256,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '1.50.0.0.0',
             ],
@@ -1336,7 +1336,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '1.50.0.0.0',
             ],
@@ -1410,7 +1410,7 @@ final class ImportEventRequestHandlerTest extends TestCase
 
         $given = [
             'mainLanguage' => 'nl',
-            'name' => 'Pannekoeken voor het goede doel',
+            'name' => 'Pannenkoeken voor het goede doel',
             'type' => [
                 'id' => '1.50.0.0.0',
             ],
@@ -1489,7 +1489,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1574,7 +1574,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'foo',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1607,7 +1607,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 'nl',
             ],
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1667,7 +1667,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
                 'fr' => '   ',
                 'en' => '',
             ],
@@ -1766,7 +1766,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
                 'es' => 'Invalid language',
             ],
             'terms' => [
@@ -1834,7 +1834,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1865,7 +1865,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1896,7 +1896,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1933,7 +1933,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1966,7 +1966,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -1997,7 +1997,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2034,7 +2034,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2073,7 +2073,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2111,7 +2111,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2150,7 +2150,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2181,7 +2181,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2218,7 +2218,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2265,7 +2265,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2303,7 +2303,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2352,7 +2352,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2405,7 +2405,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2458,7 +2458,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2500,7 +2500,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2538,7 +2538,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2576,7 +2576,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2610,7 +2610,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2642,7 +2642,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2674,7 +2674,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [],
             'location' => [
@@ -2701,7 +2701,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2733,7 +2733,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2764,7 +2764,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2797,7 +2797,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2833,7 +2833,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2866,7 +2866,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2900,7 +2900,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2936,7 +2936,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -2973,7 +2973,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3074,7 +3074,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3106,7 +3106,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3138,7 +3138,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3172,7 +3172,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3204,7 +3204,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3247,7 +3247,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3284,7 +3284,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3316,7 +3316,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3350,7 +3350,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3384,7 +3384,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3416,7 +3416,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3448,7 +3448,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3480,7 +3480,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3518,7 +3518,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3584,7 +3584,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3616,7 +3616,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3648,7 +3648,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3680,7 +3680,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3729,7 +3729,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3783,7 +3783,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3843,7 +3843,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3910,7 +3910,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -3965,7 +3965,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4008,7 +4008,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4063,7 +4063,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4104,7 +4104,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4153,7 +4153,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4208,7 +4208,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $given = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4288,7 +4288,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4322,7 +4322,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4356,7 +4356,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4390,7 +4390,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4424,7 +4424,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4458,7 +4458,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4495,7 +4495,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4532,7 +4532,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4569,7 +4569,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4612,7 +4612,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4646,7 +4646,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4681,7 +4681,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4718,7 +4718,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4757,7 +4757,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4792,7 +4792,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4824,7 +4824,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4860,7 +4860,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4906,7 +4906,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4946,7 +4946,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -4986,7 +4986,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5026,7 +5026,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5066,7 +5066,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5106,7 +5106,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5146,7 +5146,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5187,7 +5187,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5228,7 +5228,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5269,7 +5269,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5301,7 +5301,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5337,7 +5337,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5374,7 +5374,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5411,7 +5411,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5449,7 +5449,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [
@@ -5487,7 +5487,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $event = [
             'mainLanguage' => 'nl',
             'name' => [
-                'nl' => 'Pannekoeken voor het goede doel',
+                'nl' => 'Pannenkoeken voor het goede doel',
             ],
             'terms' => [
                 [

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -571,14 +571,14 @@ final class ImportEventRequestHandlerTest extends TestCase
                 [
                     '@id' => 'https://io.uitdatabank.dev/images/85b04295-479c-40f5-b3dd-469dfb4387b3',
                     '@type' => 'schema:ImageObject',
-                    'contentUrl' => 'https://io.uitdatabank.dev/images/pannekoeken.png',
-                    'thumbnailUrl' => 'https://io.uitdatabank.dev/images/pannekoeken.png',
-                    'description' => 'Een stapel pannekoeken',
+                    'contentUrl' => 'https://io.uitdatabank.dev/images/pannenkoeken.png',
+                    'thumbnailUrl' => 'https://io.uitdatabank.dev/images/pannenkoeken.png',
+                    'description' => 'Een stapel pannenkoeken',
                     'copyrightHolder' => '© publiq vzw',
                     'inLanguage' => 'nl',
                 ],
             ],
-            'image' => 'https://io.uitdatabank.dev/images/pannekoeken.png',
+            'image' => 'https://io.uitdatabank.dev/images/pannenkoeken.png',
             'videos' => [
                 [
                     'id' => 'b504cf44-9ab8-4641-9934-38d1cc67242c',
@@ -605,7 +605,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new Image(
                     new UUID('85b04295-479c-40f5-b3dd-469dfb4387b3'),
                     MIMEType::fromSubtype('png'),
-                    new Description('Een stapel pannekoeken'),
+                    new Description('Een stapel pannenkoeken'),
                     new CopyrightHolder('© publiq vzw'),
                     new Url('https://io.uitdatabank.dev/images/8b3c82d5-6cfe-442e-946c-1f4452636d61.png'),
                     new LegacyLanguage('nl')

--- a/tests/Model/Event/ImmutableEventTest.php
+++ b/tests/Model/Event/ImmutableEventTest.php
@@ -23,6 +23,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use PHPUnit\Framework\TestCase;
 
 class ImmutableEventTest extends TestCase
@@ -72,6 +73,27 @@ class ImmutableEventTest extends TestCase
         $this->assertNotEquals($event, $updatedEvent);
         $this->assertEquals($placeReference, $event->getPlaceReference());
         $this->assertEquals($updatedPlaceReference, $updatedEvent->getPlaceReference());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_offline_as_the_default_attendanceMode(): void
+    {
+        $this->assertTrue($this->getEvent()->getAttendanceMode()->sameAs(AttendanceMode::offline()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_a_copy_with_an_updated_attendanceMode(): void
+    {
+        $event = $this->getEvent();
+        $updatedEvent = $event->withAttendanceMode(AttendanceMode::mixed());
+
+        $this->assertNotEquals($event, $updatedEvent);
+        $this->assertTrue($event->getAttendanceMode()->sameAs(AttendanceMode::offline()));
+        $this->assertTrue($updatedEvent->getAttendanceMode()->sameAs(AttendanceMode::mixed()));
     }
 
     /**

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -64,6 +64,7 @@ use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedDescription;
 use CultuurNet\UDB3\Model\ValueObject\Text\TranslatedTitle;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
+use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddress;
 use CultuurNet\UDB3\Model\ValueObject\Web\EmailAddresses;
 use CultuurNet\UDB3\Model\ValueObject\Web\TranslatedWebsiteLabel;
@@ -1461,6 +1462,7 @@ class EventDenormalizerTest extends TestCase
                 '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
             ],
             'calendarType' => 'permanent',
+            'attendanceMode' => 'online',
             'terms' => [
                 [
                     'id' => '0.50.1.0.1',
@@ -1605,6 +1607,9 @@ class EventDenormalizerTest extends TestCase
             )
             ->withAgeRange(
                 new AgeRange(new Age(8), new Age(12))
+            )
+            ->withAttendanceMode(
+                AttendanceMode::online()
             )
             ->withAudienceType(
                 AudienceType::education()


### PR DESCRIPTION
### Added
- Added VO `AttendanceMode`
- Added command `UpdateAttendanceMode`
- Added event `AttendanceModeUpdated`
- Added handler `UpdateAttendanceModeHandler`

### Changed
- Extend aggregate `Event` to support updating attendance mode
- Extend `ImportEventRequestHandler` to handle attendance mode and test validation of the provided attendance mode property inside the past JSON body
- Extend `EventLDProjector` to handle `AttendanceModeUpdated`

Note:
- Handling the validation of the provided location will be done in a follow-up pull request
- Creating a dedicated endpoint to only update the attendance mode will be done in ticket https://jira.uitdatabank.be/browse/III-4677

---
Ticket: https://jira.uitdatabank.be/browse/III-4667
