### PR TITLE
III-4592 Fix duplicate labels with different visibility on organizers/places/events

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -26,7 +26,7 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CuratorEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\MediaUrlOfferRepositoryDecorator;
-use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\PropertyPolyfillOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\TermLabelOfferRepositoryDecorator;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
@@ -74,7 +74,7 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     $repository
                 );
 
-                $repository = new NewPropertyPolyfillOfferRepository($repository);
+                $repository = new PropertyPolyfillOfferRepository($repository);
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -156,7 +156,7 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     $app['udb2_event_cdbid_extractor'],
                     $app['calendar_factory'],
                     $app['cdbxml_contact_info_importer'],
-                    new CdbXMLToJsonLDLabelImporter()
+                    $app[CdbXMLToJsonLDLabelImporter::class]
                 );
             }
         );

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -34,6 +34,7 @@ use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
 use CultuurNet\UDB3\Silex\Error\LoggerFactory;
 use CultuurNet\UDB3\Silex\Error\LoggerName;
+use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use CultuurNet\UDB3\Term\TermRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -74,7 +75,10 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     $repository
                 );
 
-                $repository = new PropertyPolyfillOfferRepository($repository);
+                $repository = new PropertyPolyfillOfferRepository(
+                    $repository,
+                    $app[LabelServiceProvider::JSON_READ_REPOSITORY]
+                );
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 

--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Event;
 
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Curators\NewsArticleRepository;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
@@ -154,7 +155,8 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
                     ),
                     $app['udb2_event_cdbid_extractor'],
                     $app['calendar_factory'],
-                    $app['cdbxml_contact_info_importer']
+                    $app['cdbxml_contact_info_importer'],
+                    new CdbXMLToJsonLDLabelImporter()
                 );
             }
         );

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -188,7 +188,7 @@ class LabelServiceProvider implements ServiceProviderInterface
         );
 
         $app[CdbXMLToJsonLDLabelImporter::class] = $app->share(
-            fn (Application $app) => new CdbXMLToJsonLDLabelImporter()
+            fn (Application $app) => new CdbXMLToJsonLDLabelImporter($app[self::JSON_READ_REPOSITORY])
         );
     }
 

--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Labels;
 
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueDBALEventStoreDecorator;
 use CultuurNet\UDB3\Http\Label\Query\QueryFactory;
 use CultuurNet\UDB3\Label\CommandHandler;
@@ -184,6 +185,10 @@ class LabelServiceProvider implements ServiceProviderInterface
                     new Version4Generator()
                 );
             }
+        );
+
+        $app[CdbXMLToJsonLDLabelImporter::class] = $app->share(
+            fn (Application $app) => new CdbXMLToJsonLDLabelImporter()
         );
     }
 

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Silex\Organizer;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
+use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\CdbXMLImporter;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\EventFactory;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\PropertyPolyfillRepository;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
@@ -34,7 +35,8 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
                     new ImageNormalizer(
                         $app['media_object_repository'],
                         $app['media_object_iri_generator']
-                    )
+                    ),
+                    new CdbXMLImporter()
                 );
             }
         );

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Organizer;
 
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\ImageNormalizer;
 use CultuurNet\UDB3\Organizer\OrganizerLDProjector;
@@ -36,7 +37,9 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
                         $app['media_object_repository'],
                         $app['media_object_iri_generator']
                     ),
-                    new CdbXMLImporter()
+                    new CdbXMLImporter(
+                        new CdbXMLToJsonLDLabelImporter()
+                    )
                 );
             }
         );

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\PropertyPolyfillRepository;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -55,7 +56,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
         $app['organizer_jsonld_repository'] = $app->share(
             function ($app) {
                 $repository = new CacheDocumentRepository($app['organizer_jsonld_cache']);
-                $repository = new PropertyPolyfillRepository($repository);
+                $repository = new PropertyPolyfillRepository($repository, $app[LabelServiceProvider::JSON_READ_REPOSITORY]);
 
                 return new BroadcastingDocumentRepositoryDecorator(
                     $repository,

--- a/app/Organizer/OrganizerJSONLDServiceProvider.php
+++ b/app/Organizer/OrganizerJSONLDServiceProvider.php
@@ -38,7 +38,7 @@ class OrganizerJSONLDServiceProvider implements ServiceProviderInterface
                         $app['media_object_iri_generator']
                     ),
                     new CdbXMLImporter(
-                        new CdbXMLToJsonLDLabelImporter()
+                        $app[CdbXMLToJsonLDLabelImporter::class]
                     )
                 );
             }

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Place;
 
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
@@ -132,7 +133,8 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                         $app['config']['base_price_translations']
                     ),
                     $app['calendar_factory'],
-                    $app['cdbxml_contact_info_importer']
+                    $app['cdbxml_contact_info_importer'],
+                    new CdbXMLToJsonLDLabelImporter()
                 );
             }
         );

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -26,6 +26,7 @@ use CultuurNet\UDB3\Place\ReadModel\JSONLD\PlaceLDProjector;
 use CultuurNet\UDB3\Place\ReadModel\JSONLD\RelatedPlaceLDProjector;
 use CultuurNet\UDB3\ReadModel\BroadcastingDocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocumentLanguageEnricher;
+use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
 use CultuurNet\UDB3\Term\TermRepository;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -102,7 +103,10 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                     $repository
                 );
 
-                $repository = new PropertyPolyfillOfferRepository($repository);
+                $repository = new PropertyPolyfillOfferRepository(
+                    $repository,
+                    $app[LabelServiceProvider::JSON_READ_REPOSITORY]
+                );
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -134,7 +134,7 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                     ),
                     $app['calendar_factory'],
                     $app['cdbxml_contact_info_importer'],
-                    new CdbXMLToJsonLDLabelImporter()
+                    $app[CdbXMLToJsonLDLabelImporter::class]
                 );
             }
         );

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\MediaUrlOfferRepositoryDecorator;
-use CultuurNet\UDB3\Offer\ReadModel\JSONLD\NewPropertyPolyfillOfferRepository;
+use CultuurNet\UDB3\Offer\ReadModel\JSONLD\PropertyPolyfillOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\TermLabelOfferRepositoryDecorator;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\ReadModel\Metadata\OfferMetadataRepository;
@@ -102,7 +102,7 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
                     $repository
                 );
 
-                $repository = new NewPropertyPolyfillOfferRepository($repository);
+                $repository = new PropertyPolyfillOfferRepository($repository);
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);
 

--- a/src/Cdb/CdbXMLToJsonLDLabelImporter.php
+++ b/src/Cdb/CdbXMLToJsonLDLabelImporter.php
@@ -11,7 +11,8 @@ final class CdbXMLToJsonLDLabelImporter
 {
     public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD): void
     {
-        $labels = LabelsFactory::createLabelsFromKeywords($item->getKeywords(true));
+        $keywords = array_values($item->getKeywords(true));
+        $labels = LabelsFactory::createLabelsFromKeywords(...$keywords);
 
         $visibleLabels = $labels->getVisibleLabels()->toArrayOfStringNames();
         $hiddenLabels = $labels->getHiddenLabels()->toArrayOfStringNames();

--- a/src/Cdb/CdbXMLToJsonLDLabelImporter.php
+++ b/src/Cdb/CdbXMLToJsonLDLabelImporter.php
@@ -11,7 +11,7 @@ use stdClass;
 
 final class CdbXMLToJsonLDLabelImporter
 {
-    public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD)
+    public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD): void
     {
         $labelCollection = LabelCollection::fromKeywords(
             $item->getKeywords(true)

--- a/src/Cdb/CdbXMLToJsonLDLabelImporter.php
+++ b/src/Cdb/CdbXMLToJsonLDLabelImporter.php
@@ -5,29 +5,16 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cdb;
 
 use CultureFeed_Cdb_Item_Base;
-use CultuurNet\UDB3\Label;
-use CultuurNet\UDB3\LabelCollection;
 use stdClass;
 
 final class CdbXMLToJsonLDLabelImporter
 {
     public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD): void
     {
-        $labelCollection = LabelCollection::fromKeywords(
-            $item->getKeywords(true)
-        );
+        $labels = LabelsFactory::createLabelsFromKeywords($item->getKeywords(true));
 
-        $visibleLabels = $labelCollection->filter(
-            function (Label $label) {
-                return $label->isVisible();
-            }
-        )->toStrings();
-
-        $hiddenLabels = $labelCollection->filter(
-            function (Label $label) {
-                return !$label->isVisible();
-            }
-        )->toStrings();
+        $visibleLabels = $labels->getVisibleLabels()->toArrayOfStringNames();
+        $hiddenLabels = $labels->getHiddenLabels()->toArrayOfStringNames();
 
         empty($visibleLabels) ?: $jsonLD->labels = $visibleLabels;
         empty($hiddenLabels) ?: $jsonLD->hiddenLabels = $hiddenLabels;

--- a/src/Cdb/CdbXMLToJsonLDLabelImporter.php
+++ b/src/Cdb/CdbXMLToJsonLDLabelImporter.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3;
+namespace CultuurNet\UDB3\Cdb;
 
 use CultureFeed_Cdb_Item_Base;
+use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\LabelCollection;
 use stdClass;
 
 final class CdbXMLToJsonLDLabelImporter

--- a/src/Cdb/CdbXMLToJsonLDLabelImporter.php
+++ b/src/Cdb/CdbXMLToJsonLDLabelImporter.php
@@ -5,19 +5,48 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Cdb;
 
 use CultureFeed_Cdb_Item_Base;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use CultuurNet\UDB3\StringLiteral;
 use stdClass;
 
 final class CdbXMLToJsonLDLabelImporter
 {
+    private ReadRepositoryInterface $labelReadRepository;
+
+    public function __construct(ReadRepositoryInterface $labelReadRepository)
+    {
+        $this->labelReadRepository = $labelReadRepository;
+    }
+
     public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD): void
     {
         $keywords = array_values($item->getKeywords(true));
         $labels = LabelsFactory::createLabelsFromKeywords(...$keywords);
+        $labelsWithCorrectVisibility = new Labels();
 
-        $visibleLabels = $labels->getVisibleLabels()->toArrayOfStringNames();
-        $hiddenLabels = $labels->getHiddenLabels()->toArrayOfStringNames();
+        /** @var Label $label */
+        foreach ($labels as $label) {
+            $labelReadModel = $this->labelReadRepository->getByName(new StringLiteral($label->getName()->toString()));
+            if ($labelReadModel) {
+                $isVisible = $labelReadModel->getVisibility()->sameAs(Visibility::VISIBLE());
+                $label = new Label($label->getName(), $isVisible);
+            }
+            $labelsWithCorrectVisibility = $labelsWithCorrectVisibility->with($label);
+        }
 
-        empty($visibleLabels) ?: $jsonLD->labels = $visibleLabels;
-        empty($hiddenLabels) ?: $jsonLD->hiddenLabels = $hiddenLabels;
+        $visibleLabels = $labelsWithCorrectVisibility->getVisibleLabels()->toArrayOfStringNames();
+        $hiddenLabels = $labelsWithCorrectVisibility->getHiddenLabels()->toArrayOfStringNames();
+
+        unset($jsonLD->labels, $jsonLD->hiddenLabels);
+
+        if (!empty($visibleLabels)) {
+            $jsonLD->labels = $visibleLabels;
+        }
+        if (!empty($hiddenLabels)) {
+            $jsonLD->hiddenLabels = $hiddenLabels;
+        }
     }
 }

--- a/src/Cdb/LabelsFactory.php
+++ b/src/Cdb/LabelsFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cdb;
+
+use CultureFeed_Cdb_Data_Keyword;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels;
+use InvalidArgumentException;
+
+final class LabelsFactory
+{
+    public static function createLabelsFromKeywords(CultureFeed_Cdb_Data_Keyword ...$keywords): Labels
+    {
+        $labels = [];
+        foreach ($keywords as $keyword) {
+            try {
+                $labelName = new LabelName($keyword->getValue());
+            } catch (InvalidArgumentException $exception) {
+                // Skip keywords that are not valid label names. (Not much possible to fix that.)
+                continue;
+            }
+            $labels[] = new Label($labelName, $keyword->isVisible());
+        }
+        return new Labels(...$labels);
+    }
+}

--- a/src/CdbXMLToJsonLDLabelImporter.php
+++ b/src/CdbXMLToJsonLDLabelImporter.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3;
 use CultureFeed_Cdb_Item_Base;
 use stdClass;
 
-class LabelImporter
+final class CdbXMLToJsonLDLabelImporter
 {
     public function importLabels(CultureFeed_Cdb_Item_Base $item, stdClass $jsonLD)
     {

--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\CalendarFactoryInterface;
 use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractorInterface;
 use CultuurNet\UDB3\Cdb\Description\MergedDescription;
 use CultuurNet\UDB3\Event\ValueObjects\Audience;
-use CultuurNet\UDB3\LabelImporter;
+use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporterInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
@@ -88,7 +88,7 @@ class CdbXMLImporter
 
         $this->cdbXMLItemBaseImporter->importAvailable($event, $jsonLD);
 
-        $labelImporter = new LabelImporter();
+        $labelImporter = new CdbXMLToJsonLDLabelImporter();
         $labelImporter->importLabels($event, $jsonLD);
 
         $this->importLocation($event, $placeManager, $jsonLD);

--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -29,16 +29,20 @@ class CdbXMLImporter
 
     private CdbXmlContactInfoImporterInterface $cdbXmlContactInfoImporter;
 
+    private CdbXMLToJsonLDLabelImporter $cdbXMLLabelImporter;
+
     public function __construct(
         CdbXMLItemBaseImporter $cdbXMLItemBaseImporter,
         EventCdbIdExtractorInterface $cdbIdExtractor,
         CalendarFactoryInterface $calendarFactory,
-        CdbXmlContactInfoImporterInterface $cdbXmlContactInfoImporter
+        CdbXmlContactInfoImporterInterface $cdbXmlContactInfoImporter,
+        CdbXMLToJsonLDLabelImporter $cdbXmlLabelImporter
     ) {
         $this->cdbXMLItemBaseImporter = $cdbXMLItemBaseImporter;
         $this->cdbIdExtractor = $cdbIdExtractor;
         $this->calendarFactory = $calendarFactory;
         $this->cdbXmlContactInfoImporter = $cdbXmlContactInfoImporter;
+        $this->cdbXMLLabelImporter = $cdbXmlLabelImporter;
     }
 
     /**
@@ -88,8 +92,7 @@ class CdbXMLImporter
 
         $this->cdbXMLItemBaseImporter->importAvailable($event, $jsonLD);
 
-        $labelImporter = new CdbXMLToJsonLDLabelImporter();
-        $labelImporter->importLabels($event, $jsonLD);
+        $this->cdbXMLLabelImporter->importLabels($event, $jsonLD);
 
         $this->importLocation($event, $placeManager, $jsonLD);
 

--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\CalendarFactoryInterface;
 use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractorInterface;
 use CultuurNet\UDB3\Cdb\Description\MergedDescription;
 use CultuurNet\UDB3\Event\ValueObjects\Audience;
-use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporterInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;

--- a/src/Http/Event/ImportEventRequestHandler.php
+++ b/src/Http/Event/ImportEventRequestHandler.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Event\Commands\UpdateTheme;
 use CultuurNet\UDB3\Event\Commands\UpdateTitle;
 use CultuurNet\UDB3\Event\Commands\UpdateTypicalAgeRange;
 use CultuurNet\UDB3\Event\Event as EventAggregate;
+use CultuurNet\UDB3\Http\Label\DuplicateLabelValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Offer\BookingInfoValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Offer\CalendarValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
@@ -109,8 +110,9 @@ final class ImportEventRequestHandler implements RequestHandlerInterface
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::EVENT),
             new AttendanceModeValidatingRequestBodyParser(),
             new AgeRangeValidatingRequestBodyParser(),
-            new CalendarValidatingRequestBodyParser(),
             new BookingInfoValidatingRequestBodyParser(),
+            new CalendarValidatingRequestBodyParser(),
+            new DuplicateLabelValidatingRequestBodyParser(),
             MainLanguageValidatingRequestBodyParser::createForEvent(),
             new DenormalizingRequestBodyParser($this->eventDenormalizer, Event::class)
         )->parse($request)->getParsedBody();

--- a/src/Http/Label/DuplicateLabelValidatingRequestBodyParser.php
+++ b/src/Http/Label/DuplicateLabelValidatingRequestBodyParser.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Label;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class DuplicateLabelValidatingRequestBodyParser implements RequestBodyParser
+{
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $errors = [];
+
+        $data = $request->getParsedBody();
+
+        if (isset($data->labels, $data->hiddenLabels)) {
+            $hiddenLabelsLowerCased = array_map(
+                fn (string $labelName) => (new LabelName($labelName))->toLowerCase()->toString(),
+                $data->hiddenLabels
+            );
+            foreach ($data->labels as $index => $label) {
+                $labelLowerCased = (new LabelName($label))->toLowerCase()->toString();
+                if (in_array($labelLowerCased, $hiddenLabelsLowerCased, true)) {
+                    $errors[] = new SchemaError(
+                        '/labels/' . $index,
+                        'Label "' . $label . '" cannot be both in labels and hiddenLabels properties.'
+                    );
+                }
+            }
+        }
+
+        if (count($errors) > 0) {
+            throw ApiProblem::bodyInvalidData(...$errors);
+        }
+
+        return $request;
+    }
+}

--- a/src/Http/Organizer/ImportOrganizerRequestHandler.php
+++ b/src/Http/Organizer/ImportOrganizerRequestHandler.php
@@ -11,6 +11,7 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\EventSourcing\DBAL\DBALEventStoreException;
 use CultuurNet\UDB3\EventSourcing\DBAL\UniqueConstraintException;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\Label\DuplicateLabelValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\IdPropertyPolyfillRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
@@ -88,6 +89,7 @@ final class ImportOrganizerRequestHandler implements RequestHandlerInterface
             $this->importPreProcessingRequestBodyParser,
             new IdPropertyPolyfillRequestBodyParser($this->iriGenerator, $organizerId),
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::ORGANIZER),
+            new DuplicateLabelValidatingRequestBodyParser(),
             MainLanguageValidatingRequestBodyParser::createForOrganizer(),
             new DenormalizingRequestBodyParser(new OrganizerDenormalizer(), Organizer::class)
         )->parse($request)->getParsedBody();

--- a/src/Http/Place/ImportPlaceRequestHandler.php
+++ b/src/Http/Place/ImportPlaceRequestHandler.php
@@ -8,6 +8,7 @@ use Broadway\CommandHandling\CommandBus;
 use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
+use CultuurNet\UDB3\Http\Label\DuplicateLabelValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Offer\BookingInfoValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Offer\CalendarValidatingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
@@ -112,8 +113,9 @@ final class ImportPlaceRequestHandler implements RequestHandlerInterface
             $this->importPreProcessingRequestBodyParser,
             new IdPropertyPolyfillRequestBodyParser($this->iriGenerator, $placeId),
             new JsonSchemaValidatingRequestBodyParser(JsonSchemaLocator::PLACE),
-            new CalendarValidatingRequestBodyParser(),
             new BookingInfoValidatingRequestBodyParser(),
+            new CalendarValidatingRequestBodyParser(),
+            new DuplicateLabelValidatingRequestBodyParser(),
             MainLanguageValidatingRequestBodyParser::createForPlace(),
             new DenormalizingRequestBodyParser($this->placeDenormalizer, Place::class)
         )->parse($request)->getParsedBody();

--- a/src/Label/Services/ReadService.php
+++ b/src/Label/Services/ReadService.php
@@ -10,6 +10,10 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\StringLiteral;
 
+/**
+ * @deprecated
+ *   Use an ReadRepositoryInterface implementation directly.
+ */
 final class ReadService implements ReadServiceInterface
 {
     private ReadRepositoryInterface $readRepository;

--- a/src/Label/Services/ReadServiceInterface.php
+++ b/src/Label/Services/ReadServiceInterface.php
@@ -9,6 +9,10 @@ use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Query;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\StringLiteral;
 
+/**
+ * @deprecated
+ *   Use ReadRepositoryInterface directly.
+ */
 interface ReadServiceInterface
 {
     public function getByUuid(UUID $uuid): ?Entity;

--- a/src/LabelCollection.php
+++ b/src/LabelCollection.php
@@ -88,6 +88,17 @@ class LabelCollection implements \Countable
         return !empty($equalLabels);
     }
 
+    public function containsWithSameVisibility(Label $label): bool
+    {
+        $equalLabels = array_filter(
+            $this->labels,
+            function (Label $existingLabel) use ($label) {
+                return $label->equals($existingLabel) && $label->isVisible() === $existingLabel->isVisible();
+            }
+        );
+        return !empty($equalLabels);
+    }
+
     /**
      * @return Label[]
      */

--- a/src/LabelCollection.php
+++ b/src/LabelCollection.php
@@ -176,6 +176,7 @@ class LabelCollection implements \Countable
     /**
      * @param CultureFeed_Cdb_Data_Keyword[] $keywords
      * @return LabelCollection
+     * @deprecated Use CultuurNet\UDB3\Cdb\LabelsFactory instead.
      */
     public static function fromKeywords($keywords)
     {

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -27,4 +27,10 @@ class LabelName
 
         $this->setValue($value);
     }
+
+    public function toLowerCase(): LabelName
+    {
+        return new self(mb_strtolower($this->toString(), 'UTF-8'));
+    }
+
 }

--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -33,4 +33,8 @@ class LabelName
         return new self(mb_strtolower($this->toString(), 'UTF-8'));
     }
 
+    public function sameAs(LabelName $other): bool
+    {
+        return $this->toLowerCase()->toString() === $other->toLowerCase()->toString();
+    }
 }

--- a/src/Model/ValueObject/Taxonomy/Label/Labels.php
+++ b/src/Model/ValueObject/Taxonomy/Label/Labels.php
@@ -28,6 +28,17 @@ class Labels extends Collection
         parent::__construct(...$uniqueLabels);
     }
 
+    public function findByName(LabelName $labelName): ?Label
+    {
+        /** @var Label $label */
+        foreach ($this->toArray() as $label) {
+            if ($label->getName()->sameAs($labelName)) {
+                return $label;
+            }
+        }
+        return null;
+    }
+
     public function toArrayOfStringNames(): array
     {
         return array_map(

--- a/src/Model/ValueObject/Taxonomy/Label/Labels.php
+++ b/src/Model/ValueObject/Taxonomy/Label/Labels.php
@@ -16,9 +16,15 @@ class Labels extends Collection
         // Remove duplicates (with or without the same visibility) by copying every label to a new array, keyed by the
         // label name. If a label name is twice in $labels (with same or different visibility), the last entry will
         // always overwrite the previous entries.
+        // Also make sure that the array key is converted to lowercase so we avoid duplicates with other casing. The
+        // last casing will be kept, so a previously incorrect casing can be fixed (using with()).
         $uniqueLabels = [];
         foreach ($labels as $label) {
-            $uniqueLabels[$label->getName()->toString()] = $label;
+            $key = $label
+                ->getName()
+                ->toLowerCase()
+                ->toString();
+            $uniqueLabels[$key] = $label;
         }
 
         // Remove the keys and make the array sequential (0, 1, 2, ...) to avoid "Cannot unpack array with string keys"

--- a/src/Model/ValueObject/Taxonomy/Label/Labels.php
+++ b/src/Model/ValueObject/Taxonomy/Label/Labels.php
@@ -4,28 +4,28 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label;
 
-use CultuurNet\UDB3\Model\ValueObject\Collection\Behaviour\HasUniqueValues;
 use CultuurNet\UDB3\Model\ValueObject\Collection\Collection;
 
 class Labels extends Collection
 {
-    use HasUniqueValues;
-
     /**
      * @param Label[] ...$labels
      */
     public function __construct(Label ...$labels)
     {
-        $labelNames = array_map(
-            function (Label $label) {
-                return $label->getName();
-            },
-            $labels
-        );
+        // Remove duplicates (with or without the same visibility) by copying every label to a new array, keyed by the
+        // label name. If a label name is twice in $labels (with same or different visibility), the last entry will
+        // always overwrite the previous entries.
+        $uniqueLabels = [];
+        foreach ($labels as $label) {
+            $uniqueLabels[$label->getName()->toString()] = $label;
+        }
 
-        $this->guardUniqueValues($labelNames);
+        // Remove the keys and make the array sequential (0, 1, 2, ...) to avoid "Cannot unpack array with string keys"
+        // error in the parent::__construct() call.
+        $uniqueLabels = array_values($uniqueLabels);
 
-        parent::__construct(...$labels);
+        parent::__construct(...$uniqueLabels);
     }
 
     public function toArrayOfStringNames(): array

--- a/src/Model/ValueObject/Taxonomy/Label/Labels.php
+++ b/src/Model/ValueObject/Taxonomy/Label/Labels.php
@@ -39,6 +39,16 @@ class Labels extends Collection
         return null;
     }
 
+    public function getVisibleLabels(): Labels
+    {
+        return $this->filter(fn (Label $label) => $label->isVisible());
+    }
+
+    public function getHiddenLabels(): Labels
+    {
+        return $this->filter(fn (Label $label) => !$label->isVisible());
+    }
+
     public function toArrayOfStringNames(): array
     {
         return array_map(

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -292,7 +292,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         // Labels which are not inside the internal state but inside the imported labels
         $addedLabels = new LabelCollection();
         foreach ($importLabelsCollection->asArray() as $label) {
-            if (!$this->labels->contains($label)) {
+            if (!$this->labels->containsWithSameVisibility($label)) {
                 $addedLabels = $addedLabels->with($label);
             }
         }
@@ -311,28 +311,21 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
             $this->apply($this->createLabelsImportedEvent($importLabels));
         }
 
+        // What are the deleted labels?
+        // Labels which are inside the internal state but not inside imported labels or labels to keep. (Taking
+        // visibility into consideration.) For each deleted label fire a LabelDeleted event.
+        foreach ($this->labels->asArray() as $label) {
+            $inImportWithSameVisibility = $importLabelsCollection->containsWithSameVisibility($label);
+            $inImportWithDifferentVisibility = !$inImportWithSameVisibility && (bool) $labels->findByName(new LabelName($label->getName()->toNative()));
+            $canBeRemoved = !$keepLabelsCollection->containsWithSameVisibility($label);
+            if ((!$inImportWithSameVisibility && $canBeRemoved) || $inImportWithDifferentVisibility) {
+                $this->apply($this->createLabelRemovedEvent($label));
+            }
+        }
+
         // For each added label fire a LabelAdded event.
         foreach ($addedLabels->asArray() as $label) {
             $this->apply($this->createLabelAddedEvent($label));
-        }
-
-        // What are the deleted labels?
-        // Labels which are inside the internal state but not inside imported labels or labels to keep.
-        // For each deleted label fire a LabelDeleted event.
-        foreach ($this->labels->asArray() as $label) {
-            $labelName = $label->getName()->toNative();
-            $importLabelNames = array_map(
-                fn (LegacyLabel $label) => $label->getName()->toNative(),
-                $importLabelsCollection->asArray()
-            );
-            $keepLabelNames = array_map(
-                fn (LegacyLabel $label) => $label->getName()->toNative(),
-                $keepLabelsCollection->asArray()
-            );
-
-            if (!in_array($labelName, $importLabelNames, true) && !in_array($labelName, $keepLabelNames, true)) {
-                $this->apply($this->createLabelRemovedEvent($label));
-            }
         }
     }
 

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -11,7 +11,7 @@ use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\SameAsForUitInVlaanderen;
 
-final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
+final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 {
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
     {

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -209,7 +209,11 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                     return $json;
                 }
 
-                $duplicates = array_intersect($json['labels'], $json['hiddenLabels']);
+                $toLowerCase = fn (string $label) => mb_strtolower($label, 'UTF-8');
+                $lowerCasedLabels = array_map($toLowerCase, $json['labels']);
+                $lowerCasedHiddenLabels = array_map($toLowerCase, $json['hiddenLabels']);
+                $duplicates = array_intersect($lowerCasedLabels, $lowerCasedHiddenLabels);
+
                 foreach ($duplicates as $duplicate) {
                     // Get the visibility from the read model, or if not found assume invisible to make sure that labels
                     // that should be hidden labels do not show up on publication channels (which would be worse than
@@ -221,7 +225,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                     $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
                     $json[$filterProperty] = array_filter(
                         $json[$filterProperty],
-                        fn ($labelName) => $labelName !== $duplicate
+                        fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
                     );
                 }
 

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -5,19 +5,32 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
 use CultuurNet\UDB3\Event\ValueObjects\StatusType;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\SameAsForUitInVlaanderen;
+use CultuurNet\UDB3\StringLiteral;
 
 final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 {
+    private ReadRepositoryInterface $labelReadRepository;
+
+    public function __construct(DocumentRepository $repository, ReadRepositoryInterface $labelReadRepository)
+    {
+        parent::__construct($repository);
+        $this->labelReadRepository = $labelReadRepository;
+    }
+
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
     {
         $document = parent::fetch($id, $includeMetadata);
         $document = $this->polyfillNewProperties($document);
         $document = $this->removeObsoleteProperties($document);
+        $document = $this->fixDuplicateLabelVisibility($document);
         return $document;
     }
 
@@ -176,6 +189,49 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         return $jsonDocument->applyAssoc(
             function (array $json) use ($obsoleteProperties) {
                 $json = array_diff_key($json, array_flip($obsoleteProperties));
+                return $json;
+            }
+        );
+    }
+
+    /**
+     * Checks for labels that are both in "labels" and "hiddenLabels" and filters them out of the wrong property
+     * depending on the label's visibility in the read repository.
+     * It does not check every label to avoid performance issues, so only duplicate labels get fixed.
+     */
+    private function fixDuplicateLabelVisibility(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                if (!isset($json['labels'], $json['hiddenLabels']) ||
+                    !is_array($json['labels']) ||
+                    !is_array($json['hiddenLabels'])) {
+                    return $json;
+                }
+
+                $duplicates = array_intersect($json['labels'], $json['hiddenLabels']);
+                foreach ($duplicates as $duplicate) {
+                    // Get the visibility from the read model, or if not found assume invisible to make sure that labels
+                    // that should be hidden labels do not show up on publication channels (which would be worse than
+                    // visible labels accidentally being hidden).
+                    $readModel = $this->labelReadRepository->getByName(new StringLiteral($duplicate));
+                    $visibility = $readModel ? $readModel->getVisibility() : Visibility::INVISIBLE();
+
+                    // Filter the duplicate out of the property that it does not belong in.
+                    $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
+                    $json[$filterProperty] = array_filter(
+                        $json[$filterProperty],
+                        fn ($labelName) => $labelName !== $duplicate
+                    );
+                }
+
+                if (count($json['labels']) === 0) {
+                    unset($json['labels']);
+                }
+                if (count($json['hiddenLabels']) === 0) {
+                    unset($json['hiddenLabels']);
+                }
+
                 return $json;
             }
         );

--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -108,13 +108,14 @@ class OrganizerLDProjector implements EventListener
         DocumentRepository $repository,
         IriGeneratorInterface $iriGenerator,
         JsonDocumentMetaDataEnricherInterface $jsonDocumentMetaDataEnricher,
-        NormalizerInterface $imageNormalizer
+        NormalizerInterface $imageNormalizer,
+        CdbXMLImporter $cdbXMLImporter
     ) {
         $this->repository = $repository;
         $this->iriGenerator = $iriGenerator;
         $this->jsonDocumentMetaDataEnricher = $jsonDocumentMetaDataEnricher;
         $this->imageNormalizer = $imageNormalizer;
-        $this->cdbXMLImporter = new CdbXMLImporter();
+        $this->cdbXMLImporter = $cdbXMLImporter;
         $this->addressNormalizer = new AddressNormalizer();
         $this->contactPointNormalizer = new ContactPointNormalizer();
     }

--- a/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\ContactPoint;
-use CultuurNet\UDB3\LabelImporter;
+use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use stdClass;
 
@@ -101,7 +101,7 @@ class CdbXMLImporter
                 $urls[] = $url->getUrl();
             }
 
-            $labelImporter = new LabelImporter();
+            $labelImporter = new CdbXMLToJsonLDLabelImporter();
             $labelImporter->importLabels($actor, $jsonLD);
 
             $contactPoint = new ContactPoint($phones, $emails, $urls);

--- a/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
 use CultuurNet\UDB3\ContactPoint;
-use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use stdClass;
 

--- a/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Organizer/ReadModel/JSONLD/CdbXMLImporter.php
@@ -20,6 +20,13 @@ use stdClass;
  */
 class CdbXMLImporter
 {
+    private CdbXMLToJsonLDLabelImporter $labelImporter;
+
+    public function __construct(CdbXMLToJsonLDLabelImporter $labelImporter)
+    {
+        $this->labelImporter = $labelImporter;
+    }
+
     /**
      * Imports a UDB2 organizer actor into a UDB3 JSON-LD document.
      *
@@ -101,8 +108,7 @@ class CdbXMLImporter
                 $urls[] = $url->getUrl();
             }
 
-            $labelImporter = new CdbXMLToJsonLDLabelImporter();
-            $labelImporter->importLabels($actor, $jsonLD);
+            $this->labelImporter->importLabels($actor, $jsonLD);
 
             $contactPoint = new ContactPoint($phones, $emails, $urls);
 

--- a/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
+++ b/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
@@ -94,7 +94,11 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
                     return $json;
                 }
 
-                $duplicates = array_intersect($json['labels'], $json['hiddenLabels']);
+                $toLowerCase = fn (string $label) => mb_strtolower($label, 'UTF-8');
+                $lowerCasedLabels = array_map($toLowerCase, $json['labels']);
+                $lowerCasedHiddenLabels = array_map($toLowerCase, $json['hiddenLabels']);
+                $duplicates = array_intersect($lowerCasedLabels, $lowerCasedHiddenLabels);
+
                 foreach ($duplicates as $duplicate) {
                     // Get the visibility from the read model, or if not found assume invisible to make sure that labels
                     // that should be hidden labels do not show up on publication channels (which would be worse than
@@ -106,7 +110,7 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
                     $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
                     $json[$filterProperty] = array_filter(
                         $json[$filterProperty],
-                        fn ($labelName) => $labelName !== $duplicate
+                        fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
                     );
                 }
 

--- a/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
+++ b/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
@@ -4,15 +4,28 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\StringLiteral;
 
 final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
 {
+    private ReadRepositoryInterface $labelReadRepository;
+
+    public function __construct(DocumentRepository $repository, ReadRepositoryInterface $labelReadRepository)
+    {
+        parent::__construct($repository);
+        $this->labelReadRepository = $labelReadRepository;
+    }
+
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument
     {
         $document = parent::fetch($id, $includeMetadata);
         $document = $this->polyfillNewProperties($document);
+        $document = $this->fixDuplicateLabelVisibility($document);
         return $document;
     }
 
@@ -64,5 +77,48 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
         );
 
         return $json;
+    }
+
+    /**
+     * Checks for labels that are both in "labels" and "hiddenLabels" and filters them out of the wrong property
+     * depending on the label's visibility in the read repository.
+     * It does not check every label to avoid performance issues, so only duplicate labels get fixed.
+     */
+    private function fixDuplicateLabelVisibility(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                if (!isset($json['labels'], $json['hiddenLabels']) ||
+                    !is_array($json['labels']) ||
+                    !is_array($json['hiddenLabels'])) {
+                    return $json;
+                }
+
+                $duplicates = array_intersect($json['labels'], $json['hiddenLabels']);
+                foreach ($duplicates as $duplicate) {
+                    // Get the visibility from the read model, or if not found assume invisible to make sure that labels
+                    // that should be hidden labels do not show up on publication channels (which would be worse than
+                    // visible labels accidentally being hidden).
+                    $readModel = $this->labelReadRepository->getByName(new StringLiteral($duplicate));
+                    $visibility = $readModel ? $readModel->getVisibility() : Visibility::INVISIBLE();
+
+                    // Filter the duplicate out of the property that it does not belong in.
+                    $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
+                    $json[$filterProperty] = array_filter(
+                        $json[$filterProperty],
+                        fn ($labelName) => $labelName !== $duplicate
+                    );
+                }
+
+                if (count($json['labels']) === 0) {
+                    unset($json['labels']);
+                }
+                if (count($json['hiddenLabels']) === 0) {
+                    unset($json['hiddenLabels']);
+                }
+
+                return $json;
+            }
+        );
     }
 }

--- a/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place\ReadModel\JSONLD;
 
 use CultuurNet\UDB3\CalendarFactoryInterface;
 use CultuurNet\UDB3\Cdb\Description\MergedDescription;
-use CultuurNet\UDB3\LabelImporter;
+use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporterInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 
@@ -141,7 +141,7 @@ class CdbXMLImporter
             );
         }
 
-        $labelImporter = new LabelImporter();
+        $labelImporter = new CdbXMLToJsonLDLabelImporter();
         $labelImporter->importLabels($item, $jsonLD);
 
         $this->importTerms($item, $jsonLD);

--- a/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Place\ReadModel\JSONLD;
 
 use CultuurNet\UDB3\CalendarFactoryInterface;
 use CultuurNet\UDB3\Cdb\Description\MergedDescription;
-use CultuurNet\UDB3\CdbXMLToJsonLDLabelImporter;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporterInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 

--- a/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
@@ -31,15 +31,19 @@ class CdbXMLImporter
      */
     private $cdbXmlContactInfoImporter;
 
+    private CdbXMLToJsonLDLabelImporter $cdbXmlLabelImporter;
+
 
     public function __construct(
         CdbXMLItemBaseImporter $dbXMLItemBaseImporter,
         CalendarFactoryInterface $calendarFactory,
-        CdbXmlContactInfoImporterInterface $cdbXmlContactInfoImporter
+        CdbXmlContactInfoImporterInterface $cdbXmlContactInfoImporter,
+        CdbXMLToJsonLDLabelImporter $cdbXmlLabelImporter
     ) {
         $this->cdbXMLItemBaseImporter = $dbXMLItemBaseImporter;
         $this->calendarFactory = $calendarFactory;
         $this->cdbXmlContactInfoImporter = $cdbXmlContactInfoImporter;
+        $this->cdbXmlLabelImporter = $cdbXmlLabelImporter;
     }
 
     /**
@@ -141,8 +145,7 @@ class CdbXMLImporter
             );
         }
 
-        $labelImporter = new CdbXMLToJsonLDLabelImporter();
-        $labelImporter->importLabels($item, $jsonLD);
+        $this->cdbXmlLabelImporter->importLabels($item, $jsonLD);
 
         $this->importTerms($item, $jsonLD);
 

--- a/tests/Cdb/CdbXMLToJsonLDLabelImporterTest.php
+++ b/tests/Cdb/CdbXMLToJsonLDLabelImporterTest.php
@@ -12,13 +12,14 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class CdbXMLToJsonLDLabelImporterTest extends TestCase
 {
     private CdbXMLToJsonLDLabelImporter $cdbXMLToJsonLDLabelImporter;
-    private ReadRepositoryInterface $labelReadRepository;
+    private MockObject $labelReadRepository;
 
     protected function setUp(): void
     {

--- a/tests/Cdb/CdbXMLToJsonLDLabelImporterTest.php
+++ b/tests/Cdb/CdbXMLToJsonLDLabelImporterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Cdb;
+
+use CultureFeed_Cdb_Data_Keyword;
+use CultureFeed_Cdb_Item_Actor;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Privacy;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class CdbXMLToJsonLDLabelImporterTest extends TestCase
+{
+    private CdbXMLToJsonLDLabelImporter $cdbXMLToJsonLDLabelImporter;
+    private ReadRepositoryInterface $labelReadRepository;
+
+    protected function setUp(): void
+    {
+        $this->labelReadRepository = $this->createMock(ReadRepositoryInterface::class);
+        $this->cdbXMLToJsonLDLabelImporter = new CdbXMLToJsonLDLabelImporter($this->labelReadRepository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fixes_label_visibility_if_different_on_imported_xml_than_in_udb3(): void
+    {
+        // Organizers used to be called "Actors" in UDB2, just like places.
+        $organizer = new CultureFeed_Cdb_Item_Actor();
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('visible_in_xml_and_visible_in_udb3', true));
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('visible_in_xml_and_invisible_in_udb3', true));
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('visible_in_xml_and_unknown_in_udb3', true));
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('invisible_in_xml_and_invisible_in_udb3', false));
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('invisible_in_xml_and_visible_in_udb3', false));
+        $organizer->addKeyword(new CultureFeed_Cdb_Data_Keyword('invisible_in_xml_and_unknown_in_udb3', false));
+
+        $this->labelReadRepository->expects($this->any())
+            ->method('getByName')
+            ->willReturnCallback(
+                static function (StringLiteral $labelName): ?Entity {
+                    $labelNameString = $labelName->toNative();
+
+                    $uuid = new UUID('3b069d8a-2394-45f4-80ce-50469c643386');
+                    $privacy = Privacy::PRIVACY_PUBLIC();
+
+                    switch ($labelNameString) {
+                        case 'visible_in_xml_and_visible_in_udb3':
+                        case 'invisible_in_xml_and_visible_in_udb3':
+                            return new Entity($uuid, $labelName, Visibility::VISIBLE(), $privacy);
+
+                        case 'visible_in_xml_and_invisible_in_udb3':
+                        case 'invisible_in_xml_and_invisible_in_udb3':
+                            return new Entity($uuid, $labelName, Visibility::INVISIBLE(), $privacy);
+
+                        default:
+                            return null;
+                    }
+                }
+            );
+
+        $jsonLd = new stdClass();
+
+        $this->cdbXMLToJsonLDLabelImporter->importLabels($organizer, $jsonLd);
+
+        $expectedLabels = [
+            'visible_in_xml_and_visible_in_udb3',
+            'visible_in_xml_and_unknown_in_udb3',
+            'invisible_in_xml_and_visible_in_udb3',
+        ];
+
+        $expectedHiddenLabels = [
+            'visible_in_xml_and_invisible_in_udb3',
+            'invisible_in_xml_and_invisible_in_udb3',
+            'invisible_in_xml_and_unknown_in_udb3',
+        ];
+
+        $this->assertTrue(isset($jsonLd->labels));
+        $this->assertTrue(isset($jsonLd->hiddenLabels));
+        $this->assertEquals($expectedLabels, $jsonLd->labels);
+        $this->assertEquals($expectedHiddenLabels, $jsonLd->hiddenLabels);
+    }
+}

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -413,7 +413,7 @@ class CdbXMLImporterTest extends TestCase
     {
         $jsonEvent = $this->createJsonEventFromCdbXml('event_with_duplicate_labels.cdbxml.xml');
 
-        $this->assertEquals(['enkel'], $jsonEvent->labels);
+        $this->assertEquals(['EnKeL'], $jsonEvent->labels);
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractor;
 use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use CultuurNet\UDB3\SluggerInterface;
@@ -58,7 +59,7 @@ class CdbXMLImporterTest extends TestCase
             new EventCdbIdExtractor(),
             new CalendarFactory(),
             new CdbXmlContactInfoImporter(),
-            new CdbXMLToJsonLDLabelImporter()
+            new CdbXMLToJsonLDLabelImporter($this->createMock(ReadRepositoryInterface::class))
         );
         $this->organizerManager = $this->createMock(OrganizerServiceInterface::class);
         $this->placeManager = $this->createMock(PlaceServiceInterface::class);

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -9,6 +9,7 @@ use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use CultureFeed_Cdb_Item_Event;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractor;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\EventItemFactory;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
@@ -56,7 +57,8 @@ class CdbXMLImporterTest extends TestCase
             ),
             new EventCdbIdExtractor(),
             new CalendarFactory(),
-            new CdbXmlContactInfoImporter()
+            new CdbXmlContactInfoImporter(),
+            new CdbXMLToJsonLDLabelImporter()
         );
         $this->organizerManager = $this->createMock(OrganizerServiceInterface::class);
         $this->placeManager = $this->createMock(PlaceServiceInterface::class);

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -46,6 +46,7 @@ use CultuurNet\UDB3\Event\ValueObjects\Audience;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
@@ -130,7 +131,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             new EventCdbIdExtractor(),
             new CalendarFactory(),
             new CdbXmlContactInfoImporter(),
-            new CdbXMLToJsonLDLabelImporter()
+            new CdbXMLToJsonLDLabelImporter($this->createMock(ReadRepositoryInterface::class))
         );
 
         $this->projector = new EventLDProjector(

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -9,6 +9,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
@@ -128,7 +129,8 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             ),
             new EventCdbIdExtractor(),
             new CalendarFactory(),
-            new CdbXmlContactInfoImporter()
+            new CdbXmlContactInfoImporter(),
+            new CdbXMLToJsonLDLabelImporter()
         );
 
         $this->projector = new EventLDProjector(

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -5715,6 +5715,39 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertValidationErrors($event, $expectedErrors);
     }
 
+    /**
+     * @test
+     */
+    public function it_throws_if_a_label_is_both_in_labels_and_hiddenLabels(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannenkoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'labels' => ['foo', 'uitpas mechelen'],
+            'hiddenLabels' => ['UiTPAS Mechelen'],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/labels/1',
+                'Label "uitpas mechelen" cannot be both in labels and hiddenLabels properties.'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
     private function assertValidationErrors(array $event, array $expectedErrors): void
     {
         $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';

--- a/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
+++ b/tests/Http/Organizer/ImportOrganizerRequestHandlerTest.php
@@ -1279,6 +1279,18 @@ class ImportOrganizerRequestHandlerTest extends TestCase
                     new SchemaError('/hiddenLabels/0', 'The string should match pattern: ^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$'),
                 ],
             ],
+            'labels_duplicate_in_hiddenLabels' => [
+                'given' => [
+                    'mainLanguage' => 'nl',
+                    'name' => ['nl' => 'Test'],
+                    'url' => 'https://www.organizer.be',
+                    'labels' => ['foo', 'UitPas MecHeLen'],
+                    'hiddenLabels' => ['UiTPAS Mechelen'],
+                ],
+                'schemaErrors' => [
+                    new SchemaError('/labels/1', 'Label "UitPas MecHeLen" cannot be both in labels and hiddenLabels properties.'),
+                ],
+            ],
         ];
     }
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -4945,6 +4945,47 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $this->assertValidationErrors($place, $expectedErrors);
     }
 
+    /**
+     * @test
+     */
+    public function it_should_throw_an_exception_if_a_label_is_both_in_labels_and_hiddenLabels(): void
+    {
+        $place = [
+            '@id' => 'http://io.uitdatabank.be/place/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Test place',
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => 'Yf4aZBfsUEu2NsQqsprngw',
+                    'domain' => 'eventtype',
+                    'label' => 'Cultuur- of ontmoetingscentrum',
+                ],
+            ],
+            'address' => [
+                'nl' => [
+                    'streetAddress' => 'Henegouwenkaai 41-43',
+                    'postalCode' => '1080',
+                    'addressLocality' => 'Brussel',
+                    'addressCountry' => 'BE',
+                ],
+            ],
+            'labels' => ['foo', 'UiTPAS Mechelen'],
+            'hiddenLabels' => ['uitpas mechelen'],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/labels/1',
+                'Label "UiTPAS Mechelen" cannot be both in labels and hiddenLabels properties.'
+            ),
+        ];
+
+        $this->assertValidationErrors($place, $expectedErrors);
+    }
+
     private function assertValidationErrors(array $place, array $expectedErrors): void
     {
         $placeId = 'c4f1515a-7a73-4e18-a53a-9bf201d6fc9b';

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelsTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelsTest.php
@@ -11,29 +11,14 @@ class LabelsTest extends TestCase
     /**
      * @test
      */
-    public function it_should_throw_an_exception_if_duplicate_labels_with_the_same_visibility_are_given()
+    public function it_should_filter_out_duplicates_and_always_use_visibility_of_the_last_duplicate(): void
     {
         $name = new LabelName('foo');
         $label = new Label($name, true);
+        $labelHidden = new Label($name, false);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Found 1 duplicates in the given array.');
+        $labels = new Labels($label, $labelHidden);
 
-        new Labels($label, $label);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_throw_an_exception_if_duplicate_labels_with_different_visibility_are_given()
-    {
-        $name = new LabelName('foo');
-        $visibleLabel = new Label($name, true);
-        $invisibleLabel = new Label($name, false);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Found 1 duplicates in the given array.');
-
-        new Labels($visibleLabel, $invisibleLabel);
+        $this->assertEquals([$labelHidden], $labels->toArray());
     }
 }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -382,8 +382,8 @@ class OfferTest extends AggregateRootScenarioTestCase
                         )
                     )
                 ),
-                new LabelAdded($itemId, new LegacyLabel('new_label_1')),
                 new LabelRemoved($itemId, new LegacyLabel('existing_label_4_added_via_import')),
+                new LabelAdded($itemId, new LegacyLabel('new_label_1')),
             ]);
     }
 

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -460,7 +460,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
         // Mock that "UiTPAS Mechelen" is visible
         $this->labelReadRepository->expects($this->any())
             ->method('getByName')
-            ->with(new StringLiteral('UiTPAS Mechelen'))
+            ->with(new StringLiteral('uitpas mechelen'))
             ->willReturn(
                 new Entity(
                     new UUID('7ba9e0e6-f1b5-4931-a00a-cd660c990e57'),
@@ -479,7 +479,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                         'UiTPAS Mechelen',
                     ],
                     'hiddenLabels' => [
-                        'UiTPAS Mechelen',
+                        'uitpas Mechelen',
                     ],
                 ]
             )
@@ -496,7 +496,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 [
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
-                        'UiTPAS Mechelen',
+                        'uitpas Mechelen',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Privacy;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PropertyPolyfillOfferRepositoryTest extends TestCase
 {
     public const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
+    private MockObject $labelReadRepository;
 
     /**
      * @var PropertyPolyfillOfferRepository
@@ -20,8 +28,11 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
 
     protected function setUp()
     {
+        $this->labelReadRepository = $this->createMock(ReadRepositoryInterface::class);
+
         $this->repository = new PropertyPolyfillOfferRepository(
-            new InMemoryDocumentRepository()
+            new InMemoryDocumentRepository(),
+            $this->labelReadRepository
         );
     }
 
@@ -442,6 +453,93 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                     'http://www.uitinvlaanderen.be/agenda/e/kopieertest/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                     ],
                 ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fix_visibility_of_label_both_in_labels_and_hiddenLabels(): void
+    {
+        // Mock that "UiTPAS Mechelen" is visible
+        $this->labelReadRepository->expects($this->any())
+            ->method('getByName')
+            ->with(new StringLiteral('UiTPAS Mechelen'))
+            ->willReturn(
+                new Entity(
+                    new UUID('7ba9e0e6-f1b5-4931-a00a-cd660c990e57'),
+                    new StringLiteral('UiTPAS Mechelen'),
+                    Visibility::VISIBLE(),
+                    Privacy::PRIVACY_PUBLIC()
+                )
+            );
+
+        // Make sure the hiddenLabels property gets completely removed.
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                        'UiTPAS Mechelen',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentDoesNotContainKey('hiddenLabels');
+    }
+
+    /**
+     * @test
+     */
+    public function it_assumes_labels_are_invisible_if_duplicate_and_not_found_in_read_repository(): void
+    {
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                        'UiTPAS Mechelen',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_labels_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('labels');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_hiddenLabels_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('hiddenLabels');
     }
 
     private function given(array $given): self

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -21,12 +21,9 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     public const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
     private MockObject $labelReadRepository;
 
-    /**
-     * @var PropertyPolyfillOfferRepository
-     */
-    private $repository;
+    private PropertyPolyfillOfferRepository $repository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->labelReadRepository = $this->createMock(ReadRepositoryInterface::class);
 

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -9,18 +9,18 @@ use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use PHPUnit\Framework\TestCase;
 
-class NewPropertyPolyfillOfferRepositoryTest extends TestCase
+class PropertyPolyfillOfferRepositoryTest extends TestCase
 {
     public const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
 
     /**
-     * @var NewPropertyPolyfillOfferRepository
+     * @var PropertyPolyfillOfferRepository
      */
     private $repository;
 
     protected function setUp()
     {
-        $this->repository = new NewPropertyPolyfillOfferRepository(
+        $this->repository = new PropertyPolyfillOfferRepository(
             new InMemoryDocumentRepository()
         );
     }

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Actor\ActorEvent;
 use CultuurNet\UDB3\Address\Locality;
 use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Address\Street;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label;
@@ -94,7 +95,9 @@ final class OrganizerLDProjectorTest extends TestCase
                 $this->imageRepository,
                 $iriGenerator
             ),
-            new CdbXMLImporter()
+            new CdbXMLImporter(
+                new CdbXMLToJsonLDLabelImporter()
+            )
         );
 
         $this->recordedOn = RecordedOn::fromBroadwayDateTime(

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -45,6 +45,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
+use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\CdbXMLImporter;
 use CultuurNet\UDB3\Organizer\ReadModel\JSONLD\OrganizerJsonDocumentLanguageAnalyzer;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
@@ -92,7 +93,8 @@ final class OrganizerLDProjectorTest extends TestCase
             new ImageNormalizer(
                 $this->imageRepository,
                 $iriGenerator
-            )
+            ),
+            new CdbXMLImporter()
         );
 
         $this->recordedOn = RecordedOn::fromBroadwayDateTime(

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -17,6 +17,7 @@ use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\MediaObject;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
@@ -96,7 +97,7 @@ final class OrganizerLDProjectorTest extends TestCase
                 $iriGenerator
             ),
             new CdbXMLImporter(
-                new CdbXMLToJsonLDLabelImporter()
+                new CdbXMLToJsonLDLabelImporter($this->createMock(ReadRepositoryInterface::class))
             )
         );
 

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -160,7 +160,7 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                         '404EE8DE-E828-9C07-FE7D12DC4EB24480',
                         'foo',
                         false
-                    )
+                    ),
                 ]
             );
     }

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -114,6 +114,60 @@ class OrganizerTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_can_import_same_label_with_correct_visibility_after_udb2_import_with_incorrect_visibility(): void
+    {
+        $cdbXml = $this->getCdbXML('organizer_with_keyword.cdbxml.xml');
+
+        $this->scenario
+            ->given(
+                [
+                    new OrganizerImportedFromUDB2(
+                        '404EE8DE-E828-9C07-FE7D12DC4EB24480',
+                        $cdbXml,
+                        'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL'
+                    ),
+                ]
+            )
+            ->when(
+                function (Organizer $organizer) {
+                    $organizer->importLabels(
+                        new Labels(
+                            new Label(
+                                new LabelName('foo'),
+                                false
+                            )
+                        )
+                    );
+                }
+            )
+            ->then(
+                [
+                    new LabelsImported(
+                        '404EE8DE-E828-9C07-FE7D12DC4EB24480',
+                        new Labels(
+                            new Label(
+                                new LabelName('foo'),
+                                false
+                            )
+                        )
+                    ),
+                    new LabelRemoved(
+                        '404EE8DE-E828-9C07-FE7D12DC4EB24480',
+                        'foo',
+                        true
+                    ),
+                    new LabelAdded(
+                        '404EE8DE-E828-9C07-FE7D12DC4EB24480',
+                        'foo',
+                        false
+                    )
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_updates_from_udb2_actors_and_takes_labels_into_account(): void
     {
         $cdbXml = $this->getCdbXML('organizer_with_keyword.cdbxml.xml');
@@ -211,9 +265,9 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                             )
                         )
                     ),
-                    new LabelAdded($this->id, 'new_label_1'),
                     new LabelRemoved($this->id, 'existing_label_2'),
                     new LabelRemoved($this->id, 'existing_label_3'),
+                    new LabelAdded($this->id, 'new_label_1'),
                 ]
             );
     }

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -135,7 +135,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
         // Mock that "UiTPAS Mechelen" is visible
         $this->labelReadRepository->expects($this->any())
             ->method('getByName')
-            ->with(new StringLiteral('UiTPAS Mechelen'))
+            ->with(new StringLiteral('uitpas mechelen'))
             ->willReturn(
                 new Entity(
                     new UUID('7ba9e0e6-f1b5-4931-a00a-cd660c990e57'),
@@ -154,7 +154,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
                         'UiTPAS Mechelen',
                     ],
                     'hiddenLabels' => [
-                        'UiTPAS Mechelen',
+                        'uitpas Mechelen',
                     ],
                 ]
             )
@@ -171,7 +171,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
                 [
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
-                        'UiTPAS Mechelen',
+                        'uitpas Mechelen',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Organizer\ReadModel\JSONLD;
 
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Label\ValueObjects\Privacy;
+use CultuurNet\UDB3\Label\ValueObjects\Visibility;
+use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class PropertyPolyfillRepositoryTest extends TestCase
@@ -13,11 +20,15 @@ final class PropertyPolyfillRepositoryTest extends TestCase
     private const DOCUMENT_ID = '5d7ed700-17de-4c1f-923a-0affe7cf2d4c';
 
     private PropertyPolyfillRepository $repository;
+    private MockObject $labelReadRepository;
 
     protected function setUp(): void
     {
+        $this->labelReadRepository = $this->createMock(ReadRepositoryInterface::class);
+
         $this->repository = new PropertyPolyfillRepository(
-            new InMemoryDocumentRepository()
+            new InMemoryDocumentRepository(),
+            $this->labelReadRepository
         );
     }
 
@@ -114,6 +125,93 @@ final class PropertyPolyfillRepositoryTest extends TestCase
                 []
             )
             ->assertReturnedDocumentDoesNotContainKey('images');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_fix_visibility_of_label_both_in_labels_and_hiddenLabels(): void
+    {
+        // Mock that "UiTPAS Mechelen" is visible
+        $this->labelReadRepository->expects($this->any())
+            ->method('getByName')
+            ->with(new StringLiteral('UiTPAS Mechelen'))
+            ->willReturn(
+                new Entity(
+                    new UUID('7ba9e0e6-f1b5-4931-a00a-cd660c990e57'),
+                    new StringLiteral('UiTPAS Mechelen'),
+                    Visibility::VISIBLE(),
+                    Privacy::PRIVACY_PUBLIC()
+                )
+            );
+
+        // Make sure the hiddenLabels property gets completely removed.
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                        'UiTPAS Mechelen',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentDoesNotContainKey('hiddenLabels');
+    }
+
+    /**
+     * @test
+     */
+    public function it_assumes_labels_are_invisible_if_duplicate_and_not_found_in_read_repository(): void
+    {
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                        'UiTPAS Mechelen',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'labels' => [
+                        'Aanvaarden van SABAM-cultuurchèques',
+                    ],
+                    'hiddenLabels' => [
+                        'UiTPAS Mechelen',
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_labels_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('labels');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_add_hiddenLabels_if_not_set(): void
+    {
+        $this
+            ->given(
+                []
+            )
+            ->assertReturnedDocumentDoesNotContainKey('hiddenLabels');
     }
 
     private function given(array $given): self

--- a/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
 use InvalidArgumentException;
@@ -39,7 +40,7 @@ class CdbXMLImporterTest extends TestCase
             ),
             new CalendarFactory(),
             new CdbXmlContactInfoImporter(),
-            new CdbXMLToJsonLDLabelImporter()
+            new CdbXMLToJsonLDLabelImporter($this->createMock(ReadRepositoryInterface::class))
         );
         date_default_timezone_set('Europe/Brussels');
     }

--- a/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -8,6 +8,7 @@ use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXmlContactInfoImporter;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
@@ -37,7 +38,8 @@ class CdbXMLImporterTest extends TestCase
                 ]
             ),
             new CalendarFactory(),
-            new CdbXmlContactInfoImporter()
+            new CdbXmlContactInfoImporter(),
+            new CdbXMLToJsonLDLabelImporter()
         );
         date_default_timezone_set('Europe/Brussels');
     }

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\Metadata;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
+use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -88,7 +89,8 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
                 ]
             ),
             new CalendarFactory(),
-            new CdbXmlContactInfoImporter()
+            new CdbXmlContactInfoImporter(),
+            new CdbXMLToJsonLDLabelImporter()
         );
 
         $this->projector = new PlaceLDProjector(

--- a/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
+++ b/tests/Place/ReadModel/JSONLD/PlaceLDProjectorTest.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
@@ -90,7 +91,7 @@ class PlaceLDProjectorTest extends OfferLDProjectorTestBase
             ),
             new CalendarFactory(),
             new CdbXmlContactInfoImporter(),
-            new CdbXMLToJsonLDLabelImporter()
+            new CdbXMLToJsonLDLabelImporter($this->createMock(ReadRepositoryInterface::class))
         );
 
         $this->projector = new PlaceLDProjector(


### PR DESCRIPTION
### Fixed

- When an event/place/organizer has a label with an incorrect or outdated visibility in its internal state (due to the visibility being stored in LabelAdded or being derived from the XML in Imported/UpdatedFromUDB2 events), the `importLabels()` method no longer crashes on the same label but with a new/correct visibility (as it is always set correctly by `LabelImportPreProcessor`). Instead the label with the incorrect/old visibility is removed (resulting in a `LabelRemoved` event), and the same label but with the new/correct visibility is added (resulted in a `LabelAdded` event). This was the event listeners downstream will also update the visibility to the correct one.
- When an event/place/organizer is imported or updated via XML and the XML contains an invalid keyword visibility, the keyword is now projected as a label with the correct visibility.
- For existing events/places/organizers a polyfill is provided so that keywords that appear both in `labels` and `hiddenLabels` because they were imported/updated from XML multiple times (with different keyword visibility) are filtered out of the incorrect property.
- A clearer API problem is returned when an event/place/organizer is imported via JSON if they have the same label in `labels` and `hiddenLabels`.

---
Ticket: https://jira.uitdatabank.be/browse/III-4592

Todo:

- [x] Fix `importLabels()` crashing when importing a label that is already on the event/place/organizer but with an invalid/outdated visibility inside its aggregate state
- [x] Fix incorrect label visibility on event/place/organizer JSON-LD in projector (will only work for new XML imports - which are not happening anymore - or after a replay for existing events/places/organizers)
- [x] Fix duplicate labels on event/place/organizer JSON-LD (same label both in `labels` and `hiddenLabels`) by adding a decorator/polyfill that looks for these duplicates and checks what the correct visibility is
  - [x] For organizers
  - [x] For events + places (offers)
- [x] Add validation/error for JSON-LD imports with same label both in `labels`/`hiddenLabels`
