### PR TITLE
III-4697 Fix bug that causes `labels` and/or `hiddenLabels` to become an object

### DIFF
--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -223,9 +223,11 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 
                     // Filter the duplicate out of the property that it does not belong in.
                     $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
-                    $json[$filterProperty] = array_filter(
-                        $json[$filterProperty],
-                        fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
+                    $json[$filterProperty] = array_values(
+                        array_filter(
+                            $json[$filterProperty],
+                            fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
+                        )
                     );
                 }
 

--- a/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
+++ b/src/Organizer/ReadModel/JSONLD/PropertyPolyfillRepository.php
@@ -108,9 +108,11 @@ final class PropertyPolyfillRepository extends DocumentRepositoryDecorator
 
                     // Filter the duplicate out of the property that it does not belong in.
                     $filterProperty = $visibility->sameAs(Visibility::VISIBLE()) ? 'hiddenLabels' : 'labels';
-                    $json[$filterProperty] = array_filter(
-                        $json[$filterProperty],
-                        fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
+                    $json[$filterProperty] = array_values(
+                        array_filter(
+                            $json[$filterProperty],
+                            fn ($labelName) => mb_strtolower($labelName, 'UTF-8') !== $duplicate
+                        )
                     );
                 }
 

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -497,6 +497,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
                         'uitpas Mechelen',
+                        '3rd label to check that the array does not become an object when a label in the middle is removed',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',
@@ -507,6 +508,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 [
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
+                        '3rd label to check that the array does not become an object when a label in the middle is removed',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',

--- a/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
+++ b/tests/Organizer/ReadModel/JSONLD/PropertyPolyfillRepositoryTest.php
@@ -172,6 +172,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
                         'uitpas Mechelen',
+                        '3rd label to check that the array does not become an object when a label in the middle is removed',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',
@@ -182,6 +183,7 @@ final class PropertyPolyfillRepositoryTest extends TestCase
                 [
                     'labels' => [
                         'Aanvaarden van SABAM-cultuurchèques',
+                        '3rd label to check that the array does not become an object when a label in the middle is removed',
                     ],
                     'hiddenLabels' => [
                         'UiTPAS Mechelen',


### PR DESCRIPTION
### Fixed

- Fixed bug that causes `labels` and/or `hiddenLabels` to become an object, by calling `array_values()` on the filtered array so the array becomes sequential instead of associative again.

---
Ticket: https://jira.uitdatabank.be/browse/III-4697
