### PR TITLE
III-4776 Create script to maintain duplicate places

### DIFF
--- a/app/Console/MarkPlacesAsDuplicateFromTableCommand.php
+++ b/app/Console/MarkPlacesAsDuplicateFromTableCommand.php
@@ -64,7 +64,7 @@ class MarkPlacesAsDuplicateFromTableCommand extends AbstractCommand
         }
 
         foreach ($clusterIds as $clusterId) {
-            $cluster = $this->duplicatePlaceRepository->getCluster($clusterId);
+            $cluster = $this->duplicatePlaceRepository->getPlacesInCluster($clusterId);
             try {
                 $canonicalId = $this->canonicalService->getCanonical($clusterId);
             } catch (MuseumPassNotUniqueInCluster $museumPassNotUniqueInClusterException) {

--- a/app/Console/ProcessDuplicatePlaces.php
+++ b/app/Console/ProcessDuplicatePlaces.php
@@ -31,7 +31,7 @@ final class ProcessDuplicatePlaces extends AbstractCommand
 
     private AMQPPublisher $amqpPublisher;
 
-    private DocumentEventFactory $eventFactoryForEvents;
+    private DocumentEventFactory $placeEventFactory;
 
     private Connection $connection;
 
@@ -40,14 +40,14 @@ final class ProcessDuplicatePlaces extends AbstractCommand
         DuplicatePlaceRepository $duplicatePlaceRepository,
         CanonicalService $canonicalService,
         AMQPPublisher $amqpPublisher,
-        DocumentEventFactory $eventFactoryForEvents,
+        DocumentEventFactory $placeEventFactory,
         RepositoryInterface $eventRelationsRepository,
         Connection $connection
     ) {
         $this->duplicatePlaceRepository = $duplicatePlaceRepository;
         $this->canonicalService = $canonicalService;
         $this->amqpPublisher = $amqpPublisher;
-        $this->eventFactoryForEvents = $eventFactoryForEvents;
+        $this->placeEventFactory = $placeEventFactory;
         $this->eventRelationsRepository = $eventRelationsRepository;
         $this->connection = $connection;
 
@@ -101,7 +101,7 @@ final class ProcessDuplicatePlaces extends AbstractCommand
                 $this->getDuplicatePlacesRemovedFromCluster()
             );
             foreach ($placesToReIndex as $placeToReIndex) {
-                $placeProjected = $this->eventFactoryForEvents->createEvent($placeToReIndex);
+                $placeProjected = $this->placeEventFactory->createEvent($placeToReIndex);
                 $output->writeln('Dispatching PlaceProjectedToJSONLD for place with id ' . $placeToReIndex);
                 if (!$dryRun) {
                     $this->amqpPublisher->handle((new DomainMessageBuilder())->create($placeProjected));

--- a/app/Console/ProcessDuplicatePlaces.php
+++ b/app/Console/ProcessDuplicatePlaces.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Broadway\AMQP\AMQPPublisher;
+use CultuurNet\UDB3\Event\Commands\UpdateLocation;
+use CultuurNet\UDB3\Event\ReadModel\Relations\RepositoryInterface;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
+use CultuurNet\UDB3\Place\Canonical\CanonicalService;
+use CultuurNet\UDB3\Place\Canonical\DuplicatePlaceRepository;
+use CultuurNet\UDB3\Place\Canonical\Exception\MuseumPassNotUniqueInCluster;
+use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class ProcessDuplicatePlaces extends AbstractCommand
+{
+    private DuplicatePlaceRepository $duplicatePlaceRepository;
+
+    private CanonicalService $canonicalService;
+
+    private RepositoryInterface $eventRelationsRepository;
+
+    private AMQPPublisher $amqpPublisher;
+
+    private DocumentEventFactory $eventFactoryForEvents;
+
+    public function __construct(
+        CommandBus $commandBus,
+        DuplicatePlaceRepository $duplicatePlaceRepository,
+        CanonicalService $canonicalService,
+        AMQPPublisher $amqpPublisher,
+        DocumentEventFactory $eventFactoryForEvents,
+        RepositoryInterface $eventRelationsRepository
+    ) {
+        $this->duplicatePlaceRepository = $duplicatePlaceRepository;
+        $this->canonicalService = $canonicalService;
+        $this->amqpPublisher = $amqpPublisher;
+        $this->eventFactoryForEvents = $eventFactoryForEvents;
+        $this->eventRelationsRepository = $eventRelationsRepository;
+
+        parent::__construct($commandBus);
+    }
+
+    public function configure(): void
+    {
+        $this->setName('place:process-duplicates');
+        $this->setDescription('Process duplicate places (determine canonical, update event locations and reindex)');
+        $this->addOption(
+            'dry-run',
+            'd',
+            InputOption::VALUE_NONE,
+            'Execute a dry-run of the process-duplicates script.'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dryRun = (bool)$input->getOption('dry-run');
+
+        $clusterIds = $this->duplicatePlaceRepository->getClusterIds();
+
+        if (count($clusterIds) === 0) {
+            $output->writeln('No clusters found to process');
+            return 0;
+        }
+
+        if (!$this->askConfirmation($input, $output, count($clusterIds))) {
+            return 0;
+        }
+
+        foreach ($clusterIds as $clusterId) {
+            // 1. Set the canonical of a cluster
+            try {
+                $canonicalId = $this->canonicalService->getCanonical($clusterId);
+            } catch (MuseumPassNotUniqueInCluster $museumPassNotUniqueInClusterException) {
+                $output->writeln($museumPassNotUniqueInClusterException->getMessage());
+                continue;
+            }
+
+            $output->writeln('Setting ' . $canonicalId . ' as canonical of cluster ' . $clusterId);
+            if (!$dryRun) {
+                $this->duplicatePlaceRepository->setCanonicalOnCluster($clusterId, $canonicalId);
+            }
+
+            // 2. Trigger a SAPI3 reindex on the places in duplicate_places and places removed from duplicate_places
+            $placesInCluster = $this->duplicatePlaceRepository->getPlacesInCluster($clusterId);
+            foreach ($placesInCluster as $placeInCluster) {
+                $placeProjected = $this->eventFactoryForEvents->createEvent($placeInCluster);
+                $output->writeln('Dispatching PlaceProjectedToJSONLD for place with id ' . $placeInCluster);
+                if (!$dryRun) {
+                    $this->amqpPublisher->handle((new DomainMessageBuilder())->create($placeProjected));
+                }
+            }
+
+            // 3. Trigger an UpdateLocation for places inside duplicate_places
+            $duplicatePlaces = $this->duplicatePlaceRepository->getDuplicatesOfPlace($canonicalId);
+
+            foreach ($duplicatePlaces as $duplicatePlace) {
+                $commands = [];
+
+                $eventsLocatedAtDuplicatePlace = $this->eventRelationsRepository->getEventsLocatedAtPlace($duplicatePlace);
+
+                foreach ($eventsLocatedAtDuplicatePlace as $eventLocatedAtDuplicatePlace) {
+                    $commands[] = new UpdateLocation($eventLocatedAtDuplicatePlace, new LocationId($canonicalId));
+                }
+
+                foreach ($commands as $command) {
+                    $output->writeln('Dispatching UpdateLocation for event with id ' . $command->getItemId());
+                    if (!$dryRun) {
+                        $this->commandBus->dispatch($command);
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private function askConfirmation(InputInterface $input, OutputInterface $output, int $count): bool
+    {
+        return $this
+            ->getHelper('question')
+            ->ask(
+                $input,
+                $output,
+                new ConfirmationQuestion(
+                    "This action will process {$count} clusters, continue? [y/N] ",
+                    false
+                )
+            );
+    }
+}

--- a/app/Migrations/Version20220608094122.php
+++ b/app/Migrations/Version20220608094122.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220608094122 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places')
+            ->addColumn('canonical', Type::GUID)
+            ->setLength(36)
+            ->setNotnull(false)
+            ->setDefault(null);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places')
+            ->dropColumn('canonical');
+    }
+}

--- a/app/Migrations/Version20220608095217.php
+++ b/app/Migrations/Version20220608095217.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220608095217 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places')
+            ->addIndex(['place_uuid'], 'place_index');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('duplicate_places')
+            ->dropIndex('place_index');
+    }
+}

--- a/app/Migrations/Version20220609104420.php
+++ b/app/Migrations/Version20220609104420.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220609104420 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('duplicate_places_removed_from_cluster');
+
+        $table->addColumn('place_uuid', Type::GUID)->setLength(36)->setNotnull(true);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('duplicate_places_removed_from_cluster');
+    }
+}

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -116,6 +116,7 @@ $consoleApp->add(
         $app['amqp.publisher'],
         $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY],
         $app['event_relations_repository'],
+        $app['dbal_connection']
     )
 );
 $consoleApp->add(new MarkPlaceAsDuplicateCommand($app['event_command_bus'], $app[LocationMarkedAsDuplicateProcessManager::class]));

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Silex\Console\ImportEventCdbXmlCommand;
 use CultuurNet\UDB3\Silex\Console\ImportPlaceCdbXmlCommand;
 use CultuurNet\UDB3\Silex\Console\MarkPlaceAsDuplicateCommand;
 use CultuurNet\UDB3\Silex\Console\MarkPlacesAsDuplicateFromTableCommand;
+use CultuurNet\UDB3\Silex\Console\ProcessDuplicatePlaces;
 use CultuurNet\UDB3\Silex\Console\PurgeModelCommand;
 use CultuurNet\UDB3\Silex\Console\ReindexEventsWithRecommendations;
 use CultuurNet\UDB3\Silex\Console\ReindexOffersWithPopularityScore;
@@ -107,6 +108,16 @@ $consoleApp->add(new FireProjectedToJSONLDForRelationsCommand($app['event_bus'],
 $consoleApp->add(new FireProjectedToJSONLDCommand($app['event_bus'], $app[OrganizerJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY], $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY]));
 $consoleApp->add(new ImportEventCdbXmlCommand($app['event_command_bus'], $app['event_bus'], $app['system_user_id']));
 $consoleApp->add(new ImportPlaceCdbXmlCommand($app['event_command_bus'], $app['event_bus'], $app['system_user_id']));
+$consoleApp->add(
+    new ProcessDuplicatePlaces(
+        $app['event_command_bus'],
+        $app['duplicate_place_repository'],
+        $app['canonical_service'],
+        $app['amqp.publisher'],
+        $app[PlaceJSONLDServiceProvider::JSONLD_PROJECTED_EVENT_FACTORY],
+        $app['event_relations_repository'],
+    )
+);
 $consoleApp->add(new MarkPlaceAsDuplicateCommand($app['event_command_bus'], $app[LocationMarkedAsDuplicateProcessManager::class]));
 $consoleApp->add(
     new MarkPlacesAsDuplicateFromTableCommand(

--- a/src/Place/Canonical/CanonicalService.php
+++ b/src/Place/Canonical/CanonicalService.php
@@ -39,7 +39,7 @@ class CanonicalService
 
     public function getCanonical(int $clusterId): string
     {
-        $placeIds = $this->duplicatePlaceRepository->getCluster($clusterId);
+        $placeIds = $this->duplicatePlaceRepository->getPlacesInCluster($clusterId);
 
         $placesWithMuseumpas = $this->getPlacesWithMuseumPasInCluster($placeIds);
         if (count($placesWithMuseumpas) === 1) {

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -65,4 +65,17 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 
         return count($rows) === 1 ? $rows[0] : null;
     }
+
+    public function getDuplicatesOfPlace(string $placeId): ?array
+    {
+        $duplicates = $this->connection->createQueryBuilder()
+            ->select('place_uuid')
+            ->from('duplicate_places')
+            ->where('canonical = :canonical')
+            ->setParameter(':canonical', $placeId)
+            ->execute()
+            ->fetchAll(PDO::FETCH_COLUMN);
+
+        return count($duplicates) > 0 ? $duplicates : null;
+    }
 }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -44,9 +44,11 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->update('duplicate_places')
             ->set('canonical', ':canonical')
             ->where('cluster_id = :cluster_id')
+            ->andWhere('place_uuid != :canonical')
             ->setParameters([
                 ':canonical' => $canonical,
                 ':cluster_id' => $clusterId,
+                ':place_uuid' => $canonical,
             ])
             ->execute();
     }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -50,5 +50,4 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ])
             ->execute();
     }
-
 }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -18,9 +18,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 
     public function getClusterIds(): array
     {
-        $queryBuilder = $this->connection->createQueryBuilder();
-
-        $result = $queryBuilder
+        $result = $this->connection->createQueryBuilder()
             ->select('DISTINCT cluster_id')
             ->from('duplicate_places')
             ->execute()
@@ -31,9 +29,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
 
     public function getCluster(int $clusterId): array
     {
-        $queryBuilder = $this->connection->createQueryBuilder();
-
-        return $queryBuilder
+        return $this->connection->createQueryBuilder()
             ->select('place_uuid')
             ->from('duplicate_places')
             ->where('cluster_id = :cluster_id')

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -52,4 +52,17 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ])
             ->execute();
     }
+
+    public function getCanonicalOfPlace(string $placeId): ?string
+    {
+        $rows = $this->connection->createQueryBuilder()
+            ->select('canonical')
+            ->from('duplicate_places')
+            ->where('place_uuid = :place_uuid')
+            ->setParameter(':place_uuid', $placeId)
+            ->execute()
+            ->fetchAll(PDO::FETCH_COLUMN);
+
+        return count($rows) === 1 ? $rows[0]: null;
+    }
 }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -27,7 +27,7 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
         return array_map('intval', $result);
     }
 
-    public function getCluster(int $clusterId): array
+    public function getPlacesInCluster(int $clusterId): array
     {
         return $this->connection->createQueryBuilder()
             ->select('place_uuid')

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -37,4 +37,18 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->execute()
             ->fetchAll(PDO::FETCH_COLUMN);
     }
+
+    public function setCanonicalOnCluster(int $clusterId, string $canonical): void
+    {
+        $this->connection->createQueryBuilder()
+            ->update('duplicate_places')
+            ->set('canonical', ':canonical')
+            ->where('cluster_id = :cluster_id')
+            ->setParameters([
+                ':canonical' => $canonical,
+                ':cluster_id' => $clusterId,
+            ])
+            ->execute();
+    }
+
 }

--- a/src/Place/Canonical/DBALDuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DBALDuplicatePlaceRepository.php
@@ -63,6 +63,6 @@ class DBALDuplicatePlaceRepository implements DuplicatePlaceRepository
             ->execute()
             ->fetchAll(PDO::FETCH_COLUMN);
 
-        return count($rows) === 1 ? $rows[0]: null;
+        return count($rows) === 1 ? $rows[0] : null;
     }
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -14,7 +14,7 @@ interface DuplicatePlaceRepository
     /**
      * @return string[]
      */
-    public function getCluster(int $clusterId): array;
+    public function getPlacesInCluster(int $clusterId): array;
 
     public function setCanonicalOnCluster(int $clusterId, string $canonical): void;
 

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -15,4 +15,6 @@ interface DuplicatePlaceRepository
      * @return string[]
      */
     public function getCluster(int $clusterId): array;
+
+    public function setCanonicalOnCluster(int $clusterId, string $canonical): void;
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -17,4 +17,6 @@ interface DuplicatePlaceRepository
     public function getCluster(int $clusterId): array;
 
     public function setCanonicalOnCluster(int $clusterId, string $canonical): void;
+
+    public function getCanonicalOfPlace(string $placeId): ?string;
 }

--- a/src/Place/Canonical/DuplicatePlaceRepository.php
+++ b/src/Place/Canonical/DuplicatePlaceRepository.php
@@ -19,4 +19,6 @@ interface DuplicatePlaceRepository
     public function setCanonicalOnCluster(int $clusterId, string $canonical): void;
 
     public function getCanonicalOfPlace(string $placeId): ?string;
+
+    public function getDuplicatesOfPlace(string $placeId): ?array;
 }

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -80,10 +80,10 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
 
         $this->assertEquals(
             [
-                    '19ce6565-76be-425d-94d6-894f84dd2947',
-                    '1accbcfb-3b22-4762-bc13-be0f67fd3116',
-                    '526605d3-7cc4-4607-97a4-065896253f42',
-                ],
+                '19ce6565-76be-425d-94d6-894f84dd2947',
+                '1accbcfb-3b22-4762-bc13-be0f67fd3116',
+                '526605d3-7cc4-4607-97a4-065896253f42',
+            ],
             $clusterIds
         );
     }

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -115,4 +115,35 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
             $actualRows
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_canonical_of_a_place(): void
+    {
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+
+        $this->assertEquals(
+            '1accbcfb-3b22-4762-bc13-be0f67fd3116',
+            $this->duplicatePlaceRepository->getCanonicalOfPlace('19ce6565-76be-425d-94d6-894f84dd2947')
+        );
+        $this->assertEquals(
+            null,
+            $this->duplicatePlaceRepository->getCanonicalOfPlace('1accbcfb-3b22-4762-bc13-be0f67fd3116')
+        );
+        $this->assertEquals(
+            '1accbcfb-3b22-4762-bc13-be0f67fd3116',
+            $this->duplicatePlaceRepository->getCanonicalOfPlace('526605d3-7cc4-4607-97a4-065896253f42')
+        );
+
+        $this->assertEquals(
+            '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad',
+            $this->duplicatePlaceRepository->getCanonicalOfPlace('4a355db3-c3f9-4acc-8093-61b333a3aefb')
+        );
+        $this->assertEquals(
+            null,
+            $this->duplicatePlaceRepository->getCanonicalOfPlace('64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad')
+        );
+    }
 }

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -78,7 +78,7 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
      */
     public function it_can_return_placeIds(): void
     {
-        $clusterIds = $this->duplicatePlaceRepository->getCluster(1);
+        $clusterIds = $this->duplicatePlaceRepository->getPlacesInCluster(1);
 
         $this->assertEquals(
             [

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -107,10 +107,10 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
         $this->assertEquals(
             [
                 ['1', '19ce6565-76be-425d-94d6-894f84dd2947', '1accbcfb-3b22-4762-bc13-be0f67fd3116'],
-                ['1', '1accbcfb-3b22-4762-bc13-be0f67fd3116', '1accbcfb-3b22-4762-bc13-be0f67fd3116'],
+                ['1', '1accbcfb-3b22-4762-bc13-be0f67fd3116', null],
                 ['1', '526605d3-7cc4-4607-97a4-065896253f42', '1accbcfb-3b22-4762-bc13-be0f67fd3116'],
                 ['2', '4a355db3-c3f9-4acc-8093-61b333a3aefb', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad'],
-                ['2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad'],
+                ['2', '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad', null],
             ],
             $actualRows
         );

--- a/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
+++ b/tests/Place/Canonical/DBALDuplicatePlaceRepositoryTest.php
@@ -146,4 +146,37 @@ class DBALDuplicatePlaceRepositoryTest extends TestCase
             $this->duplicatePlaceRepository->getCanonicalOfPlace('64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad')
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_duplicates_of_a_place(): void
+    {
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(1, '1accbcfb-3b22-4762-bc13-be0f67fd3116');
+        $this->duplicatePlaceRepository->setCanonicalOnCluster(2, '64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad');
+
+        $this->assertNull(
+            $this->duplicatePlaceRepository->getDuplicatesOfPlace('19ce6565-76be-425d-94d6-894f84dd2947')
+        );
+        $this->assertEquals(
+            [
+                '19ce6565-76be-425d-94d6-894f84dd2947',
+                '526605d3-7cc4-4607-97a4-065896253f42',
+            ],
+            $this->duplicatePlaceRepository->getDuplicatesOfPlace('1accbcfb-3b22-4762-bc13-be0f67fd3116')
+        );
+        $this->assertNull(
+            $this->duplicatePlaceRepository->getDuplicatesOfPlace('526605d3-7cc4-4607-97a4-065896253f42')
+        );
+
+        $this->assertNull(
+            $this->duplicatePlaceRepository->getDuplicatesOfPlace('4a355db3-c3f9-4acc-8093-61b333a3aefb')
+        );
+        $this->assertEquals(
+            [
+                '4a355db3-c3f9-4acc-8093-61b333a3aefb',
+            ],
+            $this->duplicatePlaceRepository->getDuplicatesOfPlace('64901efc-6bd7-4e9d-8916-fcdeb5b1c8ad')
+        );
+    }
 }


### PR DESCRIPTION
### Added
- Added migration to create simple `duplicate_places_removed_from_cluster` table
- Added method `setCanonicalOnCluster` on `DuplicatePlaceRepository`
- Added method `getCanonicalOfPlace` on `DuplicatePlaceRepository`
- Added method `getDuplicatesOfPlace` on `DuplicatePlaceRepository`
- Added CLI command `ProcessDuplicatePlaces` to
  - Fill the `canonical` column of `duplicate_places`
  - Trigger SAPI3 reindex for duplicate places and for places that are no longer duplicates by dispatching a `PlaceProjectedToJSONLD`
  - Fire an `UpdateLocation` for all events of duplicate places

### Changed
- Created migration to add `canonical` column to `duplicate_places` table
- Created migration to add index on `place_uuid` column of `duplicate_places` table
- Renamed `getCluster` to `getPlacesInCluster`

---
Ticket: https://jira.uitdatabank.be/browse/III-4776
