### PR TITLE
III-4715 Change log level to warning when no address available

### DIFF
--- a/src/Geocoding/DefaultGeocodingService.php
+++ b/src/Geocoding/DefaultGeocodingService.php
@@ -14,15 +14,9 @@ use Psr\Log\LoggerInterface;
 
 class DefaultGeocodingService implements GeocodingService
 {
-    /**
-     * @var Geocoder
-     */
-    private $geocoder;
+    private Geocoder $geocoder;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(
         Geocoder $geocoder,
@@ -32,10 +26,7 @@ class DefaultGeocodingService implements GeocodingService
         $this->logger = $logger;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function getCoordinates($address)
+    public function getCoordinates($address): ?Coordinates
     {
         try {
             $addresses = $this->geocoder->geocode($address);

--- a/src/Geocoding/DefaultGeocodingService.php
+++ b/src/Geocoding/DefaultGeocodingService.php
@@ -42,7 +42,7 @@ class DefaultGeocodingService implements GeocodingService
                 new Longitude($coordinates->getLongitude())
             );
         } catch (Exception|CollectionIsEmpty $exception) {
-            $this->logger->error(
+            $this->logger->warning(
                 'No results for address: "' . $address . '". Exception message: ' . $exception->getMessage()
             );
             return null;

--- a/src/Geocoding/GeocodingService.php
+++ b/src/Geocoding/GeocodingService.php
@@ -12,9 +12,6 @@ interface GeocodingService
      * Gets the coordinates of the given address.
      * Returns null when no coordinates are found for the given address.
      * This can happen in case of a wrong/unknown address.
-     *
-     * @param string $address
-     * @return Coordinates|null
      */
-    public function getCoordinates($address);
+    public function getCoordinates(string $address): ?Coordinates;
 }

--- a/tests/Geocoding/DefaultGeocodingServiceTest.php
+++ b/tests/Geocoding/DefaultGeocodingServiceTest.php
@@ -87,7 +87,7 @@ class DefaultGeocodingServiceTest extends TestCase
             );
 
         $this->logger->expects($this->once())
-            ->method('error')
+            ->method('warning')
             ->with('No results for address: "' . $address . '". Exception message: Could not execute query');
 
         $actualCoordinates = $this->service->getCoordinates($address);


### PR DESCRIPTION
### Changed
- Changed log level to `warning` instead of `error` when no address is available, this will prevent this from being logged in Sentry.

---
Ticket: https://jira.uitdatabank.be/browse/III-4715
