### PR TITLE
III-4779 Filter out excluded labels when asking for suggestions

### DIFF
--- a/app/Labels/LabelServiceProvider.php
+++ b/app/Labels/LabelServiceProvider.php
@@ -108,7 +108,7 @@ class LabelServiceProvider implements ServiceProviderInterface
                         new StringLiteral(self::JSON_TABLE),
                         new StringLiteral(self::LABEL_ROLES_TABLE),
                         new StringLiteral(UserPermissionsServiceProvider::USER_ROLES_TABLE),
-                        new InMemoryExcludedLabelsRepository($labels)
+                        new InMemoryExcludedLabelsRepository($labels ?? [])
                     ),
                     $app['config']['user_permissions']['allow_all']
                 );

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -152,6 +152,19 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
 
         if ($query->isSuggestion()) {
             $queryBuilder->andWhere('name REGEXP \'^[a-zA-Z\d_\-]{2,50}$\'');
+
+            $excludedLabels = $this->excludedLabelsRepository->getAll();
+            if (!empty($excludedLabels)) {
+                $queryBuilder->andWhere(
+                    $queryBuilder->expr()->notIn(
+                        SchemaConfigurator::UUID_COLUMN,
+                        array_map(
+                            fn(string $label) => '"' . $label . '"',
+                            $excludedLabels
+                        )
+                    )
+                );
+            }
         }
 
         if ($query->getUserId()) {

--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -159,7 +159,7 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
                     $queryBuilder->expr()->notIn(
                         SchemaConfigurator::UUID_COLUMN,
                         array_map(
-                            fn(string $label) => '"' . $label . '"',
+                            fn (string $label) => '"' . $label . '"',
                             $excludedLabels
                         )
                     )


### PR DESCRIPTION
### Changed
- Filtered out excluded labels when asking for suggestions

---
**Note**: the initial approach was to create a table with excluded labels; that table would be used for a subquery in a `WHERE NOT IN` clause. But it turns out that Doctrine DBAL can also handle a simple array as an input parameter for the `notIn` expression. For now, I just used the existing `InMemoryExcludedLabelsRepository`.

---

Ticket: https://jira.uitdatabank.be/browse/III-4779
