### PR TITLE
III-4769 Make priceCurrency optional for priceInfo updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-III-4769-price-currency-optional",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-III-4769-price-currency-optional",
+    "publiq/udb3-json-schemas": "dev-main",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a857bd99bc4abbd2aa7133e82c9f11b",
+    "content-hash": "c4de21a40fdcb22e445b1dc9801c0740",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5064,7 +5064,7 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-III-4769-price-currency-optional",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
@@ -5076,6 +5076,7 @@
                 "reference": "230ab619ead57b5b39c8f4543670141a1597ec74",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4de21a40fdcb22e445b1dc9801c0740",
+    "content-hash": "9a857bd99bc4abbd2aa7133e82c9f11b",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5064,19 +5064,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-III-4769-price-currency-optional",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "4a53cc2549c1f8cfb448d620acde92e8a7066d5e"
+                "reference": "230ab619ead57b5b39c8f4543670141a1597ec74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/4a53cc2549c1f8cfb448d620acde92e8a7066d5e",
-                "reference": "4a53cc2549c1f8cfb448d620acde92e8a7066d5e",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/230ab619ead57b5b39c8f4543670141a1597ec74",
+                "reference": "230ab619ead57b5b39c8f4543670141a1597ec74",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5091,9 +5090,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/feature/III-4250-update-name-endpoint"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-4769-price-currency-optional"
             },
-            "time": "2022-05-19T13:24:13+00:00"
+            "time": "2022-06-02T14:40:12+00:00"
         },
         {
             "name": "ralouphie/getallheaders",


### PR DESCRIPTION
### Fixed

- Made `priceCurrency` optional again by updating the JSON schema to a version without the required field. The `PriceInfoDenormalizer` (used both in the `price-info` endpoint and the imports) always sets it to `EUR` anyway so no other changes are needed. This property is not actually parsed at the moment. (See https://github.com/cultuurnet/udb3-silex/blob/6f629a3bbfa4f6caec085b8642d2a58ff05de522/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php#L95)

---
Ticket: https://jira.uitdatabank.be/browse/III-4769
