### PR TITLE
III-4751 Allow copyright property to be empty when serializing ImageUpdated

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -531,9 +531,9 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     ): ImageUpdated {
         return new ImageUpdated(
             $this->eventId,
-            $mediaObjectId,
-            $description,
-            $copyrightHolder,
+            $mediaObjectId->toString(),
+            $description->toNative(),
+            $copyrightHolder->toString(),
             $language
         );
     }

--- a/src/Offer/Events/AbstractEvent.php
+++ b/src/Offer/Events/AbstractEvent.php
@@ -8,10 +8,7 @@ use Broadway\Serializer\Serializable;
 
 abstract class AbstractEvent implements Serializable
 {
-    /**
-     * @var string
-     */
-    protected $itemId;
+    protected string $itemId;
 
     public function __construct(string $itemId)
     {

--- a/src/Offer/Events/Image/AbstractImageUpdated.php
+++ b/src/Offer/Events/Image/AbstractImageUpdated.php
@@ -4,24 +4,15 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Events\Image;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\Offer\Events\AbstractEvent;
-use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractImageUpdated extends AbstractEvent
 {
-    protected UUID $mediaObjectId;
+    private string $mediaObjectId;
 
-    /**
-     * @var StringLiteral
-     */
-    protected $description;
+    private string $description;
 
-    /**
-     * @var CopyrightHolder
-     */
-    protected $copyrightHolder;
+    private string $copyrightHolder;
 
     /**
      * Nullable because this was missing in the past, so we don't have historical data for this.
@@ -32,9 +23,9 @@ abstract class AbstractImageUpdated extends AbstractEvent
 
     final public function __construct(
         string $itemId,
-        UUID $mediaObjectId,
-        StringLiteral $description,
-        CopyrightHolder $copyrightHolder,
+        string $mediaObjectId,
+        string $description,
+        string $copyrightHolder,
         ?string $language = null
     ) {
         parent::__construct($itemId);
@@ -44,17 +35,17 @@ abstract class AbstractImageUpdated extends AbstractEvent
         $this->language = $language;
     }
 
-    public function getMediaObjectId(): UUID
+    public function getMediaObjectId(): string
     {
         return $this->mediaObjectId;
     }
 
-    public function getDescription(): StringLiteral
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    public function getCopyrightHolder(): CopyrightHolder
+    public function getCopyrightHolder(): string
     {
         return $this->copyrightHolder;
     }
@@ -67,9 +58,9 @@ abstract class AbstractImageUpdated extends AbstractEvent
     public function serialize(): array
     {
         $data = parent::serialize() +  [
-            'media_object_id' => $this->mediaObjectId->toString(),
-            'description' => (string) $this->description,
-            'copyright_holder' => $this->copyrightHolder->toString(),
+            'media_object_id' => $this->mediaObjectId,
+            'description' => $this->description,
+            'copyright_holder' => $this->copyrightHolder,
         ];
         if ($this->language) {
             $data['language'] = $this->language;
@@ -81,9 +72,9 @@ abstract class AbstractImageUpdated extends AbstractEvent
     {
         return new static(
             $data['item_id'],
-            new UUID($data['media_object_id']),
-            new StringLiteral($data['description']),
-            new CopyrightHolder($data['copyright_holder']),
+            $data['media_object_id'],
+            $data['description'],
+            $data['copyright_holder'],
             $data['language'] ?? null
         );
     }

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -942,13 +942,13 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     protected function applyImageUpdated(AbstractImageUpdated $imageUpdated): void
     {
-        $image = $this->images->findImageByUUID($imageUpdated->getMediaObjectId());
+        $image = $this->images->findImageByUUID(new UUID($imageUpdated->getMediaObjectId()));
 
         $updatedImage = new Image(
             $image->getMediaObjectId(),
             $image->getMimeType(),
-            new ImageDescription($imageUpdated->getDescription()->toNative()),
-            $imageUpdated->getCopyrightHolder(),
+            new ImageDescription($imageUpdated->getDescription()),
+            new CopyrightHolder($imageUpdated->getCopyrightHolder()),
             $image->getSourceLocation(),
             $image->getLanguage()
         );

--- a/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
+++ b/src/Offer/ReadModel/History/OfferHistoryProjectorTrait.php
@@ -138,7 +138,7 @@ trait OfferHistoryProjectorTrait
 
         $this->writeHistory(
             $domainMessage->getId(),
-            Log::createFromDomainMessage($domainMessage, "Afbeelding '{$mediaObjectId->toString()}' aangepast")
+            Log::createFromDomainMessage($domainMessage, "Afbeelding '{$mediaObjectId}' aangepast")
         );
     }
 

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -371,13 +371,13 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             $mediaObjectMatches = (
                 strpos(
                     $mediaObject->{'@id'},
-                    $imageUpdated->getMediaObjectId()->toString()
+                    $imageUpdated->getMediaObjectId()
                 ) > 0
             );
 
             if ($mediaObjectMatches) {
-                $mediaObject->description = (string) $imageUpdated->getDescription();
-                $mediaObject->copyrightHolder = $imageUpdated->getCopyrightHolder()->toString();
+                $mediaObject->description = $imageUpdated->getDescription();
+                $mediaObject->copyrightHolder = $imageUpdated->getCopyrightHolder();
                 if ($imageUpdated->getLanguage()) {
                     $mediaObject->inLanguage = $imageUpdated->getLanguage();
                 }

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -404,9 +404,9 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
     ): ImageUpdated {
         return new ImageUpdated(
             $this->placeId,
-            $mediaObjectId,
-            $description,
-            $copyrightHolder,
+            $mediaObjectId->toString(),
+            $description->toNative(),
+            $copyrightHolder->toString(),
             $language
         );
     }

--- a/tests/Event/Events/ImageUpdatedTest.php
+++ b/tests/Event/Events/ImageUpdatedTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\Events;
 
-use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
-use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use PHPUnit\Framework\TestCase;
-use CultuurNet\UDB3\StringLiteral;
 
 class ImageUpdatedTest extends TestCase
 {
@@ -53,9 +50,9 @@ class ImageUpdatedTest extends TestCase
                 ],
                 new ImageUpdated(
                     'de305d54-75b4-431b-adb2-eb6b9e546014',
-                    new UUID('ea305d54-75b4-431b-adb2-eb6b9e546019'),
-                    new StringLiteral('some description'),
-                    new CopyrightHolder('Dirk')
+                    'ea305d54-75b4-431b-adb2-eb6b9e546019',
+                    'some description',
+                    'Dirk'
                 ),
             ],
         ];

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -976,9 +976,9 @@ class HistoryProjectorTest extends TestCase
     {
         $event = new ImageUpdated(
             self::EVENT_ID_1,
-            new UUID('0aa8d12d-26d6-409f-aa68-e8200e5c91a0'),
-            new Description('description'),
-            new CopyrightHolder('copyright holder')
+            '0aa8d12d-26d6-409f-aa68-e8200e5c91a0',
+            'description',
+            'copyright holder'
         );
 
         $domainMessage = new DomainMessage(

--- a/tests/Offer/Item/Events/ImageUpdated.php
+++ b/tests/Offer/Item/Events/ImageUpdated.php
@@ -6,6 +6,6 @@ namespace CultuurNet\UDB3\Offer\Item\Events;
 
 use CultuurNet\UDB3\Offer\Events\Image\AbstractImageUpdated;
 
-class ImageUpdated extends AbstractImageUpdated
+final class ImageUpdated extends AbstractImageUpdated
 {
 }

--- a/tests/Offer/Item/Item.php
+++ b/tests/Offer/Item/Item.php
@@ -128,9 +128,9 @@ class Item extends Offer
     ): ImageUpdated {
         return new ImageUpdated(
             $this->id,
-            $mediaObjectId,
-            $description,
-            $copyrightHolder,
+            $mediaObjectId->toString(),
+            $description->toNative(),
+            $copyrightHolder->toString(),
             $language
         );
     }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -474,9 +474,9 @@ class OfferTest extends AggregateRootScenarioTestCase
                     new ImageAdded('someId', $anotherImage),
                     new ImageUpdated(
                         'someId',
-                        $anotherImage->getMediaObjectId(),
-                        new Description('new description'),
-                        new CopyrightHolder('new copyright holder')
+                        $anotherImage->getMediaObjectId()->toString(),
+                        'new description',
+                        'new copyright holder'
                     ),
                     new MainImageSelected('someId', $anotherImage),
                 ]
@@ -519,9 +519,9 @@ class OfferTest extends AggregateRootScenarioTestCase
                     new ImageAdded('someId', $this->image),
                     new ImageUpdated(
                         'someId',
-                        $this->image->getMediaObjectId(),
-                        new Description('my favorite cat'),
-                        new CopyrightHolder('Jane Doe')
+                        $this->image->getMediaObjectId()->toString(),
+                        'my favorite cat',
+                        'Jane Doe'
                     ),
                 ]
             );
@@ -567,15 +567,15 @@ class OfferTest extends AggregateRootScenarioTestCase
                     ),
                     new ImageUpdated(
                         'someId',
-                        $this->image->getMediaObjectId(),
-                        new Description('other description'),
-                        $this->image->getCopyrightHolder()
+                        $this->image->getMediaObjectId()->toString(),
+                        'other description',
+                        $this->image->getCopyrightHolder()->toString()
                     ),
                     new ImageUpdated(
                         'someId',
-                        $this->image->getMediaObjectId(),
-                        new Description('other description'),
-                        new CopyrightHolder('other copyright')
+                        $this->image->getMediaObjectId()->toString(),
+                        'other description',
+                        'other copyright'
                     ),
                 ]
             );

--- a/tests/OfferCommandHandlerTestTrait.php
+++ b/tests/OfferCommandHandlerTestTrait.php
@@ -233,9 +233,9 @@ trait OfferCommandHandlerTestTrait
             ->then([
                 new $eventClass(
                     $itemId,
-                    $mediaObjectId,
-                    $description,
-                    $copyrightHolder
+                    $mediaObjectId->toString(),
+                    $description->toNative(),
+                    $copyrightHolder->toString()
                 ),
             ]);
     }
@@ -259,9 +259,9 @@ trait OfferCommandHandlerTestTrait
         $updatedEvent = function (Image $image) use ($itemId, $imageUpdated) {
             return new $imageUpdated(
                 $itemId,
-                $image->getMediaObjectId(),
-                $image->getDescription(),
-                $image->getCopyrightHolder(),
+                $image->getMediaObjectId()->toString(),
+                $image->getDescription()->toNative(),
+                $image->getCopyrightHolder()->toString(),
                 $image->getLanguage()->getCode()
             );
         };

--- a/tests/OfferLDProjectorTestBase.php
+++ b/tests/OfferLDProjectorTestBase.php
@@ -259,11 +259,11 @@ abstract class OfferLDProjectorTestBase extends TestCase
         $description = StringLiteral::fromNative('Some description.');
         $copyrightHolder = new CopyrightHolder('Dirk Dirkington');
         $eventClass = $this->getEventClass('ImageUpdated');
-        $imageUpdated = new $eventClass($id, $imageId, $description, $copyrightHolder);
+        $imageUpdated = new $eventClass($id, $imageId->toString(), $description->toNative(), $copyrightHolder->toString());
 
         $initialDocument = new JsonDocument(
             $id,
-            json_encode([
+            Json::encode([
                 'mediaObject' => [
                     [
                         '@id' => 'http://example.com/entity/de305d54-75b4-431b-adb2-eb6b9e546014',

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -494,9 +494,9 @@ class HistoryProjectorTest extends TestCase
     {
         $event = new ImageUpdated(
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
-            new UUID('0aa8d12d-26d6-409f-aa68-e8200e5c91a0'),
-            new Description('description'),
-            new CopyrightHolder('copyright holder')
+            '0aa8d12d-26d6-409f-aa68-e8200e5c91a0',
+            'description',
+            'copyright holder'
         );
 
         $domainMessage = $this->aDomainMessageForEvent($event->getItemId(), $event);


### PR DESCRIPTION
### Changed
- Converted `CopyrightHolder` property to a native `string` to allow empty values when serializing `ImageUpdated` from the event store
- Modified `description` property to a native `string`

---
Ticket: https://jira.uitdatabank.be/browse/III-4751
