### PR TITLE
III-4613 Finetune the update facilities command

### DIFF
--- a/app/Console/RemoveFacilitiesFromPlace.php
+++ b/app/Console/RemoveFacilitiesFromPlace.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Console;
 
 use Broadway\CommandHandling\CommandBus;
+use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Offer\Commands\UpdateFacilities;
 use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
@@ -70,8 +71,9 @@ final class RemoveFacilitiesFromPlace extends AbstractCommand
         }
 
         foreach ($places as $place) {
-            $output->writeln('Dispatching UpdateFacilities for ' . $place);
-            $this->commandBus->dispatch(new UpdateFacilities($place, []));
+            $placeId = $place instanceof ItemIdentifier ? $place->getId() : $placeId;
+            $output->writeln('Dispatching UpdateFacilities for ' . $placeId);
+            $this->commandBus->dispatch(new UpdateFacilities($placeId, []));
         }
 
         return 0;

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -114,7 +114,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     protected ?string $typeId = null;
 
-    protected array $facilities;
+    protected ?array $facilities = null;
 
     protected ?ContactPoint $contactPoint = null;
 
@@ -138,7 +138,6 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
         $this->labels = new LabelsArray();
         $this->images = new ImageCollection();
         $this->videos = new VideoCollection();
-        $this->facilities = [];
         $this->contactPoint = null;
         $this->calendar = null;
         $this->typicalAgeRange = null;
@@ -202,7 +201,7 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     public function updateFacilities(array $facilities): void
     {
-        if (!$this->sameFacilities($this->facilities, $facilities)) {
+        if ($this->facilities === null || !$this->sameFacilities($this->facilities, $facilities)) {
             $this->apply($this->createFacilitiesUpdatedEvent($facilities));
         }
     }

--- a/tests/Offer/OfferTest.php
+++ b/tests/Offer/OfferTest.php
@@ -187,6 +187,21 @@ class OfferTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_has_an_initial_null_state_for_facilities(): void
+    {
+        $itemId = '0fd9a1e5-1406-43b5-a641-4b4d77fe980d';
+
+        $this->scenario
+            ->given([
+                new ItemCreated($itemId),
+            ])
+            ->when(fn (Item $item) => $item->updateFacilities([]))
+            ->then([new FacilitiesUpdated($itemId, [])]);
+    }
+
+    /**
+     * @test
+     */
     public function it_ignores_removing_facilities_when_facilities_already_empty(): void
     {
         $itemId = '0fd9a1e5-1406-43b5-a641-4b4d77fe980d';
@@ -194,6 +209,7 @@ class OfferTest extends AggregateRootScenarioTestCase
         $this->scenario
             ->given([
                 new ItemCreated($itemId),
+                new FacilitiesUpdated($itemId, []),
             ])
             ->when(fn (Item $item) => $item->updateFacilities([]))
             ->then([]);


### PR DESCRIPTION
### Changed
- Took into account that the generator returns `ItemIdentifier` objects inside the `RemoveFacilitiesFromPlace` CLI
- Changed initial internal facilities state to `null` to better handle UDB2 imports which don't set facilities. But once an update is done either filled or empty no extra updates with the same values will be recorded.

---
Ticket: https://jira.uitdatabank.be/browse/III-4613