### PR TITLE
III-4815 allow but ignore prices with category uitpas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-uitdatabank/III-4815-Allow-but-ignore-prices-with-category-uitpas",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "respect/validation": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f99b2736ddcaab57c3a49c7cb561d73",
+    "content-hash": "d2eee07b764c73aabf1d3ba4b0e93489",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -5360,19 +5360,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-uitdatabank/III-4815-Allow-but-ignore-prices-with-category-uitpas",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "230ab619ead57b5b39c8f4543670141a1597ec74"
+                "reference": "7867dcebf4ca1816ddd9331a48f274c1793b8a75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/230ab619ead57b5b39c8f4543670141a1597ec74",
-                "reference": "230ab619ead57b5b39c8f4543670141a1597ec74",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/7867dcebf4ca1816ddd9331a48f274c1793b8a75",
+                "reference": "7867dcebf4ca1816ddd9331a48f274c1793b8a75",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5387,9 +5386,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-4769-price-currency-optional"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/uitdatabank/III-4815-Allow-but-ignore-prices-with-category-uitpas"
             },
-            "time": "2022-06-02T14:40:12+00:00"
+            "time": "2022-08-04T07:36:30+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Price/PriceInfoDenormalizer.php
@@ -45,10 +45,16 @@ class PriceInfoDenormalizer implements DenormalizerInterface
 
         $basePriceData = [];
         $tariffsData = [];
+        $UiTPASTariffsData = [];
 
         foreach ($data as $tariffData) {
             if ($tariffData['category'] === 'base') {
                 $basePriceData = $tariffData;
+                continue;
+            }
+
+            if ($tariffData['category'] === 'uitpas') {
+                $UiTPASTariffsData[] = $tariffData;
                 continue;
             }
 
@@ -64,7 +70,14 @@ class PriceInfoDenormalizer implements DenormalizerInterface
             $tariffsData
         );
 
-        return new PriceInfo($basePrice, new Tariffs(...$tariffs));
+        $UiTPASTariffs = array_map(
+            function ($UiTPASTariffData) use ($context) {
+                return $this->denormalizeTariff($UiTPASTariffData, $context);
+            },
+            $UiTPASTariffsData
+        );
+
+        return new PriceInfo($basePrice, new Tariffs(...$tariffs), new Tariffs(...$UiTPASTariffs));
     }
 
     /**

--- a/src/Model/ValueObject/Price/PriceInfo.php
+++ b/src/Model/ValueObject/Price/PriceInfo.php
@@ -36,6 +36,11 @@ class PriceInfo
         return $this->tariffs;
     }
 
+    public function getUiTPASTariffs(): Tariffs
+    {
+        return $this->UiTPASTariffs;
+    }
+
     public function withTariffs(Tariffs $tariffs): PriceInfo
     {
         $c = clone $this;

--- a/src/Model/ValueObject/Price/PriceInfo.php
+++ b/src/Model/ValueObject/Price/PriceInfo.php
@@ -10,10 +10,13 @@ class PriceInfo
 
     private Tariffs $tariffs;
 
-    public function __construct(Tariff $basePrice, Tariffs $tariffs)
+    private Tariffs $UiTPASTariffs;
+
+    public function __construct(Tariff $basePrice, Tariffs $tariffs, Tariffs $UiTPASTariffs)
     {
         $this->basePrice = $basePrice;
         $this->tariffs = $tariffs;
+        $this->UiTPASTariffs = $UiTPASTariffs;
     }
 
     public function getBasePrice(): Tariff

--- a/src/Offer/Offer.php
+++ b/src/Offer/Offer.php
@@ -466,9 +466,10 @@ abstract class Offer extends EventSourcedAggregateRoot implements LabelAwareAggr
 
     public function updatePriceInfo(PriceInfo $priceInfo): void
     {
-        if (is_null($this->priceInfo) || $priceInfo->serialize() !== $this->priceInfo->serialize()) {
+        if (is_null($this->priceInfo) || $priceInfo->withoutUiTPASTariffs()->serialize() !== $this->priceInfo->withoutUiTPASTariffs()->serialize()) {
+            $priceInfoWithUiTPAS = is_null($this->priceInfo) ? $priceInfo : $priceInfo->withoutUiTPASTariffs()->withUiTPASTariffs($this->priceInfo->getUiTPASTariffs());
             $this->apply(
-                $this->createPriceInfoUpdatedEvent($priceInfo)
+                $this->createPriceInfoUpdatedEvent($priceInfoWithUiTPAS)
             );
         }
     }

--- a/src/PriceInfo/PriceInfo.php
+++ b/src/PriceInfo/PriceInfo.php
@@ -137,6 +137,11 @@ class PriceInfo implements Serializable
             $priceInfo = $priceInfo->withExtraTariff($tariff);
         }
 
+        foreach ($udb3ModelPriceInfo->getUiTPASTariffs() as $udb3ModelUiTPASTariff) {
+            $tariff = Tariff::fromUdb3ModelTariff($udb3ModelUiTPASTariff);
+            $priceInfo = $priceInfo->withExtraUiTPASTariff($tariff);
+        }
+
         return $priceInfo;
     }
 }

--- a/src/PriceInfo/PriceInfo.php
+++ b/src/PriceInfo/PriceInfo.php
@@ -60,6 +60,13 @@ class PriceInfo implements Serializable
         return $c;
     }
 
+    public function withoutUiTPASTariffs(): PriceInfo
+    {
+        $c = clone $this;
+        $c->uitpasTariffs = [];
+        return $c;
+    }
+
     public function getBasePrice(): BasePrice
     {
         return $this->basePrice;

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -713,6 +713,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                             ),
                             new Money(1050, new Currency('EUR'))
                         ),
+                        new Tariffs(),
                         new Tariffs()
                     )
                 ),
@@ -4817,6 +4818,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                             ),
                             new Money(1050, new Currency('EUR'))
                         ),
+                        new Tariffs(),
                         new Tariffs()
                     )
                 ),

--- a/tests/Http/Offer/UpdatePriceInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdatePriceInfoRequestHandlerTest.php
@@ -99,7 +99,8 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                     ),
                     new Money(500, new Currency('EUR'))
                 )
-            )
+            ),
+            new Tariffs()
         );
 
         $expected = new UpdatePriceInfo(

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -926,6 +926,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                             ),
                             new Money(1050, new Currency('EUR'))
                         ),
+                        new Tariffs(),
                         new Tariffs()
                     )
                 ),

--- a/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
+++ b/tests/Model/Import/Offer/Udb3ModelToLegacyOfferAdapterTest.php
@@ -130,7 +130,8 @@ class Udb3ModelToLegacyOfferAdapterTest extends TestCase
                             ),
                             new Money(1050, new Currency('EUR'))
                         )
-                    )
+                    ),
+                    new Tariffs()
                 )
             )
             ->withBookingInfo(

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -359,6 +359,7 @@ class ImmutableOfferTest extends TestCase
             Tariff::createBasePrice(
                 new Money(1000, new Currency('EUR'))
             ),
+            new Tariffs(),
             new Tariffs()
         );
 

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -338,6 +338,7 @@ class ImmutableOfferTest extends TestCase
             Tariff::createBasePrice(
                 new Money(1000, new Currency('EUR'))
             ),
+            new Tariffs(),
             new Tariffs()
         );
 

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -81,17 +81,14 @@ use Symfony\Component\Serializer\Exception\UnsupportedException;
 
 class EventDenormalizerTest extends TestCase
 {
-    /**
-     * @var EventDenormalizer
-     */
-    private $denormalizer;
+    private EventDenormalizer $denormalizer;
 
     /**
      * @var MockObject|UuidFactoryInterface
      */
     private $uuidFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->uuidFactory = $this->createMock(UuidFactoryInterface::class);
 
@@ -116,7 +113,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_only_the_required_properties()
+    public function it_should_denormalize_event_data_with_only_the_required_properties(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -161,7 +158,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_status()
+    public function it_should_denormalize_event_data_with_status(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -224,7 +221,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_status_without_reason()
+    public function it_should_denormalize_event_data_with_status_without_reason(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -276,7 +273,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_title_translations()
+    public function it_should_denormalize_event_data_with_title_translations(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -325,7 +322,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_single_date_range_calendar()
+    public function it_should_denormalize_event_data_with_a_single_date_range_calendar(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -390,7 +387,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_single_date_range_calendar_and_status_and_reason()
+    public function it_should_denormalize_event_data_with_a_single_date_range_calendar_and_status_and_reason(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -467,7 +464,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_single_date_range_calendar_and_no_sub_event()
+    public function it_should_denormalize_event_data_with_a_single_date_range_calendar_and_no_sub_event(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -525,7 +522,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_multiple_date_ranges_calendar()
+    public function it_should_denormalize_event_data_with_a_multiple_date_ranges_calendar(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -622,7 +619,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_multiple_date_ranges_calendar_and_status_and_reason()
+    public function it_should_denormalize_event_data_with_a_multiple_date_ranges_calendar_and_status_and_reason(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -850,7 +847,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_single_date_range_and_apply_status_to_sub_event_with_no_status()
+    public function it_should_denormalize_event_data_with_single_date_range_and_apply_status_to_sub_event_with_no_status(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -927,7 +924,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_single_sub_event_and_apply_status_to_sub_event_with_no_status()
+    public function it_should_denormalize_event_data_with_single_sub_event_and_apply_status_to_sub_event_with_no_status(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1011,7 +1008,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_multiple_date_ranges_and_apply_status_to_sub_events_with_no_status()
+    public function it_should_denormalize_event_data_with_multiple_date_ranges_and_apply_status_to_sub_events_with_no_status(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1124,7 +1121,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_periodic_calendar_and_no_opening_hours()
+    public function it_should_denormalize_event_data_with_a_periodic_calendar_and_no_opening_hours(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1177,7 +1174,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_periodic_calendar_and_opening_hours()
+    public function it_should_denormalize_event_data_with_a_periodic_calendar_and_opening_hours(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1263,7 +1260,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_a_permanent_calendar_and_opening_hours()
+    public function it_should_denormalize_event_data_with_a_permanent_calendar_and_opening_hours(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1343,7 +1340,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_terms_with_labels_and_domains()
+    public function it_should_denormalize_event_data_with_terms_with_labels_and_domains(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1402,7 +1399,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_typical_age_range_starting_without_number()
+    public function it_should_denormalize_event_data_with_typical_age_range_starting_without_number(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1448,7 +1445,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_denormalize_event_data_with_optional_properties()
+    public function it_should_denormalize_event_data_with_optional_properties(): void
     {
         $eventData = [
             '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
@@ -1496,6 +1493,14 @@ class EventDenormalizerTest extends TestCase
                         'en' => 'Seniors',
                     ],
                     'price' => 10.5,
+                    'priceCurrency' => 'EUR',
+                ],
+                [
+                    'category' => 'uitpas',
+                    'name' => [
+                        'nl' => 'UiTPAS Regio Gent',
+                    ],
+                    'price' => 5.5,
                     'priceCurrency' => 'EUR',
                 ],
                 [
@@ -1642,7 +1647,18 @@ class EventDenormalizerTest extends TestCase
                             )
                         )
                     ),
-                    new Tariffs()
+                    new Tariffs(
+                        new Tariff(
+                            new TranslatedTariffName(
+                                new Language('nl'),
+                                new TariffName('UiTPAS Regio Gent')
+                            ),
+                            new Money(
+                                550,
+                                new Currency('EUR')
+                            )
+                        )
+                    )
                 )
             )
             ->withBookingInfo(
@@ -1734,7 +1750,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_throw_an_exception_when_trying_to_denormalize_to_an_unsupported_class()
+    public function it_should_throw_an_exception_when_trying_to_denormalize_to_an_unsupported_class(): void
     {
         $this->expectException(UnsupportedException::class);
         $this->denormalizer->denormalize([], ImmutablePlace::class);
@@ -1743,7 +1759,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_throw_an_exception_when_trying_to_denormalize_data_that_is_not_an_array()
+    public function it_should_throw_an_exception_when_trying_to_denormalize_data_that_is_not_an_array(): void
     {
         $this->expectException(UnsupportedException::class);
         $this->denormalizer->denormalize(new \stdClass(), ImmutableEvent::class);
@@ -1752,7 +1768,7 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
-    public function it_should_support_denormalization_to_immutable_event()
+    public function it_should_support_denormalization_to_immutable_event(): void
     {
         $this->assertTrue(
             $this->denormalizer->supportsDenormalization([], ImmutableEvent::class)

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -1641,7 +1641,8 @@ class EventDenormalizerTest extends TestCase
                                 new Currency('EUR')
                             )
                         )
-                    )
+                    ),
+                    new Tariffs()
                 )
             )
             ->withBookingInfo(

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -888,7 +888,8 @@ class PlaceDenormalizerTest extends TestCase
                                 new Currency('EUR')
                             )
                         )
-                    )
+                    ),
+                    new Tariffs()
                 )
             )
             ->withBookingInfo(

--- a/tests/Model/ValueObject/Price/PriceInfoTest.php
+++ b/tests/Model/ValueObject/Price/PriceInfoTest.php
@@ -20,11 +20,23 @@ class PriceInfoTest extends TestCase
             new Money(1000, new Currency('EUR'))
         );
         $tariffs = new Tariffs();
-        $UiTPASTariffs = new Tariffs();
+        $UiTPASTariffs = new Tariffs(
+            new Tariff(
+                new TranslatedTariffName(
+                    new Language('nl'),
+                    new TariffName('UiTPAS Regio Gent')
+                ),
+                new Money(
+                    100,
+                    new Currency('EUR')
+                )
+            )
+        );
         $priceInfo = new PriceInfo($basePrice, $tariffs, $UiTPASTariffs);
 
         $this->assertEquals($basePrice, $priceInfo->getBasePrice());
         $this->assertEquals($tariffs, $priceInfo->getTariffs());
+        $this->assertEquals($UiTPASTariffs, $priceInfo->getUiTPASTariffs());
     }
 
     /**

--- a/tests/Model/ValueObject/Price/PriceInfoTest.php
+++ b/tests/Model/ValueObject/Price/PriceInfoTest.php
@@ -14,7 +14,7 @@ class PriceInfoTest extends TestCase
     /**
      * @test
      */
-    public function it_should_combine_a_base_price_and_optional_extra_tariffs()
+    public function it_should_combine_a_base_price_and_optional_extra_tariffs(): void
     {
         $basePrice = Tariff::createBasePrice(
             new Money(1000, new Currency('EUR'))
@@ -30,7 +30,7 @@ class PriceInfoTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_copy_with_an_updated_base_price()
+    public function it_should_return_a_copy_with_an_updated_base_price(): void
     {
         $basePrice = Tariff::createBasePrice(
             new Money(1000, new Currency('EUR'))
@@ -52,7 +52,7 @@ class PriceInfoTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_a_copy_with_updated_tariffs()
+    public function it_should_return_a_copy_with_updated_tariffs(): void
     {
         $basePrice = Tariff::createBasePrice(
             new Money(1000, new Currency('EUR'))

--- a/tests/Model/ValueObject/Price/PriceInfoTest.php
+++ b/tests/Model/ValueObject/Price/PriceInfoTest.php
@@ -20,7 +20,8 @@ class PriceInfoTest extends TestCase
             new Money(1000, new Currency('EUR'))
         );
         $tariffs = new Tariffs();
-        $priceInfo = new PriceInfo($basePrice, $tariffs);
+        $UiTPASTariffs = new Tariffs();
+        $priceInfo = new PriceInfo($basePrice, $tariffs, $UiTPASTariffs);
 
         $this->assertEquals($basePrice, $priceInfo->getBasePrice());
         $this->assertEquals($tariffs, $priceInfo->getTariffs());
@@ -35,7 +36,8 @@ class PriceInfoTest extends TestCase
             new Money(1000, new Currency('EUR'))
         );
         $tariffs = new Tariffs();
-        $priceInfo = new PriceInfo($basePrice, $tariffs);
+        $UiTPASTariffs = new Tariffs();
+        $priceInfo = new PriceInfo($basePrice, $tariffs, $UiTPASTariffs);
 
         $updatedBasePrice = Tariff::createBasePrice(
             new Money(2000, new Currency('EUR'))
@@ -56,7 +58,8 @@ class PriceInfoTest extends TestCase
             new Money(1000, new Currency('EUR'))
         );
         $tariffs = new Tariffs();
-        $priceInfo = new PriceInfo($basePrice, $tariffs);
+        $UiTPASTariffs = new Tariffs();
+        $priceInfo = new PriceInfo($basePrice, $tariffs, $UiTPASTariffs);
 
         $updatedTariffs = new Tariffs(
             new Tariff(

--- a/tests/Offer/CommandHandlers/UpdatePriceInfoHandlerTest.php
+++ b/tests/Offer/CommandHandlers/UpdatePriceInfoHandlerTest.php
@@ -58,6 +58,7 @@ final class UpdatePriceInfoHandlerTest extends CommandHandlerScenarioTestCase
                     ),
                     new Money(1499, new Currency('EUR'))
                 ),
+                new Tariffs(),
                 new Tariffs()
             )
         );

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -180,4 +180,50 @@ class PriceInfoTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_be_creatable_from_an_udb3_model_price_info_with_uitpas_tariffs(): void
+    {
+        $udb3ModelPriceInfo = new \CultuurNet\UDB3\Model\ValueObject\Price\PriceInfo(
+            new \CultuurNet\UDB3\Model\ValueObject\Price\Tariff(
+                new TranslatedTariffName(
+                    new \CultuurNet\UDB3\Model\ValueObject\Translation\Language('nl'),
+                    new TariffName('Basistarief')
+                ),
+                new Money(1000, new Currency('EUR'))
+            ),
+            new Tariffs(),
+            new Tariffs(
+                new \CultuurNet\UDB3\Model\ValueObject\Price\Tariff(
+                    new TranslatedTariffName(
+                        new \CultuurNet\UDB3\Model\ValueObject\Translation\Language('nl'),
+                        new TariffName('UiTPAS Regio Gent')
+                    ),
+                    new Money(500, new Currency('EUR'))
+                )
+            )
+        );
+
+        $expected = new PriceInfo(
+            new BasePrice(
+                new Money(1000, new Currency('EUR'))
+            )
+        );
+        $expected = $expected
+            ->withExtraUiTPASTariff(
+                new Tariff(
+                    new MultilingualString(
+                        new Language('nl'),
+                        new StringLiteral('UiTPAS Regio Gent')
+                    ),
+                    new Money(500, new Currency('EUR'))
+                )
+            );
+
+        $actual = PriceInfo::fromUdb3ModelPriceInfo($udb3ModelPriceInfo);
+
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -91,6 +91,14 @@ class PriceInfoTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_without_uitpas_tariffs(): void
+    {
+        $this->assertEquals($this->priceInfoWithoutUiTPAS, $this->priceInfo->withoutUiTPASTariffs());
+    }
+
+    /**
+     * @test
+     */
     public function it_can_be_serialized_and_deserialized(): void
     {
         $serialized = $this->priceInfo->serialize();
@@ -112,6 +120,7 @@ class PriceInfoTest extends TestCase
                 ),
                 new Money(1000, new Currency('EUR'))
             ),
+            new Tariffs(),
             new Tariffs()
         );
 

--- a/tests/PriceInfo/PriceInfoTest.php
+++ b/tests/PriceInfo/PriceInfoTest.php
@@ -28,6 +28,8 @@ class PriceInfoTest extends TestCase
      */
     private array $uitpasTariffs;
 
+    private PriceInfo $priceInfoWithoutUiTPAS;
+
     private PriceInfo $priceInfo;
 
     public function setUp(): void
@@ -56,9 +58,10 @@ class PriceInfoTest extends TestCase
             ),
         ];
 
-        $this->priceInfo = (new PriceInfo($this->basePrice))
-            ->withExtraTariff($this->tariffs[0])
-            ->withExtraUiTPASTariff($this->uitpasTariffs[0]);
+        $this->priceInfoWithoutUiTPAS = (new PriceInfo($this->basePrice))
+            ->withExtraTariff($this->tariffs[0]);
+
+        $this->priceInfo = $this->priceInfoWithoutUiTPAS->withExtraUiTPASTariff($this->uitpasTariffs[0]);
     }
 
     /**
@@ -144,7 +147,8 @@ class PriceInfoTest extends TestCase
                     ),
                     new Money(500, new Currency('EUR'))
                 )
-            )
+            ),
+            new Tariffs()
         );
 
         $expected = new PriceInfo(


### PR DESCRIPTION
### Added

 - `withoutUiTPASTariffs()` on Legacy `PriceInfo`
 - `UiTPASTariffs` on Modal `PriceInfo`

### Changed

- updated `composer.json` to include new `udb3-json-schemas`
- Change `PriceInfoDenormalizer` to include `UiTPASTariffs`
- Updated tests
- Exclude `UiTPASTariffs` on check on equal `PriceInfo` before updating

---
Ticket: https://jira.uitdatabank.be/browse/III-4815
