### PR TITLE
III-4648 Polyfill typicalAgeRange for events

### DIFF
--- a/app/Event/EventJSONLDServiceProvider.php
+++ b/app/Event/EventJSONLDServiceProvider.php
@@ -21,6 +21,7 @@ use CultuurNet\UDB3\Event\ReadModel\JSONLD\RelatedEventLDProjector;
 use CultuurNet\UDB3\Event\Recommendations\DBALRecommendationsRepository;
 use CultuurNet\UDB3\Event\Recommendations\RecommendationForEnrichedOfferRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
+use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
@@ -77,7 +78,8 @@ class EventJSONLDServiceProvider implements ServiceProviderInterface
 
                 $repository = new PropertyPolyfillOfferRepository(
                     $repository,
-                    $app[LabelServiceProvider::JSON_READ_REPOSITORY]
+                    $app[LabelServiceProvider::JSON_READ_REPOSITORY],
+                    OfferType::event()
                 );
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);

--- a/app/Place/PlaceJSONLDServiceProvider.php
+++ b/app/Place/PlaceJSONLDServiceProvider.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Cdb\CdbXMLToJsonLDLabelImporter;
 use CultuurNet\UDB3\Cdb\PriceDescriptionParser;
 use CultuurNet\UDB3\Doctrine\ReadModel\CacheDocumentRepository;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
+use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Offer\Popularity\PopularityEnrichedOfferRepository;
 use CultuurNet\UDB3\Offer\Popularity\PopularityRepository;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\CdbXMLItemBaseImporter;
@@ -105,7 +106,8 @@ class PlaceJSONLDServiceProvider implements ServiceProviderInterface
 
                 $repository = new PropertyPolyfillOfferRepository(
                     $repository,
-                    $app[LabelServiceProvider::JSON_READ_REPOSITORY]
+                    $app[LabelServiceProvider::JSON_READ_REPOSITORY],
+                    OfferType::place()
                 );
 
                 $repository = new TermLabelOfferRepositoryDecorator($repository, $app[TermRepository::class]);

--- a/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Event/ReadModel/JSONLD/CdbXMLImporter.php
@@ -248,6 +248,7 @@ class CdbXMLImporter
         $ageTo = $event->getAgeTo();
 
         if (!is_int($ageFrom) && !is_int($ageTo)) {
+            $jsonLD->typicalAgeRange = '-';
             return;
         }
 

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -275,6 +275,8 @@ class EventLDProjector extends OfferLDProjector implements
 
         $jsonLD->attendanceMode = AttendanceMode::offline()->toString();
 
+        $jsonLD->typicalAgeRange = '-';
+
         $defaultAudience = new Audience(AudienceType::everyone());
         $jsonLD->audience = $defaultAudience->serialize();
 

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -669,7 +669,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
 
         $offerLd = $document->getBody();
 
-        unset($offerLd->typicalAgeRange);
+        $offerLd->typicalAgeRange = '-';
 
         return $document->withBody($offerLd);
     }

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -54,6 +54,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 
                 if ($this->offerType->sameAs(OfferType::event())) {
                     $json = $this->polyfillAttendanceMode($json);
+                    $json = $this->polyfillTypicalAgeRange($json);
                 }
 
                 return $this->polyfillBrokenSameAs($json);
@@ -114,6 +115,15 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
     {
         if (!isset($json['bookingAvailability'])) {
             $json['bookingAvailability'] = BookingAvailability::available()->serialize();
+        }
+
+        return $json;
+    }
+
+    private function polyfillTypicalAgeRange(array $json): array
+    {
+        if (!isset($json['typicalAgeRange'])) {
+            $json['typicalAgeRange'] = '-';
         }
 
         return $json;

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Event\ValueObjects\StatusType;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
+use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Offer\ValueObjects\BookingAvailability;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;
 use CultuurNet\UDB3\ReadModel\DocumentRepositoryDecorator;
@@ -19,10 +20,16 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
 {
     private ReadRepositoryInterface $labelReadRepository;
 
-    public function __construct(DocumentRepository $repository, ReadRepositoryInterface $labelReadRepository)
-    {
+    private OfferType $offerType;
+
+    public function __construct(
+        DocumentRepository $repository,
+        ReadRepositoryInterface $labelReadRepository,
+        OfferType $offerType
+    ) {
         parent::__construct($repository);
         $this->labelReadRepository = $labelReadRepository;
+        $this->offerType = $offerType;
     }
 
     public function fetch(string $id, bool $includeMetadata = false): JsonDocument

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -47,11 +47,15 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
             function (array $json) {
                 $json = $this->polyfillMediaObjectId($json);
                 $json = $this->polyfillStatus($json);
-                $json = $this->polyfillAttendanceMode($json);
                 $json = $this->polyfillBookingAvailability($json);
                 $json = $this->polyfillSubEventProperties($json);
                 $json = $this->polyfillEmbeddedPlaceStatus($json);
                 $json = $this->polyfillEmbeddedPlaceBookingAvailability($json);
+
+                if ($this->offerType->sameAs(OfferType::event())) {
+                    $json = $this->polyfillAttendanceMode($json);
+                }
+
                 return $this->polyfillBrokenSameAs($json);
             }
         );

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -51,10 +51,10 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                 $json = $this->polyfillSubEventProperties($json);
                 $json = $this->polyfillEmbeddedPlaceStatus($json);
                 $json = $this->polyfillEmbeddedPlaceBookingAvailability($json);
+                $json = $this->polyfillTypicalAgeRange($json);
 
                 if ($this->offerType->sameAs(OfferType::event())) {
                     $json = $this->polyfillAttendanceMode($json);
-                    $json = $this->polyfillTypicalAgeRange($json);
                 }
 
                 return $this->polyfillBrokenSameAs($json);

--- a/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
+++ b/src/Place/ReadModel/JSONLD/CdbXMLImporter.php
@@ -131,6 +131,8 @@ class CdbXMLImporter
             }
         }
 
+        $jsonLD->typicalAgeRange = '-';
+
         if ($item->getContactInfo()) {
             $this->cdbXmlContactInfoImporter->importBookingInfo(
                 $jsonLD,

--- a/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Event/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -1075,11 +1075,11 @@ class CdbXMLImporterTest extends TestCase
     /**
      * @test
      */
-    public function it_should_import_an_event_without_age_range_when_age_from_and_to_are_not_set()
+    public function it_imports_events_with_all_age_range_by_default()
     {
         $jsonEvent = $this->createJsonEventFromCdbXmlWithAgeRange(null, null);
 
-        $this->assertObjectNotHasAttribute('typicalAgeRange', $jsonEvent);
+        $this->assertObjectHasAttribute('typicalAgeRange', $jsonEvent, '-');
     }
 
     /**
@@ -1115,11 +1115,11 @@ class CdbXMLImporterTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_import_missing_age_from()
+    public function it_always_sets_an_all_age_range()
     {
         $jsonEvent = $this->createJsonEventFromCdbXmlWithoutAgeFrom();
 
-        $this->assertFalse(isset($jsonEvent->typicalAgeRange));
+        $this->assertTrue(isset($jsonEvent->typicalAgeRange));
     }
 
     /**

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -187,6 +187,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'domain' => 'eventtype',
             ],
         ];
+        $jsonLD->typicalAgeRange = '-';
 
         $this->mockPlaceService();
 
@@ -282,6 +283,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'domain' => 'theme',
             ],
         ];
+        $jsonLD->typicalAgeRange = '-';
 
         $this->mockPlaceService();
 
@@ -327,6 +329,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'domain' => 'theme',
             ],
         ];
+        $jsonLD->typicalAgeRange = '-';
         $jsonLD->creator = $expectedCreator;
 
         $this->mockPlaceService();
@@ -638,6 +641,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
                 'domain' => 'theme',
             ],
         ];
+        $jsonLD->typicalAgeRange = '-';
 
         $this->mockPlaceService();
 

--- a/tests/Event/ReadModel/JSONLD/copied_event.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event.json
@@ -26,6 +26,7 @@
   "audience": {
     "audienceType": "everyone"
   },
+  "typicalAgeRange": "-",
   "endDate": "2015-01-29T13:25:21+01:00",
   "subEvent": [
     {

--- a/tests/Event/ReadModel/JSONLD/copied_event_with_place_type.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event_with_place_type.json
@@ -23,6 +23,7 @@
   ],
   "workflowStatus": "DRAFT",
   "attendanceMode": "offline",
+  "typicalAgeRange": "-",
   "audience": {
     "audienceType": "everyone"
   },

--- a/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
+++ b/tests/Event/ReadModel/JSONLD/copied_event_without_working_hours.json
@@ -26,6 +26,7 @@
   "audience": {
     "audienceType": "everyone"
   },
+  "typicalAgeRange": "-",
   "endDate": "2015-01-29T13:25:21+01:00",
   "languages": ["en"],
   "completedLanguages": ["en"],

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\Virtual\AttendanceMode;
+use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\ReadModel\InMemoryDocumentRepository;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\StringLiteral;
@@ -29,7 +30,8 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
 
         $this->repository = new PropertyPolyfillOfferRepository(
             new InMemoryDocumentRepository(),
-            $this->labelReadRepository
+            $this->labelReadRepository,
+            OfferType::event()
         );
     }
 

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -247,22 +247,6 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_polyfill_typicalAgeRange_on_places(): void
-    {
-        $this->repository = new PropertyPolyfillOfferRepository(
-            new InMemoryDocumentRepository(),
-            $this->labelReadRepository,
-            OfferType::place()
-        );
-
-        $this
-            ->given([])
-            ->assertReturnedDocumentDoesNotContainKey('typicalAgeRange');
-    }
-
-    /**
-     * @test
-     */
     public function it_should_polyfill_a_default_booking_availability_if_not_set(): void
     {
         $this

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -186,6 +186,22 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_polyfill_attendanceMode_for_place(): void
+    {
+        $this->repository = new PropertyPolyfillOfferRepository(
+            new InMemoryDocumentRepository(),
+            $this->labelReadRepository,
+            OfferType::place()
+        );
+
+        $this
+            ->given([])
+            ->assertReturnedDocumentDoesNotContainKey('attendanceMode');
+    }
+
+    /**
+     * @test
+     */
     public function it_should_not_change_existing_attendanceMode(): void
     {
         $this

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -216,6 +216,53 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_polyfills_typicalAgeRange(): void
+    {
+        $this
+            ->given([])
+            ->assertReturnedDocumentContains(
+                [
+                    'typicalAgeRange' => '-',
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_change_existing_typicalAgeRange(): void
+    {
+        $this
+            ->given([
+                'typicalAgeRange' => '-12',
+
+            ])
+            ->assertReturnedDocumentContains(
+                [
+                    'typicalAgeRange' => '-12',
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_polyfill_typicalAgeRange_on_places(): void
+    {
+        $this->repository = new PropertyPolyfillOfferRepository(
+            new InMemoryDocumentRepository(),
+            $this->labelReadRepository,
+            OfferType::place()
+        );
+
+        $this
+            ->given([])
+            ->assertReturnedDocumentDoesNotContainKey('typicalAgeRange');
+    }
+
+    /**
+     * @test
+     */
     public function it_should_polyfill_a_default_booking_availability_if_not_set(): void
     {
         $this

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -344,6 +344,7 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $this->documentRepository->save($initialDocument);
 
         $expectedBody = (object)[
+            'typicalAgeRange' => '-',
             'modified' => $this->recordedOn->toString(),
         ];
 

--- a/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
+++ b/tests/Place/ReadModel/JSONLD/CdbXMLImporterTest.php
@@ -119,6 +119,16 @@ class CdbXMLImporterTest extends TestCase
     /**
      * @test
      */
+    public function it_sets_all_ages_as_default()
+    {
+        $jsonPlace = $this->createJsonPlaceFromCdbXml('place_with_long_description.cdbxml.xml');
+
+        $this->assertEquals('-', $jsonPlace->typicalAgeRange);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_mark_a_place_as_ready_for_validation_when_importing_without_a_workflow_status()
     {
         $jsonPlace = $this->createJsonPlaceFromCdbXml('place_with_image.cdbxml.xml');


### PR DESCRIPTION
### Added
- Polyfill `typicalAgeRange` on events and places
- Always project `typicalAgeRange` so when executing a replay the polyfill can be removed

### Changed
- Extend `PropertyPolyfillOfferRepository` with `OfferType`
- Change `XMLImporter` to set all ages by default
- Only polyfill `attendanceMode` on events

---
Ticket: https://jira.uitdatabank.be/browse/III-4648 
