### PR TITLE
III-4716 remove labels with newlines in projection

### DIFF
--- a/src/Offer/Events/AbstractLabelEvent.php
+++ b/src/Offer/Events/AbstractLabelEvent.php
@@ -46,7 +46,13 @@ abstract class AbstractLabelEvent extends AbstractEvent implements LabelEventInt
 
         return new static(
             $data['item_id'],
-            new Label($data['label'], $data['visibility'])
+            new Label(self::trimLineEndings($data['label']), $data['visibility'])
         );
+    }
+
+    private static function trimLineEndings(string $labelName): string
+    {
+        $labelName = preg_replace('/\\r\\n/', ' ', $labelName);
+        return preg_replace('/\\n/', ' ', $labelName);
     }
 }

--- a/src/Offer/Events/AbstractLabelsImported.php
+++ b/src/Offer/Events/AbstractLabelsImported.php
@@ -34,7 +34,7 @@ abstract class AbstractLabelsImported extends AbstractEvent implements LabelsImp
         $labels = new Labels();
         foreach ($data['labels'] as $label) {
             $labels = $labels->with(new Label(
-                new LabelName($label['label']),
+                new LabelName(self::trimLineEndings($label['label'])),
                 $label['visibility']
             ));
         }
@@ -59,5 +59,11 @@ abstract class AbstractLabelsImported extends AbstractEvent implements LabelsImp
         return parent::serialize() + [
             'labels' => $labels,
         ];
+    }
+
+    private static function trimLineEndings(string $labelName): string
+    {
+        $labelName = preg_replace('/\\\\r\\\\n/', ' ', $labelName);
+        return preg_replace('/\\\\n/', ' ', $labelName);
     }
 }

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -249,9 +249,12 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                     if (!isset($json[$propertyName]) || !is_array($json[$propertyName])) {
                         return $json;
                     }
-                    $json[$propertyName] = preg_replace('/\\\\r\\\\n/', ' ', $json[$propertyName]);
-                    $json[$propertyName] = preg_replace('/\\\\n/', ' ', $json[$propertyName]);
-
+                    $json[$propertyName] = array_values(
+                        array_filter($json[$propertyName], fn ($label) => !str_contains($label, '\\n'))
+                    );
+                    if ($json[$propertyName] === []) {
+                        unset($json[$propertyName]);
+                    }
                     return $json;
                 };
 

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -38,7 +38,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         $document = $this->removeObsoleteProperties($document);
         $document = $this->removeNullLabels($document);
         $document = $this->fixDuplicateLabelVisibility($document);
-        return $document;
+        return $this->removeNewLineLabels($document);
     }
 
     private function polyfillNewProperties(JsonDocument $jsonDocument): JsonDocument
@@ -237,6 +237,26 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                 $json = $filterNullLabels($json, 'hiddenLabels');
 
                 return $json;
+            }
+        );
+    }
+
+    private function removeNewLineLabels(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                $removeNewLineLabels = static function (array $json, string $propertyName): array {
+                    if (!isset($json[$propertyName]) || !is_array($json[$propertyName])) {
+                        return $json;
+                    }
+                    $json[$propertyName] = preg_replace('/\\\\r\\\\n/', ' ', $json[$propertyName]);
+                    $json[$propertyName] = preg_replace('/\\\\n/', ' ', $json[$propertyName]);
+
+                    return $json;
+                };
+
+                $json = $removeNewLineLabels($json, 'labels');
+                return $removeNewLineLabels($json, 'hiddenLabels');
             }
         );
     }

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -1208,6 +1208,40 @@ class EventTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
+     */
+    public function it_can_update_an_event_with_newline_labels(): void
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+        $createEvent = $this->getCreationEvent();
+        $newlineLabel = new LegacyLabel('Newline\r\nLabel');
+        $correctLabel = new Label(
+            new LabelName('Correct Label')
+        );
+
+        $this->scenario
+            ->given(
+                [
+                    $createEvent,
+                    new AttendanceModeUpdated($eventId, AttendanceMode::online()->toString()),
+                    new LabelAdded(
+                        $eventId,
+                        $newlineLabel
+                    )
+                ]
+            )
+            ->when(
+                fn (Event $event) => $event->addLabel($correctLabel)
+            )
+            ->then([
+               new LabelAdded(
+                   $eventId,
+                   new LegacyLabel('Correct Label')
+               )
+            ]);
+    }
+
+    /**
+     * @test
      * @group issue-III-1380
      */
     public function it_refuses_to_copy_when_there_are_uncommitted_events(): void

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -1226,7 +1226,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new LabelAdded(
                         $eventId,
                         $newlineLabel
-                    )
+                    ),
                 ]
             )
             ->when(
@@ -1236,7 +1236,7 @@ class EventTest extends AggregateRootScenarioTestCase
                new LabelAdded(
                    $eventId,
                    new LegacyLabel('Correct Label')
-               )
+               ),
             ]);
     }
 

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -634,13 +634,9 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
             ->assertReturnedDocumentContains(
                 [
                     'labels' => [
-                        'windows newline',
-                        'unix newline',
                         'sanity label',
                     ],
                     'hiddenLabels' => [
-                        'hidden windows newline',
-                        'hidden unix newline',
                         'hidden sanity label',
                     ],
                 ]

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -646,6 +646,27 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_should_unset_labels_if_only_newline_labels_are_present(): void
+    {
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'windows\r\nnewline',
+                        'unix\nnewline',
+                    ],
+                    'hiddenLabels' => [
+                        'hidden\nwindows\r\nnewline',
+                        'hidden\r\nunix\nnewline',
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentDoesNotContainKeys(['labels', 'hiddenLabels']);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_not_add_labels_if_not_set(): void
     {
         $this
@@ -718,6 +739,14 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     {
         $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
         $this->assertArrayNotHasKey($key, $actualFromFetch);
+    }
+
+    private function assertReturnedDocumentDoesNotContainKeys(array $keys): void
+    {
+        foreach ($keys as $key) {
+            $actualFromFetch = $this->repository->fetch(self::DOCUMENT_ID)->getAssocBody();
+            $this->assertArrayNotHasKey($key, $actualFromFetch);
+        }
     }
 
     private function assertArrayContainsExpectedKeys(array $expected, array $actual): void

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -622,12 +622,12 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                     'labels' => [
                         'windows\r\nnewline',
                         'unix\nnewline',
-                        'sanity label'
+                        'sanity label',
                     ],
                     'hiddenLabels' => [
                         'hidden\nwindows\r\nnewline',
                         'hidden\r\nunix\nnewline',
-                        'hidden sanity label'
+                        'hidden sanity label',
                     ],
                 ]
             )
@@ -636,12 +636,12 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                     'labels' => [
                         'windows newline',
                         'unix newline',
-                        'sanity label'
+                        'sanity label',
                     ],
                     'hiddenLabels' => [
                         'hidden windows newline',
                         'hidden unix newline',
-                        'hidden sanity label'
+                        'hidden sanity label',
                     ],
                 ]
             );

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -614,6 +614,42 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_should_remove_newlines_in_labels(): void
+    {
+        $this
+            ->given(
+                [
+                    'labels' => [
+                        'windows\r\nnewline',
+                        'unix\nnewline',
+                        'sanity label'
+                    ],
+                    'hiddenLabels' => [
+                        'hidden\nwindows\r\nnewline',
+                        'hidden\r\nunix\nnewline',
+                        'hidden sanity label'
+                    ],
+                ]
+            )
+            ->assertReturnedDocumentContains(
+                [
+                    'labels' => [
+                        'windows newline',
+                        'unix newline',
+                        'sanity label'
+                    ],
+                    'hiddenLabels' => [
+                        'hidden windows newline',
+                        'hidden unix newline',
+                        'hidden sanity label'
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_not_add_labels_if_not_set(): void
     {
         $this


### PR DESCRIPTION
### Changed

- replace labels with newline in in `AbstractLabelsImported` & `AbstractLabelsEvent`

### Added

- Remove labels with newlines in the JSON projection

---
Ticket: https://jira.uitdatabank.be/browse/III-4716
