### PR TITLE
III-4661 bugfix for polyfill sameAs

### DIFF
--- a/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepository.php
@@ -161,7 +161,10 @@ final class NewPropertyPolyfillOfferRepository extends DocumentRepositoryDecorat
             return $json;
         }
 
-        $json['sameAs'] = (new SameAsForUitInVlaanderen())->generateSameAs($json['@id'], $json['name']['nl']);
+        $urlParts = explode('/', $json['@id']);
+        $id = array_pop($urlParts);
+
+        $json['sameAs'] = (new SameAsForUitInVlaanderen())->generateSameAs($id, $json['name']['nl']);
 
         return $json;
     }

--- a/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/NewPropertyPolyfillOfferRepositoryTest.php
@@ -425,7 +425,7 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
     {
         $this
             ->given([
-                '@id' => '5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                     'name' => [
                         'nl' => 'Kopieertest',
                         ],
@@ -434,7 +434,7 @@ class NewPropertyPolyfillOfferRepositoryTest extends TestCase
                         ],
                     ])
             ->assertReturnedDocumentContains([
-                '@id' => '5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'name' => [
                     'nl' => 'Kopieertest',
                     ],


### PR DESCRIPTION
### Fixed

- Use only the `cdbid` in `sameAs` instead of the `io.uitdatabank.be` link to generate the UiTinVlaanderen link.

---
Ticket: https://jira.uitdatabank.be/browse/III-4661
