### PR TITLE
III-4775 Fix crashed for canonical places

### DIFF
--- a/app/Console/ProcessDuplicatePlaces.php
+++ b/app/Console/ProcessDuplicatePlaces.php
@@ -110,6 +110,9 @@ final class ProcessDuplicatePlaces extends AbstractCommand
 
             // 3. Trigger an UpdateLocation for places inside duplicate_places
             $duplicatePlaces = $this->duplicatePlaceRepository->getDuplicatesOfPlace($canonicalId);
+            if ($duplicatePlaces === null) {
+                continue;
+            }
 
             foreach ($duplicatePlaces as $duplicatePlace) {
                 $commands = [];


### PR DESCRIPTION
### Fixed
- Fixed crashed for canonical places: prevent looping when there are no duplicates places

---
Ticket: https://jira.uitdatabank.be/browse/III-4775 
