### PR TITLE
III-3925 Convert file errors to ApiProblem

### DIFF
--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -15,8 +15,6 @@ use CultuurNet\UDB3\Event\Productions\EventCannotBeAddedToProduction;
 use CultuurNet\UDB3\Event\Productions\EventCannotBeRemovedFromProduction;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
-use CultuurNet\UDB3\Media\Exceptions\ImageSizeError;
-use CultuurNet\UDB3\Media\Exceptions\ImageUploadError;
 use CultuurNet\UDB3\Media\MediaObjectNotFoundException;
 use CultuurNet\UDB3\Offer\CalendarTypeNotSupported;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;

--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -56,8 +56,6 @@ final class ErrorLogger
         AccessDeniedHttpException::class,
         AccessDeniedException::class,
         CalendarTypeNotSupported::class,
-        ImageUploadError::class,
-        ImageSizeError::class,
     ];
 
     /**

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -385,4 +385,34 @@ final class ApiProblem extends Exception
             $detail . ' For more information check the documentation of the update attendance mode endpoint. See: ' . Stoplight::ATTENDANCE_MODE_UPDATE
         );
     }
+
+    public static function fileMissing($detail): self
+    {
+        return self::create(
+            'https://api.publiq.be/probs/body/file-missing',
+            'File missing',
+            400,
+            $detail
+        );
+    }
+
+    public static function fileInvalidType($detail): self
+    {
+        return self::create(
+            'https://api.publiq.be/probs/body/file-invalid-type',
+            'Invalid file type',
+            400,
+            $detail
+        );
+    }
+
+    public static function fileInvalidSize($detail): self
+    {
+        return self::create(
+            'https://api.publiq.be/probs/body/file-invalid-size',
+            'Invalid file size',
+            400,
+            $detail
+        );
+    }
 }

--- a/src/Http/Media/EditMediaRestController.php
+++ b/src/Http/Media/EditMediaRestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Media;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
@@ -26,7 +27,7 @@ class EditMediaRestController
     public function upload(Request $request): JsonResponse
     {
         if (!$request->files->has('file')) {
-            return new JsonResponse(['error' => 'file required'], 400);
+            throw ApiProblem::fileMissing('The file property is required');
         }
 
         $description = $request->request->get('description');

--- a/src/Media/Exceptions/ImageSizeError.php
+++ b/src/Media/Exceptions/ImageSizeError.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media\Exceptions;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use Exception;
 
-final class ImageSizeError extends Exception
+final class ImageSizeError extends Exception implements ConvertsToApiProblem
 {
+    public function toApiProblem(): ApiProblem
+    {
+        throw ApiProblem::fileInvalidSize($this->getMessage());
+    }
 }

--- a/src/Media/Exceptions/ImageUploadError.php
+++ b/src/Media/Exceptions/ImageUploadError.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media\Exceptions;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use Exception;
 
-final class ImageUploadError extends Exception
+final class ImageUploadError extends Exception implements ConvertsToApiProblem
 {
+    public function toApiProblem(): ApiProblem
+    {
+        throw ApiProblem::fileInvalidType($this->getMessage());
+    }
 }

--- a/src/Media/Exceptions/InvalidFileSize.php
+++ b/src/Media/Exceptions/InvalidFileSize.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use Exception;
 
-final class ImageSizeError extends Exception implements ConvertsToApiProblem
+final class InvalidFileSize extends Exception implements ConvertsToApiProblem
 {
     public function toApiProblem(): ApiProblem
     {

--- a/src/Media/Exceptions/InvalidFileType.php
+++ b/src/Media/Exceptions/InvalidFileType.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use Exception;
 
-final class ImageUploadError extends Exception implements ConvertsToApiProblem
+final class InvalidFileType extends Exception implements ConvertsToApiProblem
 {
     public function toApiProblem(): ApiProblem
     {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -41,7 +41,7 @@ class ImageUploaderService implements ImageUploaderInterface
         int $maxFileSize = null
     ) {
         if ($maxFileSize < 0) {
-            throw new ImageSizeError('Max file size should be 0 or bigger.');
+            throw new \InvalidArgumentException('Max file size should be 0 or bigger inside config.yml.');
         }
 
         $this->uuidGenerator = $uuidGenerator;

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -9,7 +9,7 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Commands\UploadImage;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
-use CultuurNet\UDB3\Media\Exceptions\ImageUploadError;
+use CultuurNet\UDB3\Media\Exceptions\InvalidFileType;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -58,13 +58,13 @@ class ImageUploaderService implements ImageUploaderInterface
         Language $language
     ): UUID {
         if (!$file->isValid()) {
-            throw new ImageUploadError('The file did not upload correctly.');
+            throw new InvalidFileType('The file did not upload correctly.');
         }
 
         $mimeTypeString = $file->getMimeType();
 
         if (!$mimeTypeString) {
-            throw new ImageUploadError('The type of the uploaded file can not be guessed.');
+            throw new InvalidFileType('The type of the uploaded file can not be guessed.');
         }
 
         $this->guardFileSizeLimit($file);
@@ -72,7 +72,7 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileTypeParts = explode('/', $mimeTypeString);
         $fileType = array_shift($fileTypeParts);
         if ($fileType !== 'image') {
-            throw new ImageUploadError('The uploaded file has type "' . $fileType . '" instead of "image".');
+            throw new InvalidFileType('The uploaded file has type "' . $fileType . '" instead of "image".');
         }
 
         /** @var MIMEType $mimeType */

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -41,7 +41,7 @@ class ImageUploaderService implements ImageUploaderInterface
         int $maxFileSize = null
     ) {
         if ($maxFileSize < 0) {
-            throw new \InvalidArgumentException('Max file size should be 0 or bigger inside config.yml.');
+            throw new \RuntimeException('Max file size should be 0 or bigger inside config.yml.');
         }
 
         $this->uuidGenerator = $uuidGenerator;

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -33,6 +33,12 @@ class ImageUploaderService implements ImageUploaderInterface
      */
     private ?int $maxFileSize;
 
+    private array $supportedMimeTypes = [
+        'image/png',
+        'image/jpg',
+        'image/gif',
+    ];
+
     public function __construct(
         UuidGeneratorInterface $uuidGenerator,
         CommandBus $commandBus,
@@ -69,10 +75,10 @@ class ImageUploaderService implements ImageUploaderInterface
 
         $this->guardFileSizeLimit($file);
 
-        $fileTypeParts = explode('/', $mimeTypeString);
-        $fileType = array_shift($fileTypeParts);
-        if ($fileType !== 'image') {
-            throw new InvalidFileType('The uploaded file has type "' . $fileType . '" instead of "image".');
+        if (!\in_array($mimeTypeString, $this->supportedMimeTypes, true)){
+            throw new InvalidFileType(
+                'The uploaded file has mime type "' . $mimeTypeString . '" instead of ' . \implode(',', $this->supportedMimeTypes)
+            );
         }
 
         /** @var MIMEType $mimeType */

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -35,7 +35,7 @@ class ImageUploaderService implements ImageUploaderInterface
 
     private array $supportedMimeTypes = [
         'image/png',
-        'image/jpg',
+        'image/jpeg',
         'image/gif',
     ];
 
@@ -75,7 +75,7 @@ class ImageUploaderService implements ImageUploaderInterface
 
         $this->guardFileSizeLimit($file);
 
-        if (!\in_array($mimeTypeString, $this->supportedMimeTypes, true)){
+        if (!\in_array($mimeTypeString, $this->supportedMimeTypes, true)) {
             throw new InvalidFileType(
                 'The uploaded file has mime type "' . $mimeTypeString . '" instead of ' . \implode(',', $this->supportedMimeTypes)
             );

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -105,7 +105,7 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileSize = filesize($filePath);
 
         if ($this->maxFileSize && !$fileSize) {
-            throw new InvalidFileSize('There is a maximum size and we could not determine the size of the uploaded image.');
+            throw new \RuntimeException('The size of the uploaded image could not be determined.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\CommandBus;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Commands\UploadImage;
-use CultuurNet\UDB3\Media\Exceptions\ImageSizeError;
+use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
 use CultuurNet\UDB3\Media\Exceptions\ImageUploadError;
 use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
@@ -105,11 +105,11 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileSize = filesize($filePath);
 
         if ($this->maxFileSize && !$fileSize) {
-            throw new ImageSizeError('There is a maximum size and we could not determine the size of the uploaded image.');
+            throw new InvalidFileSize('There is a maximum size and we could not determine the size of the uploaded image.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {
-            throw new ImageSizeError(
+            throw new InvalidFileSize(
                 'The file size of the uploaded image is too big. File size (bytes): ' . $fileSize . ' Max size (bytes):' . $this->maxFileSize
             );
         }

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -72,7 +72,7 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileTypeParts = explode('/', $mimeTypeString);
         $fileType = array_shift($fileTypeParts);
         if ($fileType !== 'image') {
-            throw new ImageUploadError('The uploaded file is not an image.');
+            throw new ImageUploadError('The uploaded file has type "' . $fileType . '" instead of "image".');
         }
 
         /** @var MIMEType $mimeType */
@@ -110,7 +110,7 @@ class ImageUploaderService implements ImageUploaderInterface
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {
             throw new ImageSizeError(
-                'The file size of the uploaded image is too big.'
+                'The file size of the uploaded image is too big. File size (bytes): ' . $fileSize . ' Max size (bytes):' . $this->maxFileSize
             );
         }
     }

--- a/tests/Http/Media/EditMediaRestControllerTest.php
+++ b/tests/Http/Media/EditMediaRestControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Media;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
@@ -91,18 +92,27 @@ class EditMediaRestControllerTest extends TestCase
                 ),
                 'response' => new JsonResponse(['error' => 'copyright holder required'], 400),
             ],
-            'file' => [
-                'request' => new Request(
-                    [],
-                    [
-                        'copyrightHolder' => ' Dwight Hooker',
-                        'description' => 'Lenna',
-                        'language' => 'nl',
-                    ]
-                ),
-                'response' => new JsonResponse(['error' => 'file required'], 400),
-            ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_throw_file_missing_api_problem_on_empty_file(): void
+    {
+        $this->expectException(ApiProblem::class);
+        $this->expectExceptionMessage('File missing');
+
+        $this->controller->upload(
+            new Request(
+                [],
+                [
+                    'copyrightHolder' => ' Dwight Hooker',
+                    'description' => 'Lenna',
+                    'language' => 'nl',
+                ]
+            )
+        );
     }
 
     /**

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -79,7 +79,7 @@ class ImageUploaderServiceTest extends TestCase
             ->willReturn('video/avi');
 
         $this->expectException(ImageUploadError::class);
-        $this->expectExceptionMessage('The uploaded file is not an image.');
+        $this->expectExceptionMessage('The uploaded file has type "video" instead of "image".');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);
     }

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Media;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\Media\Exceptions\ImageSizeError;
+use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
 use CultuurNet\UDB3\Media\Exceptions\ImageUploadError;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
@@ -190,7 +190,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(ImageSizeError::class);
+        $this->expectException(InvalidFileSize::class);
         $this->expectExceptionMessage('The file size of the uploaded image is too big.');
 
         $uploader->upload($file, $description, $copyrightHolder, $language);
@@ -215,7 +215,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(ImageSizeError::class);
+        $this->expectException(InvalidFileSize::class);
         $this->expectExceptionMessage('There is a maximum size and we could not determine the size of the uploaded image.');
 
         $uploader->upload($file, $description, $copyrightHolder, $language);

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -79,7 +79,7 @@ class ImageUploaderServiceTest extends TestCase
             ->willReturn('video/avi');
 
         $this->expectException(InvalidFileType::class);
-        $this->expectExceptionMessage('The uploaded file has mime type "video/avi" instead of image/png,image/jpg,image/gif');
+        $this->expectExceptionMessage('The uploaded file has mime type "video/avi" instead of image/png,image/jpeg,image/gif');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);
     }
@@ -240,7 +240,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $expectedDestination = $this->directory . '/' . $this->fileId->toString() . '.jpg';
+        $expectedDestination = $this->directory . '/' . $this->fileId->toString() . '.jpeg';
 
         $generatedUuid = 'de305d54-75b4-431b-adb2-eb6b9e546014';
         $this->uuidGenerator
@@ -305,12 +305,12 @@ class ImageUploaderServiceTest extends TestCase
         $image
             ->expects($this->once())
             ->method('getMimeType')
-            ->willReturn('image/jpg');
+            ->willReturn('image/jpeg');
 
         $image
             ->expects($this->any())
             ->method('guessExtension')
-            ->willReturn('jpg');
+            ->willReturn('jpeg');
 
         return $image;
     }

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\CommandBus;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\Exceptions\InvalidFileSize;
-use CultuurNet\UDB3\Media\Exceptions\ImageUploadError;
+use CultuurNet\UDB3\Media\Exceptions\InvalidFileType;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use League\Flysystem\FilesystemOperator;
@@ -78,7 +78,7 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getMimeType')
             ->willReturn('video/avi');
 
-        $this->expectException(ImageUploadError::class);
+        $this->expectException(InvalidFileType::class);
         $this->expectExceptionMessage('The uploaded file has type "video" instead of "image".');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);
@@ -138,7 +138,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(ImageUploadError::class);
+        $this->expectException(InvalidFileType::class);
         $this->expectExceptionMessage('The file did not upload correctly.');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);
@@ -165,7 +165,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(ImageUploadError::class);
+        $this->expectException(InvalidFileType::class);
         $this->expectExceptionMessage('The type of the uploaded file can not be guessed.');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media;
 
-use _HumbugBox113887eee2b6\RuntimeException;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
@@ -216,7 +215,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The size of the uploaded image could not be determined.');
 
         $uploader->upload($file, $description, $copyrightHolder, $language);

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Media;
 
+use _HumbugBox113887eee2b6\RuntimeException;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\UuidGenerator\UuidGeneratorInterface;
 use CultuurNet\UDB3\Language;
@@ -215,8 +216,8 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(InvalidFileSize::class);
-        $this->expectExceptionMessage('There is a maximum size and we could not determine the size of the uploaded image.');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The size of the uploaded image could not be determined.');
 
         $uploader->upload($file, $description, $copyrightHolder, $language);
     }

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -79,7 +79,7 @@ class ImageUploaderServiceTest extends TestCase
             ->willReturn('video/avi');
 
         $this->expectException(InvalidFileType::class);
-        $this->expectExceptionMessage('The uploaded file has type "video" instead of "image".');
+        $this->expectExceptionMessage('The uploaded file has mime type "video/avi" instead of image/png,image/jpg,image/gif');
 
         $this->uploader->upload($file, $description, $copyrightHolder, $language);
     }


### PR DESCRIPTION
### Changed
- Converted `ImageSizeError` to `ApiProblem::fileInvalidSize`
- Converted `ImageUploadError` to `ApiProblem::fileInvalidType`

---
Ticket: https://jira.uitdatabank.be/browse/III-3925
