### PR TITLE
III-4701 Fix "undefined index $id" error when creating/updating an event without location.@id and location.id

### DIFF
--- a/src/Http/Event/LegacyEventRequestBodyParser.php
+++ b/src/Http/Event/LegacyEventRequestBodyParser.php
@@ -38,7 +38,9 @@ final class LegacyEventRequestBodyParser implements RequestBodyParser
 
         if (is_object($data) && isset($data->location) && !isset($data->location->{'@id'})) {
             if (is_object($data->location) && isset($data->location->id) && is_string($data->location->id)) {
-                $data->location->{'@id'} = $this->placeIriGenerator->iri($data->location->id);
+                /** @var stdClass $location */
+                $location = $data->location;
+                $location->{'@id'} = $this->placeIriGenerator->iri($location->id);
             }
 
             // Added to handle the angular UI which passes the location as a string.

--- a/src/Http/Event/LegacyEventRequestBodyParser.php
+++ b/src/Http/Event/LegacyEventRequestBodyParser.php
@@ -37,7 +37,7 @@ final class LegacyEventRequestBodyParser implements RequestBodyParser
         $data = $this->parser->parse($request)->getParsedBody();
 
         if (is_object($data) && isset($data->location) && !isset($data->location->{'@id'})) {
-            if (is_object($data->location) && is_string($data->location->id)) {
+            if (is_object($data->location) && isset($data->location->id) && is_string($data->location->id)) {
                 $data->location->{'@id'} = $this->placeIriGenerator->iri($data->location->id);
             }
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -903,6 +903,34 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_crash_on_empty_location_object_but_returns_an_invalid_data_api_problem(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => 'Pannenkoeken voor het goede doel',
+            'type' => [
+                'id' => '0.5.0.0.0',
+            ],
+            'theme' => [
+                'id' => '0.52.0.0.0',
+                'label' => 'Circus',
+            ],
+            'location' => (object) [],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/location',
+                'The required properties (@id) are missing'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_a_new_event_from_legacy_format_and_ignores_address(): void
     {
         $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -902,6 +902,8 @@ final class ImportEventRequestHandlerTest extends TestCase
 
     /**
      * @test
+     * @bugfix
+     * @see https://jira.uitdatabank.be/browse/III-4701
      */
     public function it_does_not_crash_on_empty_location_object_but_returns_an_invalid_data_api_problem(): void
     {


### PR DESCRIPTION
### Fixed

- Fixed "undefined index $id" error when creating/updating an event without `location.@id` and `location.id`

---
Ticket: https://jira.uitdatabank.be/browse/III-4701
