### PR TITLE
III-4786 get rid legacy label in aggregate Commands

### DIFF
--- a/src/Label/CommandHandler.php
+++ b/src/Label/CommandHandler.php
@@ -12,6 +12,7 @@ use CultuurNet\UDB3\Label\Commands\MakeInvisible;
 use CultuurNet\UDB3\Label\Commands\MakePrivate;
 use CultuurNet\UDB3\Label\Commands\MakePublic;
 use CultuurNet\UDB3\Label\Commands\MakeVisible;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
 class CommandHandler extends AbstractCommandHandler

--- a/src/Label/CommandHandler.php
+++ b/src/Label/CommandHandler.php
@@ -31,7 +31,7 @@ class CommandHandler extends AbstractCommandHandler
     {
         $label = Label::create(
             $create->getUuid(),
-            $create->getName(),
+            new LegacyLabelName($create->getName()->toString()),
             $create->getVisibility(),
             $create->getPrivacy()
         );
@@ -43,7 +43,7 @@ class CommandHandler extends AbstractCommandHandler
     {
         $label = Label::createCopy(
             $createCopy->getUuid(),
-            $createCopy->getName(),
+            new LegacyLabelName($createCopy->getName()->toString()),
             $createCopy->getVisibility(),
             $createCopy->getPrivacy(),
             $createCopy->getParentUuid()

--- a/src/Label/CommandHandler.php
+++ b/src/Label/CommandHandler.php
@@ -17,10 +17,7 @@ use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
 class CommandHandler extends AbstractCommandHandler
 {
-    /**
-     * @var Repository
-     */
-    private $repository;
+    private Repository $repository;
 
     public function __construct(
         Repository $repository
@@ -28,7 +25,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->repository = $repository;
     }
 
-    public function handleCreate(Create $create)
+    public function handleCreate(Create $create): void
     {
         $label = Label::create(
             $create->getUuid(),
@@ -40,7 +37,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->save($label);
     }
 
-    public function handleCreateCopy(CreateCopy $createCopy)
+    public function handleCreateCopy(CreateCopy $createCopy): void
     {
         $label = Label::createCopy(
             $createCopy->getUuid(),
@@ -53,7 +50,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->save($label);
     }
 
-    public function handleMakeVisible(MakeVisible $makeVisible)
+    public function handleMakeVisible(MakeVisible $makeVisible): void
     {
         $label = $this->load($makeVisible->getUuid());
 
@@ -62,7 +59,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->save($label);
     }
 
-    public function handleMakeInvisible(MakeInvisible $makeInvisible)
+    public function handleMakeInvisible(MakeInvisible $makeInvisible): void
     {
         $label = $this->load($makeInvisible->getUuid());
 
@@ -71,7 +68,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->save($label);
     }
 
-    public function handleMakePublic(MakePublic $makePublic)
+    public function handleMakePublic(MakePublic $makePublic): void
     {
         $label = $this->load($makePublic->getUuid());
 
@@ -80,7 +77,7 @@ class CommandHandler extends AbstractCommandHandler
         $this->save($label);
     }
 
-    public function handleMakePrivate(MakePrivate $makePrivate)
+    public function handleMakePrivate(MakePrivate $makePrivate): void
     {
         $label = $this->load($makePrivate->getUuid());
 
@@ -97,7 +94,7 @@ class CommandHandler extends AbstractCommandHandler
         return $label;
     }
 
-    private function save(Label $label)
+    private function save(Label $label): void
     {
         $this->repository->save($label);
     }

--- a/src/Label/Commands/Create.php
+++ b/src/Label/Commands/Create.php
@@ -13,19 +13,10 @@ class Create extends AbstractCommand
 {
     private LabelName $name;
 
-    /**
-     * @var string
-     */
-    private $visibility;
+    private string $visibility;
 
-    /**
-     * @var string
-     */
-    private $privacy;
+    private string $privacy;
 
-    /**
-     * Create constructor.
-     */
     public function __construct(
         UUID $uuid,
         LabelName $name,
@@ -47,18 +38,12 @@ class Create extends AbstractCommand
         return $this->name;
     }
 
-    /**
-     * @return Visibility
-     */
-    public function getVisibility()
+    public function getVisibility(): Visibility
     {
         return new Visibility($this->visibility);
     }
 
-    /**
-     * @return Privacy
-     */
-    public function getPrivacy()
+    public function getPrivacy(): Privacy
     {
         return new Privacy($this->privacy);
     }

--- a/src/Label/Commands/Create.php
+++ b/src/Label/Commands/Create.php
@@ -6,15 +6,12 @@ namespace CultuurNet\UDB3\Label\Commands;
 
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class Create extends AbstractCommand
 {
-    /**
-     * @var LabelName
-     */
-    private $name;
+    private LabelName $name;
 
     /**
      * @var string
@@ -45,10 +42,7 @@ class Create extends AbstractCommand
         $this->privacy = $privacy->toString();
     }
 
-    /**
-     * @return LabelName
-     */
-    public function getName()
+    public function getName(): LabelName
     {
         return $this->name;
     }

--- a/src/Label/Commands/CreateCopy.php
+++ b/src/Label/Commands/CreateCopy.php
@@ -6,8 +6,8 @@ namespace CultuurNet\UDB3\Label\Commands;
 
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class CreateCopy extends Create
 {

--- a/src/Label/Commands/CreateCopy.php
+++ b/src/Label/Commands/CreateCopy.php
@@ -11,14 +11,8 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class CreateCopy extends Create
 {
-    /**
-     * @var UUID
-     */
-    private $parentUuid;
+    private UUID $parentUuid;
 
-    /**
-     * CreateCopy constructor.
-     */
     public function __construct(
         UUID $uuid,
         LabelName $name,
@@ -31,10 +25,7 @@ class CreateCopy extends Create
         $this->parentUuid = $parentUuid;
     }
 
-    /**
-     * @return UUID
-     */
-    public function getParentUuid()
+    public function getParentUuid(): UUID
     {
         return $this->parentUuid;
     }

--- a/src/Label/Services/WriteService.php
+++ b/src/Label/Services/WriteService.php
@@ -19,15 +19,9 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class WriteService implements WriteServiceInterface
 {
-    /**
-     * @var CommandBus
-     */
-    private $commandBus;
+    private CommandBus $commandBus;
 
-    /**
-     * @var UuidGeneratorInterface
-     */
-    private $uuidGenerator;
+    private UuidGeneratorInterface $uuidGenerator;
 
     public function __construct(
         CommandBus $commandBus,

--- a/src/Label/Services/WriteService.php
+++ b/src/Label/Services/WriteService.php
@@ -13,8 +13,9 @@ use CultuurNet\UDB3\Label\Commands\MakePublic;
 use CultuurNet\UDB3\Label\Commands\MakeVisible;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class WriteService implements WriteServiceInterface
 {
@@ -37,7 +38,7 @@ class WriteService implements WriteServiceInterface
     }
 
     public function create(
-        LabelName $name,
+        LegacyLabelName $name,
         Visibility $visibility,
         Privacy $privacy
     ): UUID {
@@ -45,7 +46,7 @@ class WriteService implements WriteServiceInterface
 
         $command = new Create(
             $uuid,
-            $name,
+            new LabelName($name->toNative()),
             $visibility,
             $privacy
         );

--- a/tests/Label/CommandHandlerTest.php
+++ b/tests/Label/CommandHandlerTest.php
@@ -21,8 +21,9 @@ use CultuurNet\UDB3\Label\Events\MadePublic;
 use CultuurNet\UDB3\Label\Events\MadeVisible;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class CommandHandlerTest extends CommandHandlerScenarioTestCase
 {
@@ -36,10 +37,9 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
      */
     private $extraUuid;
 
-    /**
-     * @var LabelName
-     */
-    private $name;
+    private LabelName $name;
+
+    private LegacyLabelName $legacyName;
 
     /**
      * @var Visibility
@@ -71,20 +71,21 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
         $this->uuid = new UUID('0f4c288e-dec9-4a2e-bddd-94250acfcfd2');
         $this->extraUuid = new UUID('04568db8-a137-44d8-a7eb-d7a00ae545bf');
         $this->name = new LabelName('labelName');
+        $this->legacyName = new LegacyLabelName('labelName');
         $this->visibility = Visibility::INVISIBLE();
         $this->privacy = Privacy::PRIVACY_PRIVATE();
         $this->parentUuid = new UUID('f4e5608b-348d-4321-86f7-567891bf33b7');
 
         $this->created = new Created(
             $this->uuid,
-            $this->name,
+            $this->legacyName,
             $this->visibility,
             $this->privacy
         );
 
         $this->copyCreated = new CopyCreated(
             $this->uuid,
-            $this->name,
+            $this->legacyName,
             $this->visibility,
             $this->privacy,
             $this->parentUuid
@@ -150,7 +151,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
             ->withAggregateId($this->uuid->toString())
             ->given([$this->created])
             ->when(new MakeVisible($this->uuid))
-            ->then([new MadeVisible($this->uuid, $this->name)]);
+            ->then([new MadeVisible($this->uuid, $this->legacyName)]);
     }
 
     /**
@@ -160,7 +161,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
-            ->given([$this->created, new MadeVisible($this->uuid, $this->name)])
+            ->given([$this->created, new MadeVisible($this->uuid, $this->legacyName)])
             ->when(new MakeVisible($this->uuid))
             ->then([]);
     }
@@ -172,9 +173,9 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
-            ->given([$this->created, new MadeVisible($this->uuid, $this->name)])
+            ->given([$this->created, new MadeVisible($this->uuid, $this->legacyName)])
             ->when(new MakeInvisible($this->uuid))
-            ->then([new MadeInvisible($this->uuid, $this->name)]);
+            ->then([new MadeInvisible($this->uuid, $this->legacyName)]);
     }
 
     /**
@@ -198,7 +199,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
             ->withAggregateId($this->uuid->toString())
             ->given([$this->created])
             ->when(new MakePublic($this->uuid))
-            ->then([new MadePublic($this->uuid, $this->name)]);
+            ->then([new MadePublic($this->uuid, $this->legacyName)]);
     }
 
     /**
@@ -208,7 +209,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
-            ->given([$this->created, new MadePublic($this->uuid, $this->name)])
+            ->given([$this->created, new MadePublic($this->uuid, $this->legacyName)])
             ->when(new MakePublic($this->uuid))
             ->then([]);
     }
@@ -220,9 +221,9 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
-            ->given([$this->created, new MadePublic($this->uuid, $this->name)])
+            ->given([$this->created, new MadePublic($this->uuid, $this->legacyName)])
             ->when(new MakePrivate($this->uuid))
-            ->then([new MadePrivate($this->uuid, $this->name)]);
+            ->then([new MadePrivate($this->uuid, $this->legacyName)]);
     }
 
     /**

--- a/tests/Label/CommandHandlerTest.php
+++ b/tests/Label/CommandHandlerTest.php
@@ -27,49 +27,25 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 
 class CommandHandlerTest extends CommandHandlerScenarioTestCase
 {
-    /**
-     * @var UUID
-     */
-    private $uuid;
-
-    /**
-     * @var UUID
-     */
-    private $extraUuid;
+    private UUID $uuid;
 
     private LabelName $name;
 
     private LegacyLabelName $legacyName;
 
-    /**
-     * @var Visibility
-     */
-    private $visibility;
+    private Visibility $visibility;
 
-    /**
-     * @var Privacy
-     */
-    private $privacy;
+    private Privacy $privacy;
 
-    /**
-     * @var UUID
-     */
-    private $parentUuid;
+    private UUID $parentUuid;
 
-    /**
-     * @var Created
-     */
-    private $created;
+    private Created $created;
 
-    /**
-     * @var CopyCreated
-     */
-    private $copyCreated;
+    private CopyCreated $copyCreated;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->uuid = new UUID('0f4c288e-dec9-4a2e-bddd-94250acfcfd2');
-        $this->extraUuid = new UUID('04568db8-a137-44d8-a7eb-d7a00ae545bf');
         $this->name = new LabelName('labelName');
         $this->legacyName = new LegacyLabelName('labelName');
         $this->visibility = Visibility::INVISIBLE();
@@ -91,17 +67,13 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
             $this->parentUuid
         );
 
-        // Ensure all members are created before createCommandHandler is called.
         parent::setUp();
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function createCommandHandler(
         EventStore $eventStore,
         EventBus $eventBus
-    ) {
+    ): CommandHandler {
         return new CommandHandler(
             new LabelRepository($eventStore, $eventBus)
         );
@@ -110,7 +82,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_create()
+    public function it_handles_create(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -127,7 +99,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_create_copy()
+    public function it_handles_create_copy(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -145,7 +117,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_make_visible_when_invisible()
+    public function it_handles_make_visible_when_invisible(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -157,7 +129,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_does_not_handle_make_visible_when_already_visible()
+    public function it_does_not_handle_make_visible_when_already_visible(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -169,7 +141,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_make_invisible_when_visible()
+    public function it_handles_make_invisible_when_visible(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -181,7 +153,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_does_not_handle_make_invisible_when_already_invisible()
+    public function it_does_not_handle_make_invisible_when_already_invisible(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -193,7 +165,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_make_public_when_private()
+    public function it_handles_make_public_when_private(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -205,7 +177,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_does_not_handle_make_public_when_already_public()
+    public function it_does_not_handle_make_public_when_already_public(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -217,7 +189,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_handles_make_private_when_public()
+    public function it_handles_make_private_when_public(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())
@@ -229,7 +201,7 @@ class CommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
-    public function it_does_not_handle_make_private_when_already_private()
+    public function it_does_not_handle_make_private_when_already_private(): void
     {
         $this->scenario
             ->withAggregateId($this->uuid->toString())

--- a/tests/Label/Commands/CreateCopyTest.php
+++ b/tests/Label/Commands/CreateCopyTest.php
@@ -6,7 +6,7 @@ namespace CultuurNet\UDB3\Label\Commands;
 
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 
-class CreateCopyTest extends CreateTest
+final class CreateCopyTest extends CreateTest
 {
     /**
      * @var UUID
@@ -16,9 +16,9 @@ class CreateCopyTest extends CreateTest
     /**
      * @var CreateCopy
      */
-    protected $create;
+    protected Create $create;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -36,7 +36,7 @@ class CreateCopyTest extends CreateTest
     /**
      * @test
      */
-    public function it_stores_a_parent_uuid()
+    public function it_stores_a_parent_uuid(): void
     {
         $this->assertEquals($this->parentUuid, $this->create->getParentUuid());
     }
@@ -44,7 +44,7 @@ class CreateCopyTest extends CreateTest
     /**
      * @test
      */
-    public function it_can_serialize()
+    public function it_can_serialize(): void
     {
         $actualCreate = unserialize(serialize($this->create));
 

--- a/tests/Label/Commands/CreateTest.php
+++ b/tests/Label/Commands/CreateTest.php
@@ -6,8 +6,8 @@ namespace CultuurNet\UDB3\Label\Commands;
 
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\TestCase;
 
 class CreateTest extends TestCase
@@ -17,10 +17,7 @@ class CreateTest extends TestCase
      */
     protected $uuid;
 
-    /**
-     * @var LabelName
-     */
-    protected $name;
+    protected LabelName $name;
 
     /**
      * @var Visibility

--- a/tests/Label/Commands/CreateTest.php
+++ b/tests/Label/Commands/CreateTest.php
@@ -12,29 +12,17 @@ use PHPUnit\Framework\TestCase;
 
 class CreateTest extends TestCase
 {
-    /**
-     * @var UUID
-     */
-    protected $uuid;
+    protected UUID $uuid;
 
     protected LabelName $name;
 
-    /**
-     * @var Visibility
-     */
-    protected $visibility;
+    protected Visibility $visibility;
 
-    /**
-     * @var Privacy
-     */
-    protected $privacy;
+    protected Privacy $privacy;
 
-    /**
-     * @var Create
-     */
-    protected $create;
+    private Create $create;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('fec0c4d7-80e1-4713-98f9-4c436af6e650');
 
@@ -55,7 +43,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_extends_an_abstract_command()
+    public function it_extends_an_abstract_command(): void
     {
         $this->assertTrue(is_subclass_of(
             $this->create,
@@ -66,7 +54,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_uuid()
+    public function it_stores_a_uuid(): void
     {
         $this->assertEquals($this->uuid, $this->create->getUuid());
     }
@@ -74,7 +62,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_name()
+    public function it_stores_a_name(): void
     {
         $this->assertEquals($this->name, $this->create->getName());
     }
@@ -82,7 +70,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_visibility()
+    public function it_stores_a_visibility(): void
     {
         $this->assertEquals($this->visibility, $this->create->getVisibility());
     }
@@ -90,7 +78,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_privacy()
+    public function it_stores_a_privacy(): void
     {
         $this->assertEquals($this->privacy, $this->create->getPrivacy());
     }
@@ -98,7 +86,7 @@ class CreateTest extends TestCase
     /**
      * @test
      */
-    public function it_can_serialize()
+    public function it_can_serialize(): void
     {
         $actualCreate = unserialize(serialize($this->create));
 

--- a/tests/Label/Services/WriteServiceTest.php
+++ b/tests/Label/Services/WriteServiceTest.php
@@ -21,32 +21,18 @@ use PHPUnit\Framework\TestCase;
 
 class WriteServiceTest extends TestCase
 {
-    /**
-     * @var UUID
-     */
-    private $uuid;
+    private UUID $uuid;
 
-    /**
-     * @var Create
-     */
-    private $create;
+    private Create $create;
 
     /**
      * @var CommandBus|MockObject
      */
     private $commandBus;
 
-    /**
-     * @var UuidGeneratorInterface|MockObject
-     */
-    private $uuidGenerator;
+    private WriteService $writeService;
 
-    /**
-     * @var WriteService
-     */
-    private $writeService;
-
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uuid = new UUID('91a6cfb3-f556-48cd-91ef-b0675b827728');
 
@@ -59,20 +45,20 @@ class WriteServiceTest extends TestCase
 
         $this->commandBus = $this->createMock(CommandBus::class);
 
-        $this->uuidGenerator = $this->createMock(UuidGeneratorInterface::class);
-        $this->uuidGenerator->method('generate')
+        $uuidGenerator = $this->createMock(UuidGeneratorInterface::class);
+        $uuidGenerator->method('generate')
             ->willReturn($this->create->getUuid()->toString());
 
         $this->writeService = new WriteService(
             $this->commandBus,
-            $this->uuidGenerator
+            $uuidGenerator
         );
     }
 
     /**
      * @test
      */
-    public function it_calls_dispatch_with_create_command_for_create()
+    public function it_calls_dispatch_with_create_command_for_create(): void
     {
         $this->commandBus->expects($this->once())
             ->method('dispatch')
@@ -90,7 +76,7 @@ class WriteServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispatch_with_make_visible_command_for_make_visible()
+    public function it_calls_dispatch_with_make_visible_command_for_make_visible(): void
     {
         $this->commandBus->expects($this->once())
             ->method('dispatch')
@@ -102,7 +88,7 @@ class WriteServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispatch_with_make_invisible_command_for_make_invisible()
+    public function it_calls_dispatch_with_make_invisible_command_for_make_invisible(): void
     {
         $this->commandBus->expects($this->once())
             ->method('dispatch')
@@ -114,7 +100,7 @@ class WriteServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispatch_with_make_public_command_for_make_public()
+    public function it_calls_dispatch_with_make_public_command_for_make_public(): void
     {
         $this->commandBus->expects($this->once())
             ->method('dispatch')
@@ -126,7 +112,7 @@ class WriteServiceTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispatch_with_make_private_command_for_make_private()
+    public function it_calls_dispatch_with_make_private_command_for_make_private(): void
     {
         $this->commandBus->expects($this->once())
             ->method('dispatch')

--- a/tests/Label/Services/WriteServiceTest.php
+++ b/tests/Label/Services/WriteServiceTest.php
@@ -13,8 +13,9 @@ use CultuurNet\UDB3\Label\Commands\MakePublic;
 use CultuurNet\UDB3\Label\Commands\MakeVisible;
 use CultuurNet\UDB3\Label\ValueObjects\Privacy;
 use CultuurNet\UDB3\Label\ValueObjects\Visibility;
-use CultuurNet\UDB3\Label\ValueObjects\LabelName;
+use CultuurNet\UDB3\Label\ValueObjects\LabelName as LegacyLabelName;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
+use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -78,7 +79,7 @@ class WriteServiceTest extends TestCase
             ->with($this->create);
 
         $uuid = $this->writeService->create(
-            $this->create->getName(),
+            new LegacyLabelName($this->create->getName()->toString()),
             $this->create->getVisibility(),
             $this->create->getPrivacy()
         );


### PR DESCRIPTION
### Changed

- Changed the legacy `LabelName` in the Commands of the `Label` aggregate

---
Ticket: https://jira.uitdatabank.be/browse/III-47896
