### PR TITLE
III-4786 refactor add label use new vo

### DIFF
--- a/app/Console/ImportOfferAutoClassificationLabels.php
+++ b/app/Console/ImportOfferAutoClassificationLabels.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Console;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use Doctrine\DBAL\Connection;
 use Exception;
@@ -74,7 +74,7 @@ final class ImportOfferAutoClassificationLabels extends Command
             $label = (string) $row['label'];
 
             try {
-                $this->commandBus->dispatch(new AddLabel($offerId, new Label($label)));
+                $this->commandBus->dispatch(new AddLabel($offerId, new LegacyLabel($label)));
             } catch (Exception $e) {
                 $errors[] = [
                     'offer_id' => $offerId,

--- a/app/Console/ImportOfferAutoClassificationLabels.php
+++ b/app/Console/ImportOfferAutoClassificationLabels.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Console;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;

--- a/app/Console/ImportOfferAutoClassificationLabels.php
+++ b/app/Console/ImportOfferAutoClassificationLabels.php
@@ -6,6 +6,8 @@ namespace CultuurNet\UDB3\Silex\Console;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use Doctrine\DBAL\Connection;
 use Exception;
@@ -74,7 +76,7 @@ final class ImportOfferAutoClassificationLabels extends Command
             $label = (string) $row['label'];
 
             try {
-                $this->commandBus->dispatch(new AddLabel($offerId, new LegacyLabel($label)));
+                $this->commandBus->dispatch(new AddLabel($offerId, new Label(new LabelName($label))));
             } catch (Exception $e) {
                 $errors[] = [
                     'offer_id' => $offerId,

--- a/src/Curators/LabelFactory.php
+++ b/src/Curators/LabelFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Curators;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use InvalidArgumentException;

--- a/src/Curators/LabelFactory.php
+++ b/src/Curators/LabelFactory.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Curators;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use InvalidArgumentException;
 
 class LabelFactory
@@ -23,7 +25,7 @@ class LabelFactory
     {
         foreach (array_keys($this->labelMapping) as $key) {
             if ($publisher->equals(new PublisherName($key))) {
-                return new Label($this->labelMapping[$key], false);
+                return new Label(new LabelName($this->labelMapping[$key]), false);
             }
         }
 

--- a/src/Http/Offer/EditOfferRestController.php
+++ b/src/Http/Offer/EditOfferRestController.php
@@ -8,6 +8,8 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
 use CultuurNet\UDB3\Offer\OfferEditingServiceInterface;
@@ -67,7 +69,7 @@ class EditOfferRestController
 
     public function addLabel(string $cdbid, string $label): Response
     {
-        $this->commandBus->dispatch(new AddLabel($cdbid, new LegacyLabel($label)));
+        $this->commandBus->dispatch(new AddLabel($cdbid, new Label(new LabelName($label))));
         return new NoContent();
     }
 

--- a/src/Http/Offer/EditOfferRestController.php
+++ b/src/Http/Offer/EditOfferRestController.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;

--- a/src/Http/Offer/EditOfferRestController.php
+++ b/src/Http/Offer/EditOfferRestController.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
@@ -67,7 +67,7 @@ class EditOfferRestController
 
     public function addLabel(string $cdbid, string $label): Response
     {
-        $this->commandBus->dispatch(new AddLabel($cdbid, new Label($label)));
+        $this->commandBus->dispatch(new AddLabel($cdbid, new LegacyLabel($label)));
         return new NoContent();
     }
 

--- a/src/Label/LabelServiceInterface.php
+++ b/src/Label/LabelServiceInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Label;
 
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
 interface LabelServiceInterface
@@ -18,5 +18,5 @@ interface LabelServiceInterface
      * UUID of the newly created aggregate label, or null if no new label
      * aggregate was created.
      */
-    public function createLabelAggregateIfNew(LabelName $labelName, bool $visible): ?UUID;
+    public function createLabelAggregateIfNew(LegacyLabelName $labelName, bool $visible): ?UUID;
 }

--- a/src/LabelJSONDeserializer.php
+++ b/src/LabelJSONDeserializer.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 
 /**
  * @deprecated

--- a/src/LabelJSONDeserializer.php
+++ b/src/LabelJSONDeserializer.php
@@ -26,6 +26,6 @@ class LabelJSONDeserializer extends JSONDeserializer
             throw new MissingValueException('Missing value "label"!');
         }
 
-        return new Label(new LabelName( $data->label));
+        return new Label(new LabelName($data->label));
     }
 }

--- a/src/LabelJSONDeserializer.php
+++ b/src/LabelJSONDeserializer.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 /**
  * @deprecated
@@ -25,6 +26,6 @@ class LabelJSONDeserializer extends JSONDeserializer
             throw new MissingValueException('Missing value "label"!');
         }
 
-        return new Label($data->label);
+        return new Label(new LabelName( $data->label));
     }
 }

--- a/src/Offer/BulkLabelCommandHandler.php
+++ b/src/Offer/BulkLabelCommandHandler.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
@@ -78,7 +78,7 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
 
     private function label(
         ItemIdentifier $offerIdentifier,
-        Label $label,
+        LegacyLabel $label,
         string $originalCommandName = null
     ): void {
         try {

--- a/src/Offer/BulkLabelCommandHandler.php
+++ b/src/Offer/BulkLabelCommandHandler.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Offer;
 
 use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;

--- a/src/Offer/BulkLabelCommandHandler.php
+++ b/src/Offer/BulkLabelCommandHandler.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\CommandHandling\Udb3CommandHandler;
 use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToMultiple;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToQuery;
@@ -78,7 +79,7 @@ class BulkLabelCommandHandler extends Udb3CommandHandler implements LoggerAwareI
 
     private function label(
         ItemIdentifier $offerIdentifier,
-        LegacyLabel $label,
+        Label $label,
         string $originalCommandName = null
     ): void {
         try {

--- a/src/Offer/CommandHandlers/AddLabelHandler.php
+++ b/src/Offer/CommandHandlers/AddLabelHandler.php
@@ -40,11 +40,11 @@ final class AddLabelHandler implements CommandHandler
         }
 
         $this->labelService->createLabelAggregateIfNew(
-            new LegacyLabelName((string) $command->getLabel()),
+            new LegacyLabelName($command->getLabel()->getName()->toString()),
             $command->getLabel()->isVisible()
         );
 
-        $labelName = (string) $command->getLabel();
+        $labelName = $command->getLabel()->getName()->toString();
         $labelVisibility = $command->getLabel()->isVisible();
 
         // Load the label read model so we can determine the correct visibility.

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
 use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractLabelCommand extends AbstractCommand implements AuthorizableLabelCommand
 {
-    /**
-     * @var LegacyLabel
-     */
-    protected $label;
+    protected Label $label;
 
-    public function __construct(string $itemId, LegacyLabel $label)
+    public function __construct(string $itemId, Label $label)
     {
         parent::__construct($itemId);
         $this->label = $label;
@@ -28,7 +26,7 @@ abstract class AbstractLabelCommand extends AbstractCommand implements Authoriza
 
     public function getLabel(): LegacyLabel
     {
-        return $this->label;
+        return new LegacyLabel($this->label->getName()->toString(), $this->label->isVisible());
     }
 
     public function getLabelNames(): array

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -24,9 +24,9 @@ abstract class AbstractLabelCommand extends AbstractCommand implements Authoriza
         return $this->itemId;
     }
 
-    public function getLabel(): LegacyLabel
+    public function getLabel(): Label
     {
-        return new LegacyLabel($this->label->getName()->toString(), $this->label->isVisible());
+        return $this->label;
     }
 
     public function getLabelNames(): array

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
 use CultuurNet\UDB3\StringLiteral;

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Security\AuthorizableLabelCommand;
 use CultuurNet\UDB3\StringLiteral;
 
 abstract class AbstractLabelCommand extends AbstractCommand implements AuthorizableLabelCommand
 {
     /**
-     * @var Label
+     * @var LegacyLabel
      */
     protected $label;
 
-    public function __construct(string $itemId, Label $label)
+    public function __construct(string $itemId, LegacyLabel $label)
     {
         parent::__construct($itemId);
         $this->label = $label;
@@ -26,7 +26,7 @@ abstract class AbstractLabelCommand extends AbstractCommand implements Authoriza
         return $this->itemId;
     }
 
-    public function getLabel(): Label
+    public function getLabel(): LegacyLabel
     {
         return $this->label;
     }

--- a/src/Offer/Commands/AbstractLabelCommand.php
+++ b/src/Offer/Commands/AbstractLabelCommand.php
@@ -34,7 +34,7 @@ abstract class AbstractLabelCommand extends AbstractCommand implements Authoriza
     public function getLabelNames(): array
     {
         return [
-            new StringLiteral((string)$this->label),
+            new StringLiteral($this->label->getName()->toString()),
         ];
     }
 }

--- a/src/Offer/Commands/AddLabelToMultiple.php
+++ b/src/Offer/Commands/AddLabelToMultiple.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 

--- a/src/Offer/Commands/AddLabelToMultiple.php
+++ b/src/Offer/Commands/AddLabelToMultiple.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 
 class AddLabelToMultiple
@@ -14,10 +15,7 @@ class AddLabelToMultiple
      */
     protected $offerIdentifiers;
 
-    /**
-     * @var Label
-     */
-    protected $label;
+    protected Label $label;
 
 
     public function __construct(OfferIdentifierCollection $offerIdentifiers, Label $label)
@@ -34,10 +32,7 @@ class AddLabelToMultiple
         return $this->offerIdentifiers;
     }
 
-    /**
-     * @return Label
-     */
-    public function getLabel()
+    public function getLabel(): Label
     {
         return $this->label;
     }

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -8,7 +8,6 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;

--- a/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToMultipleJSONDeserializer.php
@@ -8,7 +8,9 @@ use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
 use CultuurNet\UDB3\Deserializer\NotWellFormedException;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
 use CultuurNet\UDB3\StringLiteral;
 
@@ -47,7 +49,7 @@ class AddLabelToMultipleJSONDeserializer extends JSONDeserializer
             throw new MissingValueException('Missing value "offers".');
         }
 
-        $label = new Label($data->label);
+        $label = new Label(new LabelName($data->label));
         $offers = new OfferIdentifierCollection();
 
         foreach ($data->offers as $offer) {

--- a/src/Offer/Commands/AddLabelToQuery.php
+++ b/src/Offer/Commands/AddLabelToQuery.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 
 class AddLabelToQuery
 {
@@ -13,10 +14,7 @@ class AddLabelToQuery
      */
     protected $query;
 
-    /**
-     * @var Label
-     */
-    protected $label;
+    protected Label $label;
 
     public function __construct($query, Label $label)
     {
@@ -32,10 +30,7 @@ class AddLabelToQuery
         return $this->query;
     }
 
-    /**
-     * @return Label
-     */
-    public function getLabel()
+    public function getLabel(): Label
     {
         return $this->label;
     }

--- a/src/Offer/Commands/AddLabelToQuery.php
+++ b/src/Offer/Commands/AddLabelToQuery.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 
 class AddLabelToQuery

--- a/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
@@ -6,7 +6,9 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\StringLiteral;
 
 /**
@@ -28,7 +30,7 @@ class AddLabelToQueryJSONDeserializer extends JSONDeserializer
 
         return new AddLabelToQuery(
             $data->query,
-            new Label($data->label)
+            new Label(new LabelName( $data->label))
         );
     }
 }

--- a/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
+++ b/src/Offer/Commands/AddLabelToQueryJSONDeserializer.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\JSONDeserializer;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\StringLiteral;
@@ -30,7 +29,7 @@ class AddLabelToQueryJSONDeserializer extends JSONDeserializer
 
         return new AddLabelToQuery(
             $data->query,
-            new Label(new LabelName( $data->label))
+            new Label(new LabelName($data->label))
         );
     }
 }

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UiTPAS\Event;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
@@ -91,8 +91,8 @@ class EventProcessManager implements EventListener
 
     /**
      * @param CardSystem[] $cardSystems
-     * @param Label[] $uitPasLabels
-     * @return Label[]
+     * @param LegacyLabel[] $uitPasLabels
+     * @return LegacyLabel[]
      */
     private function determineApplicableLabelsForEvent(
         array $cardSystems,
@@ -117,15 +117,15 @@ class EventProcessManager implements EventListener
     }
 
     /**
-     * @param Label[] $applicableLabels
-     * @param Label[] $uitPasLabels
-     * @return Label[]
+     * @param LegacyLabel[] $applicableLabels
+     * @param LegacyLabel[] $uitPasLabels
+     * @return LegacyLabel[]
      */
     private function determineInapplicableLabelsForEvent(
         array $applicableLabels,
         array $uitPasLabels
     ): array {
-        $uitPasLabelDoesNotApply = function (Label $uitPasLabel) use ($applicableLabels) {
+        $uitPasLabelDoesNotApply = function (LegacyLabel $uitPasLabel) use ($applicableLabels) {
             return !$this->labelsContain($applicableLabels, $uitPasLabel);
         };
 
@@ -136,9 +136,9 @@ class EventProcessManager implements EventListener
     }
 
     /**
-     * @param Label[] $haystack
+     * @param LegacyLabel[] $haystack
      */
-    private function labelsContain(array $haystack, Label $needle): bool
+    private function labelsContain(array $haystack, LegacyLabel $needle): bool
     {
         foreach ($haystack as $label) {
             if ($needle->equals($label)) {
@@ -150,7 +150,7 @@ class EventProcessManager implements EventListener
 
     /**
      * @param string $eventId
-     * @param Label[] $labels
+     * @param LegacyLabel[] $labels
      */
     private function removeLabelsFromEvent($eventId, array $labels): void
     {
@@ -159,7 +159,7 @@ class EventProcessManager implements EventListener
         );
 
         $commands = array_map(
-            function (Label $label) use ($eventId) {
+            function (LegacyLabel $label) use ($eventId) {
                 return new RemoveLabel(
                     $eventId,
                     $label->getName()->toNative(),
@@ -174,7 +174,7 @@ class EventProcessManager implements EventListener
 
     /**
      * @param string $eventId
-     * @param Label[] $labels
+     * @param LegacyLabel[] $labels
      */
     private function addLabelsToEvent($eventId, array $labels)
     {
@@ -187,7 +187,7 @@ class EventProcessManager implements EventListener
         );
 
         $commands = array_map(
-            function (Label $label) use ($eventId) {
+            function (LegacyLabel $label) use ($eventId) {
                 return new AddLabel(
                     $eventId,
                     $label

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -206,7 +206,7 @@ class EventProcessManager implements EventListener
     {
         foreach ($commands as $command) {
             if ($command instanceof AddLabel) {
-                $labelName = (string) $command->getLabel();
+                $labelName = $command->getLabel()->getName()->toString();
             } elseif ($command instanceof RemoveLabel) {
                 $labelName = $command->getLabelName();
             } else {

--- a/src/UiTPAS/Event/EventProcessManager.php
+++ b/src/UiTPAS/Event/EventProcessManager.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\UiTPAS\Event;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Offer\Commands\AbstractCommand;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;

--- a/src/UiTPAS/Label/InMemoryUiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/InMemoryUiTPASLabelsRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\Label;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
@@ -38,7 +37,7 @@ final class InMemoryUiTPASLabelsRepository implements UiTPASLabelsRepository
     {
         $labelVOs = [];
         foreach ($labels as $cardSystemId => $label) {
-            $labelVOs[$cardSystemId] = new Label(new LabelName( $label));
+            $labelVOs[$cardSystemId] = new Label(new LabelName($label));
         }
 
         return new self($labelVOs);

--- a/src/UiTPAS/Label/InMemoryUiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/InMemoryUiTPASLabelsRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\Label;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 final class InMemoryUiTPASLabelsRepository implements UiTPASLabelsRepository
 {
@@ -36,7 +38,7 @@ final class InMemoryUiTPASLabelsRepository implements UiTPASLabelsRepository
     {
         $labelVOs = [];
         foreach ($labels as $cardSystemId => $label) {
-            $labelVOs[$cardSystemId] = new Label($label);
+            $labelVOs[$cardSystemId] = new Label(new LabelName( $label));
         }
 
         return new self($labelVOs);

--- a/src/UiTPAS/Label/UiTPASLabelsRepository.php
+++ b/src/UiTPAS/Label/UiTPASLabelsRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\Label;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 
 interface UiTPASLabelsRepository
 {

--- a/tests/Curators/LabelFactoryTest.php
+++ b/tests/Curators/LabelFactoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Curators;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -13,14 +15,14 @@ class LabelFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_will_create_label_for_known_publishers()
+    public function it_will_create_label_for_known_publishers():void
     {
         $labelFactory = new LabelFactory(
             [
                 'bruzz' => 'BRUZZ-redactioneel',
             ]
         );
-        $expected = new Label('BRUZZ-redactioneel', false);
+        $expected = new Label(new LabelName('BRUZZ-redactioneel'), false);
         $label = $labelFactory->forPublisher(new PublisherName('bruzz'));
 
         $this->assertEquals($expected, $label);
@@ -36,7 +38,7 @@ class LabelFactoryTest extends TestCase
                 'bruzz' => 'BRUZZ-redactioneel',
             ]
         );
-        $expected = new Label('BRUZZ-redactioneel', false);
+        $expected = new Label(new LabelName('BRUZZ-redactioneel'), false);
         $label = $labelFactory->forPublisher(new PublisherName('Bruzz'));
 
         $this->assertEquals($expected, $label);

--- a/tests/Curators/LabelFactoryTest.php
+++ b/tests/Curators/LabelFactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Curators;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use InvalidArgumentException;
@@ -15,7 +14,7 @@ class LabelFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_will_create_label_for_known_publishers():void
+    public function it_will_create_label_for_known_publishers(): void
     {
         $labelFactory = new LabelFactory(
             [

--- a/tests/Curators/NewsArticleProcessManagerTest.php
+++ b/tests/Curators/NewsArticleProcessManagerTest.php
@@ -9,6 +9,8 @@ use CultuurNet\UDB3\Deserializer\SimpleDeserializerLocator;
 use CultuurNet\UDB3\Broadway\AMQP\EventBusForwardingConsumer;
 use CultuurNet\UDB3\Curators\Events\NewsArticleAboutEventAddedJSONDeserializer;
 use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\SimpleEventBus;
 use InvalidArgumentException;
@@ -109,7 +111,7 @@ final class NewsArticleProcessManagerTest extends TestCase
         );
         $message->delivery_info = $this->messageDeliveryInfo;
 
-        $expectedLabel = new LegacyLabel('TEST_LABEL', false);
+        $expectedLabel = new Label(new LabelName('TEST_LABEL'), false);
 
         $this->labelFactory->expects($this->once())
             ->method('forPublisher')

--- a/tests/Curators/NewsArticleProcessManagerTest.php
+++ b/tests/Curators/NewsArticleProcessManagerTest.php
@@ -8,7 +8,6 @@ use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Deserializer\SimpleDeserializerLocator;
 use CultuurNet\UDB3\Broadway\AMQP\EventBusForwardingConsumer;
 use CultuurNet\UDB3\Curators\Events\NewsArticleAboutEventAddedJSONDeserializer;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;

--- a/tests/Curators/NewsArticleProcessManagerTest.php
+++ b/tests/Curators/NewsArticleProcessManagerTest.php
@@ -8,7 +8,7 @@ use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Deserializer\SimpleDeserializerLocator;
 use CultuurNet\UDB3\Broadway\AMQP\EventBusForwardingConsumer;
 use CultuurNet\UDB3\Curators\Events\NewsArticleAboutEventAddedJSONDeserializer;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\SimpleEventBus;
 use InvalidArgumentException;
@@ -109,7 +109,7 @@ final class NewsArticleProcessManagerTest extends TestCase
         );
         $message->delivery_info = $this->messageDeliveryInfo;
 
-        $expectedLabel = new Label('TEST_LABEL', false);
+        $expectedLabel = new LegacyLabel('TEST_LABEL', false);
 
         $this->labelFactory->expects($this->once())
             ->method('forPublisher')

--- a/tests/Http/Offer/EditOfferRestControllerTest.php
+++ b/tests/Http/Offer/EditOfferRestControllerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Offer;
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\DescriptionJSONDeserializer;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\LabelJSONDeserializer;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;

--- a/tests/Http/Offer/EditOfferRestControllerTest.php
+++ b/tests/Http/Offer/EditOfferRestControllerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Http\Offer;
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use CultuurNet\UDB3\Description;
 use CultuurNet\UDB3\DescriptionJSONDeserializer;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\LabelJSONDeserializer;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
@@ -99,7 +99,7 @@ class EditOfferRestControllerTest extends TestCase
         $response = $this->controller
             ->addLabel($cdbid, $label);
 
-        $this->assertEquals([new AddLabel($cdbid, new Label($label))], $this->commandBus->getRecordedCommands());
+        $this->assertEquals([new AddLabel($cdbid, new LegacyLabel($label))], $this->commandBus->getRecordedCommands());
 
         $this->assertEquals(204, $response->getStatusCode());
     }

--- a/tests/Http/Offer/EditOfferRestControllerTest.php
+++ b/tests/Http/Offer/EditOfferRestControllerTest.php
@@ -10,6 +10,8 @@ use CultuurNet\UDB3\DescriptionJSONDeserializer;
 use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\LabelJSONDeserializer;
 use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
 use CultuurNet\UDB3\Offer\OfferEditingServiceInterface;
@@ -99,7 +101,7 @@ class EditOfferRestControllerTest extends TestCase
         $response = $this->controller
             ->addLabel($cdbid, $label);
 
-        $this->assertEquals([new AddLabel($cdbid, new LegacyLabel($label))], $this->commandBus->getRecordedCommands());
+        $this->assertEquals([new AddLabel($cdbid, new Label(new LabelName($label)))], $this->commandBus->getRecordedCommands());
 
         $this->assertEquals(204, $response->getStatusCode());
     }

--- a/tests/LabelJSONDeserializerTest.php
+++ b/tests/LabelJSONDeserializerTest.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;
 
 class LabelJSONDeserializerTest extends TestCase
 {
-    /**
-     * @var Label
-     */
-    private $label;
+    private Label $label;
 
-    /**
-     * @var LabelJSONDeserializer
-     */
-    private $deserializer;
+    private LabelJSONDeserializer $deserializer;
 
     public function setUp()
     {
-        $this->label = new Label('test-label');
+        $this->label = new Label(new LabelName('test-label'));
         $this->deserializer = new LabelJSONDeserializer();
     }
 

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -40,7 +40,7 @@ class BulkLabelCommandHandlerTest extends TestCase
     private $query;
 
     /**
-     * @var Label
+     * @var LegacyLabel
      */
     private $label;
 
@@ -73,7 +73,7 @@ class BulkLabelCommandHandlerTest extends TestCase
         $this->commandHandler->setLogger($this->logger);
 
         $this->query = 'city:leuven';
-        $this->label = new Label('foo');
+        $this->label = new LegacyLabel('foo');
 
         $this->offerIdentifiers = [
             1 => new IriOfferIdentifier(
@@ -194,7 +194,7 @@ class BulkLabelCommandHandlerTest extends TestCase
     }
 
 
-    private function expectEventAndPlaceToBeLabelledWith(Label $label): void
+    private function expectEventAndPlaceToBeLabelledWith(LegacyLabel $label): void
     {
         $this->commandBus->expects($this->exactly(2))
             ->method('dispatch')

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;

--- a/tests/Offer/BulkLabelCommandHandlerTest.php
+++ b/tests/Offer/BulkLabelCommandHandlerTest.php
@@ -8,6 +8,8 @@ use Broadway\CommandHandling\CommandBus;
 use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemIdentifier;
 use CultuurNet\UDB3\Model\ValueObject\Identity\ItemType;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabelToMultiple;
@@ -39,10 +41,7 @@ class BulkLabelCommandHandlerTest extends TestCase
      */
     private $query;
 
-    /**
-     * @var LegacyLabel
-     */
-    private $label;
+    private Label $label;
 
     /**
      * @var IriOfferIdentifier[]
@@ -73,7 +72,7 @@ class BulkLabelCommandHandlerTest extends TestCase
         $this->commandHandler->setLogger($this->logger);
 
         $this->query = 'city:leuven';
-        $this->label = new LegacyLabel('foo');
+        $this->label = new Label(new LabelName('foo'));
 
         $this->offerIdentifiers = [
             1 => new IriOfferIdentifier(
@@ -194,7 +193,7 @@ class BulkLabelCommandHandlerTest extends TestCase
     }
 
 
-    private function expectEventAndPlaceToBeLabelledWith(LegacyLabel $label): void
+    private function expectEventAndPlaceToBeLabelledWith(Label $label): void
     {
         $this->commandBus->expects($this->exactly(2))
             ->method('dispatch')

--- a/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
+++ b/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\Events\LabelAdded;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
@@ -87,7 +87,7 @@ final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
         $this->scenario
             ->withAggregateId($id)
             ->given([$this->eventCreated($id)])
-            ->when(new AddLabel($id, new Label('foo', false)))
+            ->when(new AddLabel($id, new LegacyLabel('foo', false)))
             ->then([new LabelAdded($id, 'foo', true)]);
     }
 
@@ -109,9 +109,9 @@ final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
         $this->scenario
             ->withAggregateId($id)
             ->given([$this->eventCreated($id)])
-            ->when(new AddLabel($id, new Label('visible', true)))
+            ->when(new AddLabel($id, new LegacyLabel('visible', true)))
             ->then([new LabelAdded($id, 'visible', true)])
-            ->when(new AddLabel($id, new Label('hidden', false)))
+            ->when(new AddLabel($id, new LegacyLabel('hidden', false)))
             ->then([new LabelAdded($id, 'hidden', false)]);
     }
 

--- a/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
+++ b/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Event\Events\EventCreated;
 use CultuurNet\UDB3\Event\Events\LabelAdded;
 use CultuurNet\UDB3\Event\EventType;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;

--- a/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
+++ b/tests/Offer/CommandHandlers/AddLabelHandlerTest.php
@@ -18,11 +18,13 @@ use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Label\LabelServiceInterface;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\Entity;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\OfferRepository;
 use CultuurNet\UDB3\Place\PlaceRepository;
@@ -80,14 +82,14 @@ final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
 
         $this->labelService
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('foo'), false);
+            ->with(new LegacyLabelName('foo'), false);
 
         $id = '4c6d4bb8-702b-49f1-b0ca-e51eb09a1c19';
 
         $this->scenario
             ->withAggregateId($id)
             ->given([$this->eventCreated($id)])
-            ->when(new AddLabel($id, new LegacyLabel('foo', false)))
+            ->when(new AddLabel($id, new Label(new LabelName('foo'), false)))
             ->then([new LabelAdded($id, 'foo', true)]);
     }
 
@@ -98,20 +100,20 @@ final class AddLabelHandlerTest extends CommandHandlerScenarioTestCase
     {
         $this->labelService->expects($this->at(0))
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('visible'), true);
+            ->with(new LegacyLabelName('visible'), true);
 
         $this->labelService->expects($this->at(1))
             ->method('createLabelAggregateIfNew')
-            ->with(new LabelName('hidden'), false);
+            ->with(new LegacyLabelName('hidden'), false);
 
         $id = '4c6d4bb8-702b-49f1-b0ca-e51eb09a1c19';
 
         $this->scenario
             ->withAggregateId($id)
             ->given([$this->eventCreated($id)])
-            ->when(new AddLabel($id, new LegacyLabel('visible', true)))
+            ->when(new AddLabel($id, new Label(new LabelName('visible'), true)))
             ->then([new LabelAdded($id, 'visible', true)])
-            ->when(new AddLabel($id, new LegacyLabel('hidden', false)))
+            ->when(new AddLabel($id, new Label(new LabelName('hidden'), false)))
             ->then([new LabelAdded($id, 'hidden', false)]);
     }
 

--- a/tests/Offer/Commands/AbstractLabelCommandTest.php
+++ b/tests/Offer/Commands/AbstractLabelCommandTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;

--- a/tests/Offer/Commands/AbstractLabelCommandTest.php
+++ b/tests/Offer/Commands/AbstractLabelCommandTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Role\ValueObjects\Permission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +31,7 @@ class AbstractLabelCommandTest extends TestCase
     public function setUp(): void
     {
         $this->itemId = 'Foo';
-        $this->label = new Label('LabelTest');
+        $this->label = new Label(new LabelName('LabelTest'));
 
         $this->labelCommand = $this->getMockForAbstractClass(
             AbstractLabelCommand::class,
@@ -43,7 +45,7 @@ class AbstractLabelCommandTest extends TestCase
     public function it_can_return_its_properties(): void
     {
         $label = $this->labelCommand->getLabel();
-        $expectedLabel = new Label('LabelTest');
+        $expectedLabel = new LegacyLabel('LabelTest');
 
         $this->assertEquals($expectedLabel, $label);
 

--- a/tests/Offer/Commands/AbstractLabelCommandTest.php
+++ b/tests/Offer/Commands/AbstractLabelCommandTest.php
@@ -45,7 +45,7 @@ class AbstractLabelCommandTest extends TestCase
     public function it_can_return_its_properties(): void
     {
         $label = $this->labelCommand->getLabel();
-        $expectedLabel = new LegacyLabel('LabelTest');
+        $expectedLabel = new Label(new LabelName('LabelTest'));
 
         $this->assertEquals($expectedLabel, $label);
 

--- a/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
@@ -6,7 +6,9 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
@@ -69,7 +71,7 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
                         OfferType::event()
                     )
                 ),
-            new Label('foo')
+            new Label(new LabelName( 'foo'))
         );
 
         $actual = $this->deserializer->deserialize($json);

--- a/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleJSONDeserializerTest.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\DeserializerInterface;
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
@@ -71,7 +70,7 @@ class AddLabelToMultipleJSONDeserializerTest extends TestCase
                         OfferType::event()
                     )
                 ),
-            new Label(new LabelName( 'foo'))
+            new Label(new LabelName('foo'))
         );
 
         $actual = $this->deserializer->deserialize($json);

--- a/tests/Offer/Commands/AddLabelToMultipleTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;

--- a/tests/Offer/Commands/AddLabelToMultipleTest.php
+++ b/tests/Offer/Commands/AddLabelToMultipleTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Web\Url;
 use CultuurNet\UDB3\Offer\IriOfferIdentifier;
 use CultuurNet\UDB3\Offer\OfferIdentifierCollection;
@@ -23,10 +25,7 @@ class AddLabelToMultipleTest extends TestCase
      */
     protected $offerIdentifiers;
 
-    /**
-     * @var Label
-     */
-    protected $label;
+    protected Label $label;
 
     public function setUp()
     {
@@ -50,7 +49,7 @@ class AddLabelToMultipleTest extends TestCase
             ]
         );
 
-        $this->label = new Label('testlabel');
+        $this->label = new Label(new LabelName('testlabel'));
 
         $this->labelMultiple = new AddLabelToMultiple(
             $this->offerIdentifiers,

--- a/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;

--- a/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryJSONDeserializerTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Offer\Commands;
 
 use CultuurNet\UDB3\Deserializer\MissingValueException;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 
@@ -26,7 +28,7 @@ class AddLabelToQueryJSONDeserializerTest extends TestCase
      */
     public function it_can_deserialize_a_valid_add_label_to_query_command()
     {
-        $expectedLabel = new Label('foo');
+        $expectedLabel = new Label(new LabelName('foo'));
         $expectedQuery = 'city:leuven';
 
         $json = new StringLiteral('{"label":"foo", "query":"city:leuven"}');

--- a/tests/Offer/Commands/AddLabelToQueryTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;

--- a/tests/Offer/Commands/AddLabelToQueryTest.php
+++ b/tests/Offer/Commands/AddLabelToQueryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\Commands;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;
 
 class AddLabelToQueryTest extends TestCase
@@ -18,7 +20,7 @@ class AddLabelToQueryTest extends TestCase
     {
         $this->labelQuery = new AddLabelToQuery(
             'query',
-            new Label('testlabel')
+            new Label(new LabelName('testlabel'))
         );
     }
 
@@ -28,7 +30,7 @@ class AddLabelToQueryTest extends TestCase
     public function it_returns_the_correct_property_values()
     {
         $expectedQuery = 'query';
-        $expectedLabel = new Label('testlabel');
+        $expectedLabel = new Label(new LabelName('testlabel'));
 
         $this->assertEquals($expectedQuery, $this->labelQuery->getQuery());
         $this->assertEquals($expectedLabel, $this->labelQuery->getLabel());

--- a/tests/Security/LabelCommandBusSecurityTest.php
+++ b/tests/Security/LabelCommandBusSecurityTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
@@ -58,7 +57,7 @@ class LabelCommandBusSecurityTest extends TestCase
             $this->labelReadRepository
         );
 
-        $this->addLabel = new AddLabel('6a475eb2-04dd-41e3-95d1-225a1cd511f1', new Label(new LabelName( 'bibliotheekweek')));
+        $this->addLabel = new AddLabel('6a475eb2-04dd-41e3-95d1-225a1cd511f1', new Label(new LabelName('bibliotheekweek')));
     }
 
     /**

--- a/tests/Security/LabelCommandBusSecurityTest.php
+++ b/tests/Security/LabelCommandBusSecurityTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Security;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
@@ -56,7 +58,7 @@ class LabelCommandBusSecurityTest extends TestCase
             $this->labelReadRepository
         );
 
-        $this->addLabel = new AddLabel('6a475eb2-04dd-41e3-95d1-225a1cd511f1', new Label('bibliotheekweek'));
+        $this->addLabel = new AddLabel('6a475eb2-04dd-41e3-95d1-225a1cd511f1', new Label(new LabelName( 'bibliotheekweek')));
     }
 
     /**

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\UiTPAS\Event;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -8,6 +8,8 @@ use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
@@ -41,7 +43,7 @@ class EventProcessManagerTest extends TestCase
     private $eventProcessManager;
 
     /**
-     * @var LegacyLabel[]
+     * @var Label[]
      */
     private $uitpasLabels;
 
@@ -73,16 +75,16 @@ class EventProcessManagerTest extends TestCase
         );
 
         $this->uitpasLabels = [
-            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new LegacyLabel('Paspartoe'),
-            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new LegacyLabel('UiTPAS'),
-            'f23ccb75-190a-4814-945e-c95e83101cc5' => new LegacyLabel('UiTPAS Gent'),
-            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new LegacyLabel('UiTPAS Oostende'),
-            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new LegacyLabel('UiTPAS regio Aalst'),
-            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new LegacyLabel('UiTPAS Dender'),
-            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new LegacyLabel('UiTPAS Zuidwest'),
-            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new LegacyLabel('UiTPAS Mechelen'),
-            '47256d4c-47e8-4046-b9bb-acb166920f76' => new LegacyLabel('UiTPAS Kempen'),
-            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new LegacyLabel('UiTPAS Maasmechelen'),
+            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label(new LabelName('Paspartoe')),
+            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label(new LabelName('UiTPAS')),
+            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label(new LabelName('UiTPAS Gent')),
+            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label(new LabelName('UiTPAS Oostende')),
+            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label(new LabelName('UiTPAS regio Aalst')),
+            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label(new LabelName('UiTPAS Dender')),
+            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label(new LabelName('UiTPAS Zuidwest')),
+            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label(new LabelName('UiTPAS Mechelen')),
+            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label(new LabelName('UiTPAS Kempen')),
+            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' =>new Label(new LabelName('UiTPAS Maasmechelen')),
         ];
 
         $this->uitpasLabelsRepository->expects($this->any())
@@ -188,9 +190,9 @@ class EventProcessManagerTest extends TestCase
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Mechelen'),
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Kempen'),
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Maasmechelen'),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('Paspartoe', true)),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('UiTPAS Gent', true)),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('UiTPAS Oostende', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label(new LabelName('Paspartoe'), true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label(new LabelName('UiTPAS Gent'), true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label(new LabelName('UiTPAS Oostende'), true)),
         ];
 
         $this->eventProcessManager->handle($domainMessage);

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UiTPAS\Event;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Offer\Commands\AddLabel;
 use CultuurNet\UDB3\Offer\Commands\RemoveLabel;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
@@ -41,7 +41,7 @@ class EventProcessManagerTest extends TestCase
     private $eventProcessManager;
 
     /**
-     * @var Label[]
+     * @var LegacyLabel[]
      */
     private $uitpasLabels;
 
@@ -73,16 +73,16 @@ class EventProcessManagerTest extends TestCase
         );
 
         $this->uitpasLabels = [
-            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label('Paspartoe'),
-            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label('UiTPAS'),
-            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label('UiTPAS Gent'),
-            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label('UiTPAS Oostende'),
-            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label('UiTPAS regio Aalst'),
-            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label('UiTPAS Dender'),
-            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label('UiTPAS Zuidwest'),
-            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label('UiTPAS Mechelen'),
-            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label('UiTPAS Kempen'),
-            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new Label('UiTPAS Maasmechelen'),
+            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new LegacyLabel('Paspartoe'),
+            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new LegacyLabel('UiTPAS'),
+            'f23ccb75-190a-4814-945e-c95e83101cc5' => new LegacyLabel('UiTPAS Gent'),
+            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new LegacyLabel('UiTPAS Oostende'),
+            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new LegacyLabel('UiTPAS regio Aalst'),
+            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new LegacyLabel('UiTPAS Dender'),
+            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new LegacyLabel('UiTPAS Zuidwest'),
+            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new LegacyLabel('UiTPAS Mechelen'),
+            '47256d4c-47e8-4046-b9bb-acb166920f76' => new LegacyLabel('UiTPAS Kempen'),
+            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new LegacyLabel('UiTPAS Maasmechelen'),
         ];
 
         $this->uitpasLabelsRepository->expects($this->any())
@@ -188,9 +188,9 @@ class EventProcessManagerTest extends TestCase
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Mechelen'),
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Kempen'),
             new RemoveLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', 'UiTPAS Maasmechelen'),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('Paspartoe', true)),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Gent', true)),
-            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new Label('UiTPAS Oostende', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('Paspartoe', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('UiTPAS Gent', true)),
+            new AddLabel('cbee7413-ac1e-4dfb-8004-34767eafb8b7', new LegacyLabel('UiTPAS Oostende', true)),
         ];
 
         $this->eventProcessManager->handle($domainMessage);

--- a/tests/UiTPAS/Label/InMemoryUiTPASLabelsRepositoryTest.php
+++ b/tests/UiTPAS/Label/InMemoryUiTPASLabelsRepositoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\UiTPAS\Label;
 
-use CultuurNet\UDB3\Label;
+use CultuurNet\UDB3\Label as LegacyLabel;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\UiTPAS\Label\InMemoryUiTPASLabelsRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -30,16 +32,16 @@ final class InMemoryUiTPASLabelsRepositoryTest extends TestCase
         ];
 
         $expected = [
-            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label('Paspartoe'),
-            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label('UiTPAS'),
-            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label('UiTPAS Gent'),
-            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label('UiTPAS Oostende'),
-            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label('UiTPAS regio Aalst'),
-            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label('UiTPAS Dender'),
-            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label('UiTPAS Zuidwest'),
-            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label('UiTPAS Mechelen'),
-            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label('UiTPAS Kempen'),
-            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new Label('UiTPAS Maasmechelen'),
+            'c73d78b7-95a7-45b3-bde5-5b2ec7b13afa' => new Label(new LabelName('Paspartoe')),
+            'ebd91df0-8ed7-4522-8401-ef5508ad1426' => new Label(new LabelName('UiTPAS')),
+            'f23ccb75-190a-4814-945e-c95e83101cc5' => new Label(new LabelName('UiTPAS Gent')),
+            '98ce6fbc-fb68-4efc-b8c7-95763cb967dd' => new Label(new LabelName('UiTPAS Oostende')),
+            '68f849c0-bf55-4f73-b0f4-e0683bf0c807' => new Label(new LabelName('UiTPAS regio Aalst')),
+            'cd6200cc-5b9d-43fd-9638-f6cc27f1c9b8' => new Label(new LabelName('UiTPAS Dender')),
+            'd9cf96b6-1256-4760-b66b-1c31152d7db4' => new Label(new LabelName('UiTPAS Zuidwest')),
+            'aaf3a58e-2aac-45b3-a9e9-3f3ebf467681' => new Label(new LabelName('UiTPAS Mechelen')),
+            '47256d4c-47e8-4046-b9bb-acb166920f76' => new Label(new LabelName('UiTPAS Kempen')),
+            '54b5273e-5e0b-4c1e-b33f-93eca55eb472' => new Label(new LabelName('UiTPAS Maasmechelen')),
         ];
 
         $repository = InMemoryUiTPASLabelsRepository::fromStrings($given);

--- a/tests/UiTPAS/Label/InMemoryUiTPASLabelsRepositoryTest.php
+++ b/tests/UiTPAS/Label/InMemoryUiTPASLabelsRepositoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\UiTPAS\Label;
 
-use CultuurNet\UDB3\Label as LegacyLabel;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use CultuurNet\UDB3\UiTPAS\Label\InMemoryUiTPASLabelsRepository;


### PR DESCRIPTION
### Changed

- Make `AddLabel` use the new VO `Label` instead the legacy one.
- Make `app/Console/ImportOfferAutoClassificationLabels`, `Curators/LabelFactory`, `Http/Offer/EditOfferRestController`, `LabelJSONDeserializer`, `Offer/BulkLabelCommandHandler`,`Offer/Commands/AddLabelToMultiple`, `Offer/Commands/AddLabelToMultipleJSONDeserializer`, `Offer/Commands/AddLabelToQuery`, `Offer/Commands/AddLabelToQueryJSONDeserializer`, `UiTPAS/Event/EventProcessManager`, `UiTPAS/Label/InMemoryUiTPASLabelsRepository`  use the  new VO `Label` instead the legacy one.

- Updated tests after refactoring

---
Ticket: https://jira.uitdatabank.be/browse/III-4786
