### PR TITLE
III-4790 Keep `availableTo` on start date for lessenreeks

### DIFF
--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -341,24 +341,8 @@ class EventLDProjector extends OfferLDProjector implements
         unset($eventJsonLD->labels);
         unset($eventJsonLD->hiddenLabels);
 
-        $eventType = null;
-        foreach ($eventJsonLD->terms as $term) {
-            if ($term->domain === 'eventtype') {
-                $typeId = new StringLiteral($term->id);
-                // This is a workaround to allow copies of events that
-                // have a placeType instead of an eventType.
-                // These events could also be cleaned up in the future
-                // @see https://jira.uitdatabank.be/browse/III-3926
-                try {
-                    $eventType = $this->eventTypeResolver->byId($typeId);
-                } catch (\Exception $exception) {
-                    $eventType = $this->placeTypeResolver->byId($typeId);
-                }
-            }
-        }
-
         // Set available to and from.
-        $availableTo = AvailableTo::createFromCalendar($eventCopied->getCalendar(), $eventType);
+        $availableTo = AvailableTo::createFromCalendar($eventCopied->getCalendar(), $this->getEventType($eventJsonLD));
         $eventJsonLD->availableTo = (string) $availableTo;
         unset($eventJsonLD->availableFrom);
 

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -71,6 +71,7 @@ use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Model\ValueObject\Online\AttendanceMode;
 use CultuurNet\UDB3\Offer\AvailableTo;
+use CultuurNet\UDB3\Offer\Events\AbstractCalendarUpdated;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferLDProjector;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferUpdate;
@@ -362,6 +363,18 @@ class EventLDProjector extends OfferLDProjector implements
         return $document->withBody($jsonLD);
     }
 
+    protected function applyCalendarUpdated(AbstractCalendarUpdated $calendarUpdated): JsonDocument
+    {
+        $document = $this->loadDocumentFromRepository($calendarUpdated)
+            ->apply(OfferUpdate::calendar($calendarUpdated->getCalendar()));
+
+        $offerLd = $document->getBody();
+
+        $availableTo = AvailableTo::createFromCalendar($calendarUpdated->getCalendar(), $this->getEventType($offerLd));
+        $offerLd->availableTo = (string)$availableTo;
+
+        return $document->withBody($offerLd);
+    }
 
     private function getEventType(\stdClass $eventJsonLD): ?EventType
     {

--- a/src/Offer/AvailableTo.php
+++ b/src/Offer/AvailableTo.php
@@ -17,10 +17,7 @@ use DateTimeInterface;
  */
 class AvailableTo
 {
-    /**
-     * @var DateTimeInterface
-     */
-    private $availableTo;
+    private DateTimeInterface $availableTo;
 
     private function __construct(DateTimeInterface $availableTo)
     {

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -1488,6 +1488,54 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $this->assertEquals($expectedTerms, $updatedItem->terms);
     }
 
+
+    /**
+     * @test
+     */
+    public function it_keeps_start_date_for_lessen_reeks_on_calendar_updated(): void
+    {
+        $eventId = '1a08516e-aba4-47f0-887e-df37b61a1e8d';
+
+        $lessenReeksEvent = new JsonDocument(
+            $eventId,
+            Json::encode([
+                '@id' => $eventId,
+                '@type' => 'event',
+                'terms' => [
+                    (object) [
+                        'id' => '1.51.12.0.0',
+                        'label' => 'Omnisport en andere',
+                        'domain' => 'theme',
+                    ],
+                    (object) [
+                        'id' => '0.3.1.0.0',
+                        'label' => 'Lessenreeks',
+                        'domain' => 'eventtype',
+                    ],
+                ],
+            ])
+        );
+        $this->documentRepository->save($lessenReeksEvent);
+
+        $startDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T12:00:00+01:00');
+        $endDate = DateTimeImmutable::createFromFormat(\DATE_ATOM, '2020-01-01T12:00:00+01:00');
+        $calendarUpdated = new CalendarUpdated(
+            $eventId,
+            new Calendar(
+                CalendarType::SINGLE(),
+                $startDate,
+                $endDate,
+                [
+                    new Timestamp($startDate, $endDate),
+                ]
+            )
+        );
+
+        $updatedItem = $this->project($calendarUpdated, $eventId);
+
+        $this->assertEquals($startDate->format(DATE_ATOM), $updatedItem->availableTo);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
### Changed
- Made sure to Keep `availableTo` on the start date for lessenreeks

---
Ticket: https://jira.uitdatabank.be/browse/III-4790
