### PR TITLE
III-4693 Support deleting an onlineUrl

### DIFF
--- a/app/Event/EventCommandHandlerProvider.php
+++ b/app/Event/EventCommandHandlerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Event;
 
 use CultuurNet\UDB3\Event\CommandHandlers\CopyEventHandler;
+use CultuurNet\UDB3\Event\CommandHandlers\DeleteOnlineUrlHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\RemoveThemeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAttendanceModeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAudienceHandler;
@@ -37,6 +38,10 @@ final class EventCommandHandlerProvider implements ServiceProviderInterface
 
         $app[UpdateOnlineUrlHandler::class] = $app->share(
             fn (Application $application) => new UpdateOnlineUrlHandler($app['event_repository'])
+        );
+
+        $app[DeleteOnlineUrlHandler::class] = $app->share(
+            fn (Application $application) => new DeleteOnlineUrlHandler($app['event_repository'])
         );
 
         $app[UpdateAudienceHandler::class] = $app->share(

--- a/app/Event/EventControllerProvider.php
+++ b/app/Event/EventControllerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Event;
 
 use CultuurNet\UDB3\Http\Event\CopyEventRequestHandler;
+use CultuurNet\UDB3\Http\Event\DeleteOnlineUrlRequestHandler;
 use CultuurNet\UDB3\Http\Event\DeleteThemeRequestHandler;
 use CultuurNet\UDB3\Http\Event\EditEventRestController;
 use CultuurNet\UDB3\Http\Event\ImportEventRequestHandler;
@@ -47,6 +48,7 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
         $controllers->delete('/{eventId}/theme/', DeleteThemeRequestHandler::class);
         $controllers->put('/{eventId}/attendance-mode/', UpdateAttendanceModeRequestHandler::class);
         $controllers->put('/{eventId}/online-url/', UpdateOnlineUrlRequestHandler::class);
+        $controllers->delete('/{eventId}/online-url/', DeleteOnlineUrlRequestHandler::class);
         $controllers->put('/{eventId}/audience/', UpdateAudienceRequestHandler::class);
         $controllers->post('/{eventId}/copies/', CopyEventRequestHandler::class);
 
@@ -139,6 +141,10 @@ class EventControllerProvider implements ControllerProviderInterface, ServicePro
 
         $app[UpdateOnlineUrlRequestHandler::class] = $app->share(
             fn (Application $app) => new UpdateOnlineUrlRequestHandler($app['event_command_bus'])
+        );
+
+        $app[DeleteOnlineUrlRequestHandler::class] = $app->share(
+            fn (Application $app) => new DeleteOnlineUrlRequestHandler($app['event_command_bus'])
         );
 
         $app[UpdateAudienceRequestHandler::class] = $app->share(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Broadway\EventHandling\ReplayFlaggingEventBus;
 use CultuurNet\UDB3\CalendarFactory;
 use CultuurNet\UDB3\Clock\SystemClock;
 use CultuurNet\UDB3\Event\CommandHandlers\CopyEventHandler;
+use CultuurNet\UDB3\Event\CommandHandlers\DeleteOnlineUrlHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\RemoveThemeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAttendanceModeHandler;
 use CultuurNet\UDB3\Event\CommandHandlers\UpdateAudienceHandler;
@@ -620,6 +621,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[RemoveThemeHandler::class]);
         $commandBus->subscribe($app[UpdateAttendanceModeHandler::class]);
         $commandBus->subscribe($app[UpdateOnlineUrlHandler::class]);
+        $commandBus->subscribe($app[DeleteOnlineUrlHandler::class]);
         $commandBus->subscribe($app[UpdateAudienceHandler::class]);
         $commandBus->subscribe($app[CopyEventHandler::class]);
 

--- a/src/Event/CommandHandlers/DeleteOnlineUrlHandler.php
+++ b/src/Event/CommandHandlers/DeleteOnlineUrlHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
+use CultuurNet\UDB3\Event\Event;
+use CultuurNet\UDB3\Event\EventRepository;
+
+final class DeleteOnlineUrlHandler implements CommandHandler
+{
+    private EventRepository $eventRepository;
+
+    public function __construct(EventRepository $eventRepository)
+    {
+        $this->eventRepository = $eventRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof DeleteOnlineUrl) {
+            return;
+        }
+
+        /** @var Event $event */
+        $event = $this->eventRepository->load($command->getItemId());
+
+        $event->deleteOnlineUrl();
+
+        $this->eventRepository->save($event);
+    }
+}

--- a/src/Event/Commands/DeleteOnlineUrl.php
+++ b/src/Event/Commands/DeleteOnlineUrl.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Commands;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class DeleteOnlineUrl implements AuthorizableCommand
+{
+    private string $eventId;
+
+    public function __construct(string $eventId)
+    {
+        $this->eventId = $eventId;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::aanbodBewerken();
+    }
+}

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Event;
 use Broadway\EventSourcing\EventSourcedAggregateRoot;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\AvailableFromUpdated;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
 use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
@@ -404,6 +405,18 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     public function applyOnlineUrlUpdated(OnlineUrlUpdated $onlineUrlUpdated): void
     {
         $this->onlineUrl = $onlineUrlUpdated->getOnlineUrl();
+    }
+
+    public function deleteOnlineUrl(): void
+    {
+        if (!empty($this->onlineUrl)) {
+            $this->apply(new OnlineUrlDeleted($this->eventId));
+        }
+    }
+
+    public function applyOnlineUrlDeleted(OnlineUrlDeleted $onlineUrlDeleted): void
+    {
+        $this->onlineUrl = '';
     }
 
     public function updateAudience(Audience $audience): void

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -384,6 +384,10 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
         if ($this->attendanceMode !== $attendanceMode->toString()) {
             $this->apply(new AttendanceModeUpdated($this->eventId, $attendanceMode->toString()));
         }
+
+        if (!empty($this->onlineUrl) && $this->attendanceMode === AttendanceMode::offline()->toString()) {
+            $this->apply(new OnlineUrlDeleted($this->eventId));
+        }
     }
 
     public function applyAttendanceModeUpdated(AttendanceModeUpdated $attendanceModeUpdated): void

--- a/src/Event/Events/OnlineUrlDeleted.php
+++ b/src/Event/Events/OnlineUrlDeleted.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use Broadway\Serializer\Serializable;
+
+final class OnlineUrlDeleted implements Serializable
+{
+    private string $eventId;
+
+    public function __construct(string $eventId)
+    {
+        $this->eventId = $eventId;
+    }
+
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }
+
+    public static function deserialize(array $data): OnlineUrlDeleted
+    {
+        return new OnlineUrlDeleted($data['eventId']);
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'eventId' => $this->eventId,
+        ];
+    }
+}

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -41,6 +41,7 @@ use CultuurNet\UDB3\Event\Events\Moderation\FlaggedAsDuplicate;
 use CultuurNet\UDB3\Event\Events\Moderation\FlaggedAsInappropriate;
 use CultuurNet\UDB3\Event\Events\Moderation\Published;
 use CultuurNet\UDB3\Event\Events\Moderation\Rejected;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
 use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
 use CultuurNet\UDB3\Event\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Event\Events\OrganizerUpdated;
@@ -447,6 +448,16 @@ class EventLDProjector extends OfferLDProjector implements
         $jsonLD = $document->getBody();
 
         $jsonLD->onlineUrl = $onlineUrlUpdated->getOnlineUrl();
+
+        return $document->withBody($jsonLD);
+    }
+
+    protected function applyOnlineUrlDeleted(OnlineUrlDeleted $onlineUrlDeleted): JsonDocument
+    {
+        $document = $this->loadDocumentFromRepositoryByItemId($onlineUrlDeleted->getEventId());
+        $jsonLD = $document->getBody();
+
+        unset($jsonLD->onlineUrl);
 
         return $document->withBody($jsonLD);
     }

--- a/src/Http/Event/DeleteOnlineUrlRequestHandler.php
+++ b/src/Http/Event/DeleteOnlineUrlRequestHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Event;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DeleteOnlineUrlRequestHandler implements RequestHandlerInterface
+{
+    private CommandBus $commandBus;
+
+    public function __construct(CommandBus $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $routeParameters = new RouteParameters($request);
+        $eventId = $routeParameters->getEventId();
+
+        $this->commandBus->dispatch(new DeleteOnlineUrl($eventId));
+
+        return new NoContentResponse();
+    }
+}

--- a/src/Http/Event/ImportEventRequestHandler.php
+++ b/src/Http/Event/ImportEventRequestHandler.php
@@ -9,6 +9,7 @@ use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\Repository;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Event\Commands\DeleteCurrentOrganizer;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Event\Commands\ImportImages;
 use CultuurNet\UDB3\Event\Commands\Moderation\Publish;
@@ -207,6 +208,8 @@ final class ImportEventRequestHandler implements RequestHandlerInterface
 
         if ($event->getOnlineUrl()) {
             $commands[] = new UpdateOnlineUrl($eventId, $event->getOnlineUrl());
+        } else {
+            $commands[] = new DeleteOnlineUrl($eventId);
         }
 
         if ($location->isDummyPlaceForEducation()) {

--- a/tests/Event/CommandHandlers/DeleteOnlineUrlHandlerTest.php
+++ b/tests/Event/CommandHandlers/DeleteOnlineUrlHandlerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\CommandHandlers;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
+use CultuurNet\UDB3\Event\EventRepository;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
+use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
+use CultuurNet\UDB3\Event\EventType;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Theme;
+use CultuurNet\UDB3\Title;
+
+final class DeleteOnlineUrlHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new DeleteOnlineUrlHandler(new EventRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_deleting_an_onlineUrl(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([
+                $this->getEventCreated($eventId),
+                new OnlineUrlUpdated($eventId, 'https://www.publiq.be/livestream'),
+            ])
+            ->when(new DeleteOnlineUrl($eventId))
+            ->then([new OnlineUrlDeleted($eventId)]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_delete_an_empty_onlineUrl(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([
+                $this->getEventCreated($eventId),
+            ])
+            ->when(new DeleteOnlineUrl($eventId))
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_delete_an_already_deleted_onlineUrl(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([
+                $this->getEventCreated($eventId),
+                new OnlineUrlUpdated($eventId, 'https://www.publiq.be/livestream'),
+                new OnlineUrlDeleted($eventId),
+            ])
+            ->when(new DeleteOnlineUrl($eventId))
+            ->then([]);
+    }
+
+    private function getEventCreated(string $id): EventCreated
+    {
+        return new EventCreated(
+            $id,
+            new Language('nl'),
+            new Title('some representative title'),
+            new EventType('0.50.4.0.0', 'Concert'),
+            new LocationId('bfc60a14-6208-4372-942e-86e63744769a'),
+            new Calendar(CalendarType::PERMANENT()),
+            new Theme('1.8.1.0.0', 'Rock')
+        );
+    }
+}

--- a/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateAttendanceModeHandlerTest.php
@@ -14,6 +14,8 @@ use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
 use CultuurNet\UDB3\Event\EventRepository;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
 use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
+use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
 use CultuurNet\UDB3\Language;
@@ -40,6 +42,27 @@ final class UpdateAttendanceModeHandlerTest extends CommandHandlerScenarioTestCa
             ->given([$this->getEventCreated($eventId)])
             ->when(new UpdateAttendanceMode($eventId, AttendanceMode::online()))
             ->then([new AttendanceModeUpdated($eventId, AttendanceMode::online()->toString())]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_onlineUrl_for_offline_attendanceMode(): void
+    {
+        $eventId = '40021958-0ad8-46bd-8528-3ac3686818a1';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given([
+                $this->getEventCreated($eventId),
+                new AttendanceModeUpdated($eventId, AttendanceMode::online()->toString()),
+                new OnlineUrlUpdated($eventId, 'https://www.publiq.be/livestream'),
+            ])
+            ->when(new UpdateAttendanceMode($eventId, AttendanceMode::offline()))
+            ->then([
+                new AttendanceModeUpdated($eventId, AttendanceMode::offline()->toString()),
+                new OnlineUrlDeleted($eventId),
+            ]);
     }
 
     /**

--- a/tests/Event/Commands/DeleteOnlineUrlTest.php
+++ b/tests/Event/Commands/DeleteOnlineUrlTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Commands;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteOnlineUrlTest extends TestCase
+{
+    private DeleteOnlineUrl $deleteOnlineUrl;
+
+    protected function setUp(): void
+    {
+        $this->deleteOnlineUrl = new DeleteOnlineUrl('8ca71433-7a38-4c46-bc01-b3388da89214');
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_eventId(): void
+    {
+        $this->assertEquals('8ca71433-7a38-4c46-bc01-b3388da89214', $this->deleteOnlineUrl->getItemId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_permission(): void
+    {
+        $this->assertEquals(Permission::aanbodBewerken(), $this->deleteOnlineUrl->getPermission());
+    }
+}

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -135,6 +135,26 @@ class EventTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_removes_onlineUrl_for_offline_attendanceMode(): void
+    {
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new AttendanceModeUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', AttendanceMode::online()->toString()),
+                new OnlineUrlUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', 'https://www.publiq.be/livestream'),
+            ])
+            ->when(
+                fn (Event $event) => $event->updateAttendanceMode(AttendanceMode::offline())
+            )
+            ->then([
+                new AttendanceModeUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', AttendanceMode::offline()->toString()),
+                new OnlineUrlDeleted('d2b41f1d-598c-46af-a3a5-10e373faa6fe'),
+            ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_update_onlineUrl_on_online_event(): void
     {
         $this->scenario

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -27,6 +27,7 @@ use CultuurNet\UDB3\Event\Events\LabelRemoved;
 use CultuurNet\UDB3\Event\Events\LabelsImported;
 use CultuurNet\UDB3\Event\Events\LocationUpdated;
 use CultuurNet\UDB3\Event\Events\Moderation\Published;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
 use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
 use CultuurNet\UDB3\Event\Events\PriceInfoUpdated;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
@@ -200,6 +201,41 @@ class EventTest extends AggregateRootScenarioTestCase
             ])
             ->when(
                 fn (Event $event) => $event->updateOnlineUrl(new Url('https://www.publiq.be/livestream'))
+            )
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_an_onlineUrl(): void
+    {
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new AttendanceModeUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', AttendanceMode::mixed()->toString()),
+                new OnlineUrlUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', 'https://www.publiq.be/livestream'),
+            ])
+            ->when(
+                fn (Event $event) => $event->deleteOnlineUrl()
+            )
+            ->then([
+                new OnlineUrlDeleted('d2b41f1d-598c-46af-a3a5-10e373faa6fe'),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_deleting_an_empty_onlineUrl(): void
+    {
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new AttendanceModeUpdated('d2b41f1d-598c-46af-a3a5-10e373faa6fe', AttendanceMode::mixed()->toString()),
+            ])
+            ->when(
+                fn (Event $event) => $event->deleteOnlineUrl()
             )
             ->then([]);
     }

--- a/tests/Event/Events/OnlineUrlDeletedTest.php
+++ b/tests/Event/Events/OnlineUrlDeletedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events;
+
+use PHPUnit\Framework\TestCase;
+
+final class OnlineUrlDeletedTest extends TestCase
+{
+    private OnlineUrlDeleted $onlineUrlDeleted;
+
+    protected function setUp(): void
+    {
+        $this->onlineUrlDeleted = new OnlineUrlDeleted('8ca71433-7a38-4c46-bc01-b3388da89214');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deserialize(): void
+    {
+        $this->assertEquals(
+            $this->onlineUrlDeleted,
+            OnlineUrlDeleted::deserialize([
+                'eventId' => '8ca71433-7a38-4c46-bc01-b3388da89214',
+            ])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            [
+                'eventId' => '8ca71433-7a38-4c46-bc01-b3388da89214',
+            ],
+            $this->onlineUrlDeleted->serialize()
+        );
+    }
+}

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -11,6 +11,7 @@ use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Event\Events\AttendanceModeUpdated;
+use CultuurNet\UDB3\Event\Events\OnlineUrlDeleted;
 use CultuurNet\UDB3\Event\Events\OnlineUrlUpdated;
 use CultuurNet\UDB3\Event\Events\ThemeRemoved;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
@@ -1283,6 +1284,35 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
             '@id' => 'http://example.com/entity/' . $eventId,
             '@context' => '/contexts/event',
             'onlineUrl' => 'https://www.publiq.be/livestream',
+            'modified' => $this->recordedOn->toString(),
+        ];
+
+        $this->assertEquals($expectedJson, $body);
+    }
+
+    /**
+     * @test
+     */
+    public function it_projects_onlineUrl_deleted(): void
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $this->project(
+            new OnlineUrlUpdated($eventId, 'https://www.publiq.be/livestream'),
+            $eventId,
+            null,
+            $this->recordedOn->toBroadwayDateTime()
+        );
+        $body = $this->project(
+            new OnlineUrlDeleted($eventId),
+            $eventId,
+            null,
+            $this->recordedOn->toBroadwayDateTime()
+        );
+
+        $expectedJson = (object) [
+            '@id' => 'http://example.com/entity/' . $eventId,
+            '@context' => '/contexts/event',
             'modified' => $this->recordedOn->toString(),
         ];
 

--- a/tests/Http/Event/DeleteOnlineUrlRequestHandlerTest.php
+++ b/tests/Http/Event/DeleteOnlineUrlRequestHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Event;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteOnlineUrlRequestHandlerTest extends TestCase
+{
+    private TraceableCommandBus $commandBus;
+
+    private DeleteOnlineUrlRequestHandler $deleteOnlineUrlRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->commandBus->record();
+
+        $this->deleteOnlineUrlRequestHandler = new DeleteOnlineUrlRequestHandler($this->commandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_delete_onlineUrl(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('eventId', 'c269632a-a887-4f21-8455-1631c31e4df5')
+            ->build('DELETE');
+
+        $response = $this->deleteOnlineUrlRequestHandler->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(
+            [
+                new DeleteOnlineUrl('c269632a-a887-4f21-8455-1631c31e4df5'),
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+}

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\CalendarType;
 use CultuurNet\UDB3\ContactPoint;
 use CultuurNet\UDB3\Description as LegacyDescription;
 use CultuurNet\UDB3\Event\Commands\DeleteCurrentOrganizer;
+use CultuurNet\UDB3\Event\Commands\DeleteOnlineUrl;
 use CultuurNet\UDB3\Event\Commands\DeleteTypicalAgeRange;
 use CultuurNet\UDB3\Event\Commands\ImportImages;
 use CultuurNet\UDB3\Event\Commands\UpdateAttendanceMode;
@@ -186,6 +187,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -267,6 +269,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -385,6 +388,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -459,6 +463,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
                 new UpdateLocation($eventId, new LocationId('5cf42d51-3a4f-46f0-a8af-1cf672be8c84')),
                 new UpdateCalendar($eventId, new Calendar(CalendarType::PERMANENT())),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -786,6 +791,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -856,6 +862,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -972,6 +979,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1041,6 +1049,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1120,6 +1129,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1197,6 +1207,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1273,6 +1284,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1353,6 +1365,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1427,6 +1440,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1505,6 +1519,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1577,6 +1592,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -1855,6 +1871,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -2666,6 +2683,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::online()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -3896,6 +3914,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),
@@ -4223,6 +4242,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint([], ['info@publiq.be'], [])),
@@ -4595,6 +4615,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new UpdateAttendanceMode($eventId, AttendanceMode::offline()),
+                new DeleteOnlineUrl($eventId),
                 new UpdateAudience($eventId, AudienceType::everyone()),
                 new UpdateBookingInfo($eventId, new BookingInfo()),
                 new UpdateContactPoint($eventId, new ContactPoint()),


### PR DESCRIPTION
### Added
- Added `DeleteOnlineUrl` command
- Added `OnlineUrlDeleted` event
- Added `DeleteOnlineUrlHandler` to handle `DeleteOnlineUrl` command
- Added HTTP handler `DeleteOnlineUrlRequestHandler`

### Changed
- Extended `EventLDProjector` with apply method for `OnlineUrlDeleted`
- Extended `Event` aggregate with `deleteOnlineUrl` method
- Handled empty onlineUrl on import as a delete
- Delete `onlineUrl` when setting `attendanceMode` to `offline`

---
Ticket: https://jira.uitdatabank.be/browse/III-4693
