### PR TITLE
III-4705 Fix term validation for imports when no domain is set

### DIFF
--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3140,6 +3140,39 @@ final class ImportEventRequestHandlerTest extends TestCase
 
     /**
      * @test
+     * @bugfix
+     * @see https://jira.uitdatabank.be/browse/III-4705
+     */
+    public function it_throws_if_terms_id_is_not_known_and_no_domain_is_set(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannenkoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.51.12.0.',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/terms/0/id',
+                'The term 1.51.12.0. does not exist or is not supported'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
      */
     public function it_throws_if_terms_id_is_not_known(): void
     {

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -3164,7 +3164,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/terms',
-                'At least 1 array items must match schema'
+                'The term 1 does not exist or is not supported'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -2281,7 +2281,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/terms',
-                'At least 1 array items must match schema'
+                'The term 1 does not exist or is not supported'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -1952,7 +1952,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             ],
             'terms' => [
                 [
-                    'id' => '0.50.1.0.0',
+                    'id' => '0.15.0.0.0',
                 ],
             ],
             'address' => [
@@ -4163,7 +4163,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
             'calendarType' => 'permanent',
             'terms' => [
                 [
-                    'id' => '0.50.1.0.0',
+                    'id' => '0.15.0.0.0',
                 ],
             ],
             'address' => [


### PR DESCRIPTION
### Fixed

- Fixed term validation in imports when no term `domain` is set, while still ignoring the legacy domains to avoid errors when an integrator sends us our own JSON-LD (with some modifications) that might still contain legacy domains

---
Ticket: https://jira.uitdatabank.be/browse/III-4705
