### PR TITLE
III-4613 Add script to remove facilities from places

### DIFF
--- a/app/Console/RemoveFacilitiesFromPlace.php
+++ b/app/Console/RemoveFacilitiesFromPlace.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 final class RemoveFacilitiesFromPlace extends AbstractCommand
 {
-    private const FACILITY_QUERY = 'terms.id:3.';
+    private const FACILITY_QUERY = 'terms.id:3.*';
 
     private ResultsGeneratorInterface $searchResultsGenerator;
 

--- a/app/Console/RemoveFacilitiesFromPlace.php
+++ b/app/Console/RemoveFacilitiesFromPlace.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Console;
+
+use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Offer\Commands\UpdateFacilities;
+use CultuurNet\UDB3\Search\ResultsGenerator;
+use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
+use CultuurNet\UDB3\Search\SearchServiceInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class RemoveFacilitiesFromPlace extends AbstractCommand
+{
+    private const FACILITY_QUERY = 'terms.id:3.';
+
+    private ResultsGeneratorInterface $searchResultsGenerator;
+
+    public function __construct(
+        CommandBus $commandBus,
+        SearchServiceInterface $searchService
+    ) {
+        $this->searchResultsGenerator = new ResultsGenerator(
+            $searchService,
+            ['created' => 'asc'],
+            100
+        );
+
+        parent::__construct($commandBus);
+    }
+
+    public function configure(): void
+    {
+        $this->setName('place:facilities:remove');
+
+        $this->setDescription(
+            'Remove all facilities from either a single place or all places with `q=' . self::FACILITY_QUERY . '`'
+        );
+
+        $this->addArgument('id', InputArgument::OPTIONAL, 'Optional id of the place to remove all facilities');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $placeId = $input->getArgument('id');
+
+        if ($placeId) {
+            $count = 1;
+        } else {
+            $count = $this->searchResultsGenerator->count(self::FACILITY_QUERY);
+        }
+
+        if ($count === 0) {
+            $output->writeln('Found no places to remove facilities');
+            return 0;
+        }
+
+        if (!$this->askConfirmation($input, $output, $count)) {
+            return 0;
+        }
+
+        if ($placeId) {
+            $places = [$placeId];
+        } else {
+            $places = $this->searchResultsGenerator->search(self::FACILITY_QUERY);
+        }
+
+        foreach ($places as $place) {
+            $output->writeln('Dispatching UpdateFacilities for ' . $place);
+            $this->commandBus->dispatch(new UpdateFacilities($place, []));
+        }
+
+        return 0;
+    }
+
+    private function askConfirmation(InputInterface $input, OutputInterface $output, int $count): bool
+    {
+        return $this
+            ->getHelper('question')
+            ->ask(
+                $input,
+                $output,
+                new ConfirmationQuestion(
+                    "This action will remove the facilities from {$count} place(s), continue? [y/N] ",
+                    false
+                )
+            );
+    }
+}

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Silex\Console\ProcessDuplicatePlaces;
 use CultuurNet\UDB3\Silex\Console\PurgeModelCommand;
 use CultuurNet\UDB3\Silex\Console\ReindexEventsWithRecommendations;
 use CultuurNet\UDB3\Silex\Console\ReindexOffersWithPopularityScore;
+use CultuurNet\UDB3\Silex\Console\RemoveFacilitiesFromPlace;
 use CultuurNet\UDB3\Silex\Console\ReplaceNewsArticlePublisher;
 use CultuurNet\UDB3\Silex\Console\ReplayCommand;
 use CultuurNet\UDB3\Silex\Console\UpdateBookingAvailabilityCommand;
@@ -147,6 +148,7 @@ $consoleApp->add(new ChangeOrganizerOwner($app['event_command_bus']));
 $consoleApp->add(new ChangeOrganizerOwnerInBulk($app['event_command_bus'], $app['organizer_owner.repository']));
 $consoleApp->add(new UpdateUniqueLabels($app['dbal_connection']));
 $consoleApp->add(new UpdateUniqueOrganizers($app['dbal_connection'], new WebsiteNormalizer()));
+$consoleApp->add(new RemoveFacilitiesFromPlace($app['event_command_bus'], $app[Sapi3SearchServiceProvider::SEARCH_SERVICE_PLACES]));
 
 $consoleApp->add(new ImportOfferAutoClassificationLabels($app['dbal_connection'], $app['event_command_bus']));
 

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -202,7 +202,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     public function updateFacilities(array $facilities): void
     {
-        if (empty($this->facilities) || !$this->sameFacilities($this->facilities, $facilities)) {
+        if (!$this->sameFacilities($this->facilities, $facilities)) {
             $this->apply($this->createFacilitiesUpdatedEvent($facilities));
         }
     }
@@ -214,6 +214,10 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     private function sameFacilities(array $facilities1, array $facilities2): bool
     {
+        if (empty($facilities1) && empty($facilities2)) {
+            return true;
+        }
+
         if (count($facilities1) !== count($facilities2)) {
             return false;
         }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -187,6 +187,21 @@ class OfferTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_ignores_removing_facilities_when_facilities_already_empty(): void
+    {
+        $itemId = '0fd9a1e5-1406-43b5-a641-4b4d77fe980d';
+
+        $this->scenario
+            ->given([
+                new ItemCreated($itemId),
+            ])
+            ->when(fn (Item $item) => $item->updateFacilities([]))
+            ->then([]);
+    }
+
+    /**
+     * @test
+     */
     public function it_updates_contact_point_when_changed(): void
     {
         $itemId = 'c25e603a-19dd-48e4-94d9-893484402189';


### PR DESCRIPTION
### Added
- Added CLI command `RemoveFacilitiesFromPlace` to remove the facilities from a single place or a list of places matching the query `terms.id:3.`

### Changed
- Prevent updating the facilities with an empty list if the offer has no facilities. This will prevent a redundant and empty `FacilitiesUpdated` inside the event store

---
Ticket: https://jira.uitdatabank.be/browse/III-4613
