### PR TITLE
Add allow plugins on composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,10 @@
     }
   },
   "config": {
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true,
+      "icanhazstring/composer-unused": true
+    },
     "preferred-install": {
       "cultuurnet/*": "source",
       "2dotstwice/*": "source",


### PR DESCRIPTION
### Added

- Added `allow-plugins` section in `composer.json
- Added `kylekatarnls/update-helper`, `icanhazstring/composer-unused` to `allow-plugins`

---
Ticket: https://getcomposer.org/doc/06-config.md#allow-plugins
