### PR TITLE
III-4764 Prevent marking as duplicate when already canonical

### DIFF
--- a/src/Place/CannotMarkPlaceAsDuplicate.php
+++ b/src/Place/CannotMarkPlaceAsDuplicate.php
@@ -17,4 +17,9 @@ final class CannotMarkPlaceAsDuplicate extends Exception
     {
         return new self('Cannot mark place ' . $placeId . ' as duplicate because it is already a duplicate');
     }
+
+    public static function becauseItIsCanonical(string $placeId): self
+    {
+        return new self('Cannot mark place ' . $placeId . ' as duplicate because it is a canonical place');
+    }
 }

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -204,6 +204,10 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
             throw CannotMarkPlaceAsDuplicate::becauseItIsAlreadyADuplicate($this->placeId);
         }
 
+        if (!empty($this->duplicates)) {
+            throw CannotMarkPlaceAsDuplicate::becauseItIsCanonical($this->placeId);
+        }
+
         $this->apply(new MarkedAsDuplicate($this->placeId, $placeIdOfCanonical));
     }
 

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -748,6 +748,33 @@ class PlaceTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_will_not_be_marked_as_duplicate_when_it_is_already_marked_as_canonical(): void
+    {
+        $placeCreated = $this->createPlaceCreatedEvent();
+        $placeId = $placeCreated->getPlaceId();
+        $canonicalPlaceId = 'ef694e51-9ac6-4f45-be25-5207ba6ec9dc';
+        $duplicatedBy = 'd51440e5-f3bc-4dcb-8af1-a28d23031fbc';
+
+        $this->expectException(CannotMarkPlaceAsDuplicate::class);
+
+        $this->scenario
+            ->withAggregateId('c5c1b435-0f3c-4b75-9f28-94d93be7078b')
+            ->given(
+                [
+                    $placeCreated,
+                    new MarkedAsCanonical($placeId, $duplicatedBy),
+                ]
+            )
+            ->when(
+                function (Place $place) use ($canonicalPlaceId) {
+                    $place->markAsDuplicateOf($canonicalPlaceId);
+                }
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_can_be_marked_as_canonical(): void
     {
         $placeCreated = $this->createPlaceCreatedEvent();


### PR DESCRIPTION
### Fixed
- Prevented marking a place as duplicate when the place is already a canonical place

---
Ticket: https://jira.uitdatabank.be/browse/III-4764
