### PR TITLE
III-4709 Make sure ConvertsToApiProblem exceptions do not get logged in Sentry

### DIFF
--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -14,6 +14,7 @@ use CultuurNet\UDB3\EntityNotFoundException;
 use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
 use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
 use CultuurNet\UDB3\Offer\CalendarTypeNotSupported;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
@@ -54,6 +55,7 @@ final class ErrorLogger
         AccessDeniedException::class,
         CalendarTypeNotSupported::class,
         ApiProblem::class,
+        ConvertsToApiProblem::class,
     ];
 
     /**


### PR DESCRIPTION
### Fixed

- `ConvertsToApiProblem` exceptions do not get logged to Sentry anymore, except if the status code of their ApiProblem is not 4XX.
- `ApiProblem` exceptions still do not get logged to Sentry (like before), except if their status code is not 4XX.

---
Ticket: https://jira.uitdatabank.be/browse/III-4709
