### PR TITLE
III-4642 Create `ChangeOwner` command

### DIFF
--- a/app/Console/ChangeOrganizerOwner.php
+++ b/app/Console/ChangeOrganizerOwner.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use CultuurNet\UDB3\Organizer\Commands\ChangeOwner;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ChangeOrganizerOwner extends AbstractCommand
+{
+    public function configure(): void
+    {
+        $this->setName('organizer:change-owner');
+        $this->setDescription('Change the owner of an organizer to a new user id');
+        $this->addArgument('organizerId', InputArgument::REQUIRED, 'Uuid of the organizer');
+        $this->addArgument(
+            'newOwnerId',
+            InputArgument::REQUIRED,
+            'Id of the new user. '
+            . 'Can either be a v1 id (e.g. "97f0f81d-a2b6-44c5-ab27-e076d6329f91") '
+            . 'or a v2 id (e.g. "auth0|2836d202-1955-40f4-aee4-1b2ea493f17c"). '
+            . 'Always use v1 ids for users migrated from UiTID v1!'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $logger = new ConsoleLogger($output);
+
+        $organizerId = $input->getArgument('organizerId');
+        $newOwnerId = $input->getArgument('newOwnerId');
+
+        $this->commandBus->dispatch(
+            new ChangeOwner($organizerId, $newOwnerId)
+        );
+        $logger->info('Successfully changed owner of organizer "' . $organizerId . '" to user with id "' . $newOwnerId . '"');
+
+        return 0;
+    }
+}

--- a/app/Console/ChangeOrganizerOwnerInBulk.php
+++ b/app/Console/ChangeOrganizerOwnerInBulk.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Organizer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerQuery;
+use CultuurNet\UDB3\StringLiteral;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class ChangeOrganizerOwnerInBulk extends AbstractCommand
+{
+    private ResourceOwnerQuery $permissionQuery;
+
+    public function __construct(
+        CommandBus $commandBus,
+        ResourceOwnerQuery $permissionQuery
+    ) {
+        parent::__construct($commandBus);
+        $this->permissionQuery = $permissionQuery;
+    }
+
+    public function configure(): void
+    {
+        $this->setName('organizer:change-owner-bulk');
+        $this->setDescription('Change the owner of multiple organizers to a new user id');
+        $this->addArgument('originalOwnerId', InputArgument::REQUIRED, 'Id of the original owner');
+        $this->addArgument(
+            'newOwnerId',
+            InputArgument::REQUIRED,
+            'Id of the new user. '
+            . 'Can either be a v1 id (e.g. "97f0f81d-a2b6-44c5-ab27-e076d6329f91") '
+            . 'or a v2 id (e.g. "auth0|2836d202-1955-40f4-aee4-1b2ea493f17c"). '
+            . 'Always use v1 ids for users migrated from UiTID v1!'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $logger = new ConsoleLogger($output);
+
+        $originalOwnerId = $input->getArgument('originalOwnerId');
+        $newOwnerId = $input->getArgument('newOwnerId');
+
+        $success = 0;
+        $errors = 0;
+        foreach ($this->permissionQuery->getEditableResourceIds(new StringLiteral($originalOwnerId)) as $editableOrganizers) {
+            $organizerId = $editableOrganizers->toNative();
+            try {
+                $this->commandBus->dispatch(
+                    new ChangeOwner(
+                        $organizerId,
+                        $newOwnerId
+                    )
+                );
+                $logger->info(
+                    'Successfully changed owner of organizer "' . $organizerId . '" to user with id "' . $newOwnerId . '"'
+                );
+                $success++;
+            } catch (Throwable $t) {
+                $logger->error(
+                    sprintf(
+                        'An error occurred while changing owner of organizer "%s": %s with message %s',
+                        $organizerId,
+                        get_class($t),
+                        $t->getMessage()
+                    )
+                );
+                $errors++;
+            }
+        }
+
+        $logger->info('Successfully changed owner of ' . $success . ' organizers to user with id "' . $newOwnerId . '"');
+
+        if ($errors) {
+            $logger->error('Failed to change owner of ' . $errors . ' organizers');
+        }
+
+        return $errors > 0 ? 1 : 0;
+    }
+}

--- a/app/Organizer/OrganizerCommandHandlerProvider.php
+++ b/app/Organizer/OrganizerCommandHandlerProvider.php
@@ -8,6 +8,7 @@ use CultuurNet\UDB3\Event\EventOrganizerRelationService;
 use CultuurNet\UDB3\Label\LabelImportPreProcessor;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddImageHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\AddLabelHandler;
+use CultuurNet\UDB3\Organizer\CommandHandler\ChangeOwnerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteDescriptionHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\DeleteOrganizerHandler;
 use CultuurNet\UDB3\Organizer\CommandHandler\ImportImagesHandler;
@@ -117,6 +118,10 @@ class OrganizerCommandHandlerProvider implements ServiceProviderInterface
 
         $app[ImportImagesHandler::class] = $app->share(
             fn (Application $application) => new ImportImagesHandler($app['organizer_repository'])
+        );
+
+        $app[ChangeOwnerHandler::class] = $app->share(
+            fn (Application $application) => new ChangeOwnerHandler($app['organizer_repository'])
         );
     }
 

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\Silex\ApiName;
 use CultuurNet\UDB3\Silex\ConfigWriter;
 use CultuurNet\UDB3\Silex\Console\ChangeOfferOwner;
 use CultuurNet\UDB3\Silex\Console\ChangeOfferOwnerInBulk;
+use CultuurNet\UDB3\Silex\Console\ChangeOrganizerOwner;
 use CultuurNet\UDB3\Silex\Console\ConsumeCommand;
 use CultuurNet\UDB3\Silex\Console\DispatchMarkedAsDuplicateEventCommand;
 use CultuurNet\UDB3\Silex\Console\EventAncestorsCommand;
@@ -148,6 +149,7 @@ $consoleApp->add(new UpdateOfferStatusCommand(OfferType::place(), $app['event_co
 $consoleApp->add(new UpdateBookingAvailabilityCommand($app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_EVENTS]));
 $consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
 $consoleApp->add(new ChangeOfferOwnerInBulk($app['event_command_bus'], $app['offer_owner_query']));
+$consoleApp->add(new ChangeOrganizerOwner($app['event_command_bus']));
 $consoleApp->add(new UpdateUniqueLabels($app['dbal_connection']));
 $consoleApp->add(new UpdateUniqueOrganizers($app['dbal_connection'], new WebsiteNormalizer()));
 

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Silex\ConfigWriter;
 use CultuurNet\UDB3\Silex\Console\ChangeOfferOwner;
 use CultuurNet\UDB3\Silex\Console\ChangeOfferOwnerInBulk;
 use CultuurNet\UDB3\Silex\Console\ChangeOrganizerOwner;
+use CultuurNet\UDB3\Silex\Console\ChangeOrganizerOwnerInBulk;
 use CultuurNet\UDB3\Silex\Console\ConsumeCommand;
 use CultuurNet\UDB3\Silex\Console\DispatchMarkedAsDuplicateEventCommand;
 use CultuurNet\UDB3\Silex\Console\EventAncestorsCommand;
@@ -150,6 +151,7 @@ $consoleApp->add(new UpdateBookingAvailabilityCommand($app['event_command_bus'],
 $consoleApp->add(new ChangeOfferOwner($app['event_command_bus']));
 $consoleApp->add(new ChangeOfferOwnerInBulk($app['event_command_bus'], $app['offer_owner_query']));
 $consoleApp->add(new ChangeOrganizerOwner($app['event_command_bus']));
+$consoleApp->add(new ChangeOrganizerOwnerInBulk($app['event_command_bus'], $app['organizer_owner.repository']));
 $consoleApp->add(new UpdateUniqueLabels($app['dbal_connection']));
 $consoleApp->add(new UpdateUniqueOrganizers($app['dbal_connection'], new WebsiteNormalizer()));
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -642,6 +642,7 @@ $subscribeCoreCommandHandlers = function (CommandBus $commandBus, Application $a
         $commandBus->subscribe($app[UpdateImageHandler::class]);
         $commandBus->subscribe($app[RemoveImageHandler::class]);
         $commandBus->subscribe($app[ImportImagesHandler::class]);
+        $commandBus->subscribe($app[\CultuurNet\UDB3\Organizer\CommandHandler\ChangeOwnerHandler::class]);
 
         $commandBus->subscribe($app[LabelServiceProvider::COMMAND_HANDLER]);
     };

--- a/src/Organizer/CommandHandler/ChangeOwnerHandler.php
+++ b/src/Organizer/CommandHandler/ChangeOwnerHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use CultuurNet\UDB3\Organizer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class ChangeOwnerHandler implements CommandHandler
+{
+    private OrganizerRepository $organizerRepository;
+
+    public function __construct(OrganizerRepository $organizerRepository)
+    {
+        $this->organizerRepository = $organizerRepository;
+    }
+
+    public function handle($command): void
+    {
+        if (!$command instanceof ChangeOwner) {
+            return;
+        }
+
+        $organizer = $this->organizerRepository->load($command->getItemId());
+
+        $organizer->changeOwner($command->getNewOwnerId());
+
+        $this->organizerRepository->save($organizer);
+    }
+}

--- a/src/Organizer/Commands/ChangeOwner.php
+++ b/src/Organizer/Commands/ChangeOwner.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use CultuurNet\UDB3\Security\AuthorizableCommand;
+
+final class ChangeOwner implements AuthorizableCommand
+{
+    private string $organizerId;
+
+    private string $newOwnerId;
+
+    public function __construct(string $organizerId, string $newOwnerId)
+    {
+        $this->organizerId = $organizerId;
+        $this->newOwnerId = $newOwnerId;
+    }
+
+    public function getItemId(): string
+    {
+        return $this->organizerId;
+    }
+
+    public function getNewOwnerId(): string
+    {
+        return $this->newOwnerId;
+    }
+
+    public function getPermission(): Permission
+    {
+        return Permission::organisatiesBewerken();
+    }
+}

--- a/src/Organizer/Events/OwnerChanged.php
+++ b/src/Organizer/Events/OwnerChanged.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+final class OwnerChanged extends OrganizerEvent
+{
+    private string $newOwnerId;
+
+    public function __construct(string $organizerId, string $newOwnerId)
+    {
+        parent::__construct($organizerId);
+        $this->newOwnerId = $newOwnerId;
+    }
+
+    public function getNewOwnerId(): string
+    {
+        return $this->newOwnerId;
+    }
+
+    public function serialize(): array
+    {
+        return parent::serialize() + [
+            'new_owner_id' => $this->newOwnerId,
+        ];
+    }
+
+    public static function deserialize(array $data): self
+    {
+        return new OwnerChanged(
+            $data['organizer_id'],
+            $data['new_owner_id']
+        );
+    }
+}

--- a/src/Organizer/Organizer.php
+++ b/src/Organizer/Organizer.php
@@ -46,6 +46,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\MainImageUpdated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
@@ -82,6 +83,8 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
     private Labels $labels;
 
     private WorkflowStatus $workflowStatus;
+
+    private string $ownerId = '';
 
     /**
      * @var string[]
@@ -518,6 +521,18 @@ class Organizer extends EventSourcedAggregateRoot implements UpdateableWithCdbXm
                 new OrganizerDeleted($this->getAggregateRootId())
             );
         }
+    }
+
+    public function changeOwner(string $newOwnerId): void
+    {
+        if ($this->ownerId !== $newOwnerId) {
+            $this->apply(new OwnerChanged($this->actorId, $newOwnerId));
+        }
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
+    {
+        $this->ownerId = $ownerChanged->getNewOwnerId();
     }
 
     protected function applyOrganizerCreated(OrganizerCreated $organizerCreated): void

--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -47,6 +47,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerEvent;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\MainImageUpdated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
@@ -68,6 +69,7 @@ class OrganizerLDProjector implements EventListener
      * @uses applyOrganizerImportedFromUDB2
      * @uses applyOrganizerCreated
      * @uses applyOrganizerCreatedWithUniqueWebsite
+     * @uses applyOwnerChanged
      * @uses applyWebsiteUpdated
      * @uses applyTitleUpdated
      * @uses applyTitleTranslated
@@ -255,6 +257,16 @@ class OrganizerLDProjector implements EventListener
         $jsonLD = $this->appendCreator($jsonLD, $domainMessage);
 
         $jsonLD->workflowStatus = WorkflowStatus::ACTIVE()->toString();
+
+        return $document->withBody($jsonLD);
+    }
+
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): JsonDocument
+    {
+        $document = $this->repository->fetch($ownerChanged->getOrganizerId());
+        $jsonLD = $document->getBody();
+
+        $jsonLD->creator = $ownerChanged->getNewOwnerId();
 
         return $document->withBody($jsonLD);
     }

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -20,15 +20,9 @@ class Projector implements EventListener
 {
     use DelegateEventHandlingToSpecificMethodTrait;
 
-    /**
-     * @var CreatedByToUserIdResolverInterface
-     */
-    private $userIdResolver;
+    private CreatedByToUserIdResolverInterface $userIdResolver;
 
-    /**
-     * @var ResourceOwnerRepository
-     */
-    private $permissionRepository;
+    private ResourceOwnerRepository $permissionRepository;
 
     public function __construct(
         ResourceOwnerRepository $permissionRepository,
@@ -40,7 +34,7 @@ class Projector implements EventListener
 
     protected function applyOrganizerImportedFromUDB2(
         OrganizerImportedFromUDB2 $organizerImportedFromUDB2
-    ) {
+    ): void {
         $cdbEvent = ActorItemFactory::createActorFromCdbXml(
             $organizerImportedFromUDB2->getCdbXmlNamespaceUri(),
             $organizerImportedFromUDB2->getCdbXml()
@@ -67,7 +61,7 @@ class Projector implements EventListener
     protected function applyOrganizerCreated(
         OrganizerCreated $organizerCreated,
         DomainMessage $domainMessage
-    ) {
+    ): void  {
         $this->makeOrganizerEditableByUser(
             $organizerCreated->getOrganizerId(),
             $domainMessage
@@ -77,7 +71,7 @@ class Projector implements EventListener
     protected function applyOrganizerCreatedWithUniqueWebsite(
         OrganizerCreatedWithUniqueWebsite $organizerCreatedWithUniqueWebsite,
         DomainMessage $domainMessage
-    ) {
+    ): void  {
         $this->makeOrganizerEditableByUser(
             $organizerCreatedWithUniqueWebsite->getOrganizerId(),
             $domainMessage
@@ -95,7 +89,7 @@ class Projector implements EventListener
     private function makeOrganizerEditableByUser(
         string $organizerId,
         DomainMessage $domainMessage
-    ) {
+    ): void  {
         $metadata = $domainMessage->getMetadata()->serialize();
         $ownerId = new StringLiteral($metadata['user_id']);
 

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -9,6 +9,7 @@ use Broadway\EventHandling\EventListener;
 use CultuurNet\UDB3\Cdb\ActorItemFactory;
 use CultuurNet\UDB3\Cdb\CreatedByToUserIdResolverInterface;
 use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
@@ -83,6 +84,13 @@ class Projector implements EventListener
         );
     }
 
+    protected function applyOwnerChanged(OwnerChanged $ownerChanged): void
+    {
+        $this->permissionRepository->markResourceEditableByNewUser(
+            new StringLiteral($ownerChanged->getOrganizerId()),
+            new StringLiteral($ownerChanged->getNewOwnerId())
+        );
+    }
 
     private function makeOrganizerEditableByUser(
         string $organizerId,

--- a/src/Organizer/ReadModel/Permission/Projector.php
+++ b/src/Organizer/ReadModel/Permission/Projector.php
@@ -61,7 +61,7 @@ class Projector implements EventListener
     protected function applyOrganizerCreated(
         OrganizerCreated $organizerCreated,
         DomainMessage $domainMessage
-    ): void  {
+    ): void {
         $this->makeOrganizerEditableByUser(
             $organizerCreated->getOrganizerId(),
             $domainMessage
@@ -71,7 +71,7 @@ class Projector implements EventListener
     protected function applyOrganizerCreatedWithUniqueWebsite(
         OrganizerCreatedWithUniqueWebsite $organizerCreatedWithUniqueWebsite,
         DomainMessage $domainMessage
-    ): void  {
+    ): void {
         $this->makeOrganizerEditableByUser(
             $organizerCreatedWithUniqueWebsite->getOrganizerId(),
             $domainMessage
@@ -89,7 +89,7 @@ class Projector implements EventListener
     private function makeOrganizerEditableByUser(
         string $organizerId,
         DomainMessage $domainMessage
-    ): void  {
+    ): void {
         $metadata = $domainMessage->getMetadata()->serialize();
         $ownerId = new StringLiteral($metadata['user_id']);
 

--- a/tests/Organizer/CommandHandler/ChangeOwnerHandlerTest.php
+++ b/tests/Organizer/CommandHandler/ChangeOwnerHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\CommandHandler;
+
+use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
+use Broadway\EventHandling\EventBus;
+use Broadway\EventStore\EventStore;
+use CultuurNet\UDB3\Organizer\Commands\ChangeOwner;
+use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
+use CultuurNet\UDB3\Organizer\OrganizerRepository;
+
+final class ChangeOwnerHandlerTest extends CommandHandlerScenarioTestCase
+{
+    protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler
+    {
+        return new ChangeOwnerHandler(new OrganizerRepository($eventStore, $eventBus));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_setting_a_new_owner(): void
+    {
+        $this->scenario
+            ->withAggregateId('5c5a7abd-04ab-4575-8eab-befc2d8be064')
+            ->given([
+                $this->organizerCreatedWithUniqueWebsite(),
+            ])
+            ->when(
+                new ChangeOwner(
+                    '5c5a7abd-04ab-4575-8eab-befc2d8be064',
+                    'f7ea40a7-4758-4798-a059-65740ab53bcb',
+                ),
+            )
+            ->then([
+                new OwnerChanged(
+                    '5c5a7abd-04ab-4575-8eab-befc2d8be064',
+                    'f7ea40a7-4758-4798-a059-65740ab53bcb'
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_the_same_owner(): void
+    {
+        $this->scenario
+            ->withAggregateId('5c5a7abd-04ab-4575-8eab-befc2d8be064')
+            ->given([
+                $this->organizerCreatedWithUniqueWebsite(),
+                new OwnerChanged(
+                    '5c5a7abd-04ab-4575-8eab-befc2d8be064',
+                    'f7ea40a7-4758-4798-a059-65740ab53bcb'
+                ),
+            ])
+            ->when(
+                new ChangeOwner(
+                    '5c5a7abd-04ab-4575-8eab-befc2d8be064',
+                    'f7ea40a7-4758-4798-a059-65740ab53bcb',
+                ),
+            )
+            ->then([]);
+    }
+
+    private function organizerCreatedWithUniqueWebsite(): OrganizerCreatedWithUniqueWebsite
+    {
+        return new OrganizerCreatedWithUniqueWebsite(
+            '5c5a7abd-04ab-4575-8eab-befc2d8be064',
+            'nl',
+            'https://www.publiq.be',
+            'publiq'
+        );
+    }
+}

--- a/tests/Organizer/Commands/ChangeOwnerTest.php
+++ b/tests/Organizer/Commands/ChangeOwnerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Commands;
+
+use CultuurNet\UDB3\Role\ValueObjects\Permission;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeOwnerTest extends TestCase
+{
+    private ChangeOwner $changeOwner;
+
+    protected function setUp(): void
+    {
+        $this->changeOwner = new ChangeOwner(
+            'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+            '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_item_id(): void
+    {
+        $this->assertEquals(
+            'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+            $this->changeOwner->getItemId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_new_owner_id(): void
+    {
+        $this->assertEquals(
+            '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3',
+            $this->changeOwner->getNewOwnerId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_permission(): void
+    {
+        $this->assertEquals(
+            Permission::organisatiesBewerken(),
+            $this->changeOwner->getPermission()
+        );
+    }
+}

--- a/tests/Organizer/Events/OwnerChangedTest.php
+++ b/tests/Organizer/Events/OwnerChangedTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\Events;
+
+use PHPUnit\Framework\TestCase;
+
+final class OwnerChangedTest extends TestCase
+{
+    private OwnerChanged $ownerChanged;
+
+    protected function setUp(): void
+    {
+        $this->ownerChanged = new OwnerChanged(
+            'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+            '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_organizer_id(): void
+    {
+        $this->assertEquals(
+            'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+            $this->ownerChanged->getOrganizerId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_an_owner_id(): void
+    {
+        $this->assertEquals(
+            '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3',
+            $this->ownerChanged->getNewOwnerId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            [
+                'organizer_id' => 'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+                'new_owner_id' => '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3',
+            ],
+            $this->ownerChanged->serialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deserialize(): void
+    {
+        $this->assertEquals(
+            $this->ownerChanged,
+            OwnerChanged::deserialize(
+                [
+                    'organizer_id' => 'ab56df51-7b9d-468b-8aaa-a275a31098f7',
+                    'new_owner_id' => '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3',
+                ]
+            )
+        );
+    }
+}

--- a/tests/Organizer/OrganizerLDProjectorTest.php
+++ b/tests/Organizer/OrganizerLDProjectorTest.php
@@ -44,6 +44,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerCreatedWithUniqueWebsite;
 use CultuurNet\UDB3\Organizer\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
@@ -254,6 +255,24 @@ final class OrganizerLDProjectorTest extends TestCase
                 $this->recordedOn->toBroadwayDateTime()
             )
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_owner_changed(): void
+    {
+        $organizerId = '586f596d-7e43-4ab9-b062-04db9436fca4';
+
+        $this->mockGet($organizerId, 'organizer.json');
+
+        $domainMessage = $this->createDomainMessage(
+            new OwnerChanged($organizerId, '9906d685-9557-4422-a3a9-44aec6e2a23f')
+        );
+
+        $this->expectSave($organizerId, 'organizer_with_changed_owner.json');
+
+        $this->projector->handle($domainMessage);
     }
 
     /**

--- a/tests/Organizer/OrganizerTest.php
+++ b/tests/Organizer/OrganizerTest.php
@@ -44,6 +44,7 @@ use CultuurNet\UDB3\Organizer\Events\OrganizerDeleted;
 use CultuurNet\UDB3\Organizer\Events\OrganizerImportedFromUDB2;
 use CultuurNet\UDB3\Organizer\Events\MainImageUpdated;
 use CultuurNet\UDB3\Organizer\Events\OrganizerUpdatedFromUDB2;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
 use CultuurNet\UDB3\Organizer\Events\TitleTranslated;
 use CultuurNet\UDB3\Organizer\Events\TitleUpdated;
 use CultuurNet\UDB3\Organizer\Events\WebsiteUpdated;
@@ -1409,6 +1410,29 @@ class OrganizerTest extends AggregateRootScenarioTestCase
             ->then(
                 [
                     new OrganizerDeleted($this->id),
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_change_the_owner(): void
+    {
+        $this->scenario
+            ->given(
+                [
+                    $this->organizerCreatedWithUniqueWebsite,
+                ]
+            )
+            ->when(
+                function (Organizer $organizer) {
+                    $organizer->changeOwner('5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3');
+                }
+            )
+            ->then(
+                [
+                    new OwnerChanged($this->id, '5314f3fd-69fd-4650-8c87-0e7b0b5c0dd3'),
                 ]
             );
     }

--- a/tests/Organizer/ReadModel/Permission/ProjectorTest.php
+++ b/tests/Organizer/ReadModel/Permission/ProjectorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer\ReadModel\Permission;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Cdb\CreatedByToUserIdResolverInterface;
+use CultuurNet\UDB3\Organizer\Events\OwnerChanged;
+use CultuurNet\UDB3\Security\ResourceOwner\ResourceOwnerRepository;
+use CultuurNet\UDB3\StringLiteral;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectorTest extends TestCase
+{
+    /**
+     * @var ResourceOwnerRepository|MockObject
+     */
+    private $repository;
+
+    /**
+     * @var CreatedByToUserIdResolverInterface|MockObject
+     */
+    private $userIdResolver;
+
+    private Projector $projector;
+
+    public function setUp(): void
+    {
+        $this->repository = $this->createMock(ResourceOwnerRepository::class);
+        $this->userIdResolver = $this->createMock(CreatedByToUserIdResolverInterface::class);
+
+        $this->projector = new Projector(
+            $this->repository,
+            $this->userIdResolver
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_owner_changed(): void
+    {
+        $organizerId = '9a18a42f-d80d-4784-8c34-8b8b36dd6080';
+        $newOwnerId = '20656964-10cd-4ca7-85f2-997137479900';
+        $ownerChanged = new OwnerChanged($organizerId, $newOwnerId);
+
+        $domainMessage = DomainMessage::recordNow(
+            $organizerId,
+            1,
+            new Metadata(['user_id' => '00000000-0000-0000-0000-000000000000']),
+            $ownerChanged
+        );
+
+        $this->repository->expects($this->once())
+            ->method('markResourceEditableByNewUser')
+            ->with(
+                new StringLiteral($organizerId),
+                new StringLiteral($newOwnerId)
+            );
+
+        $this->projector->handle($domainMessage);
+    }
+}

--- a/tests/Organizer/Samples/organizer_with_changed_owner.json
+++ b/tests/Organizer/Samples/organizer_with_changed_owner.json
@@ -1,0 +1,23 @@
+{
+  "@id": "http:\/\/udb-silex.dev\/organizer\/586f596d-7e43-4ab9-b062-04db9436fca4",
+  "@context": "\/api\/1.0\/organizer.jsonld",
+  "name": {
+    "nl": "TestOrganisatie"
+  },
+  "address": {
+    "nl": {
+      "addressCountry": "BE",
+      "addressLocality": "Kessel-Lo (Leuven)",
+      "postalCode": "3010",
+      "streetAddress": "Straat"
+    }
+  },
+  "phone": [],
+  "email": [],
+  "url": [],
+  "created": "2016-09-28T10:01:28+00:00",
+  "creator": "9906d685-9557-4422-a3a9-44aec6e2a23f",
+  "languages": ["nl"],
+  "completedLanguages": ["nl"],
+  "modified": "2018-01-18T13:57:09+00:00"
+}


### PR DESCRIPTION
### Added
- Created `ChangeOwner` command
- Created `OwnerChanged` event
- Added method `changeOwner` on `Organizer` aggregate
- Added `ChangeOwnerHandler` to handle the `ChangeOwner` command
- Added `ChangeOrganizerOwner` command to change owner of a single organizer
- Added `ChangeOrganizerOwnerInBulk` command to change the owner of all organizers belonging to a certain owner

### Changed
- Extended `OrganizerLDProjector` to handle `OwnerChanged`
- Extended Resource owner projector to handle `OwnerChanged` event

---
Ticket: https://jira.uitdatabank.be/browse/III-4642
