### PR TITLE
III-3919 Tweak `RetryingCommandBus`

### DIFF
--- a/app/CommandHandling/RetriedCommandFailed.php
+++ b/app/CommandHandling/RetriedCommandFailed.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\CommandHandling;
+
+use RuntimeException;
+
+final class RetriedCommandFailed extends RuntimeException
+{
+}

--- a/app/CommandHandling/RetryingCommandBus.php
+++ b/app/CommandHandling/RetryingCommandBus.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\EventSourcing\DBAL\DBALEventStoreException;
 
 class RetryingCommandBus extends CommandBusDecoratorBase
 {
-    public const MAX_RETRIES = 3;
+    public const MAX_RETRIES = 15;
 
     public function dispatch($command): void
     {

--- a/app/CommandHandling/RetryingCommandBus.php
+++ b/app/CommandHandling/RetryingCommandBus.php
@@ -25,6 +25,14 @@ class RetryingCommandBus extends CommandBusDecoratorBase
             $attempt++;
         } while ($attempt <= self::MAX_RETRIES);
 
-        throw $lastException;
+        throw new RetriedCommandFailed(
+            sprintf(
+                'Command %s failed due to a DBAL event store exception after %s retries',
+                get_class($command),
+                $attempt
+            ),
+            0,
+            $lastException
+        );
     }
 }

--- a/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
+++ b/tests/Broadway/CommandHandling/RetryingCommandBusTest.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Broadway\CommandHandling;
 use Broadway\CommandHandling\CommandBus;
 use Broadway\CommandHandling\CommandHandler;
 use CultuurNet\UDB3\EventSourcing\DBAL\DBALEventStoreException;
+use CultuurNet\UDB3\Silex\CommandHandling\RetriedCommandFailed;
 use CultuurNet\UDB3\Silex\CommandHandling\RetryingCommandBus;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +42,7 @@ class RetryingCommandBusTest extends TestCase
             ->with($command)
             ->willThrowException(new DBALEventStoreException());
 
-        $this->expectException(DBALEventStoreException::class);
+        $this->expectException(RetriedCommandFailed::class);
         $this->commandBus->dispatch($command);
     }
 


### PR DESCRIPTION
### Changed

- Increased the max amount of retries
- Wrapped the `DBALEventStoreException` in a custom `RetriedCommandFailed` so it's easier to see in Sentry that the `RetryingCommandBus` is working as expected (or not)

---
Ticket: https://jira.uitdatabank.be/browse/III-3919
