### PR TITLE
III-4796 reactive regex to block newlines

### DIFF
--- a/src/Model/ValueObject/Taxonomy/Label/LabelName.php
+++ b/src/Model/ValueObject/Taxonomy/Label/LabelName.php
@@ -14,7 +14,7 @@ class LabelName
     use Trims;
     use MatchesRegexPattern;
 
-    public const REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/s';
+    public const REGEX = '/^(?=.{2,255}$)(?=.*\S.*\S.*)[^;]*$/';
 
     /**
      * @param string $value

--- a/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
+++ b/tests/Model/ValueObject/Taxonomy/Label/LabelNameTest.php
@@ -77,11 +77,11 @@ class LabelNameTest extends TestCase
             ],
             [
                 "Hard\r\nRock",
-                true,
+                false,
             ],
             [
                 "\r\nTechno",
-                true,
+                false,
             ],
         ];
     }
@@ -149,9 +149,13 @@ class LabelNameTest extends TestCase
     /**
      * @test
      */
-    public function it_stores_a_newline_label_value(): void
+    public function it_throws_on_newlines_in_label(): void
     {
-        $labelName = new LabelName("New\nWave");
-        $this->assertEquals("New\nWave", $labelName->toString());
+        $newLineLabel = "New\nWave";
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'String \'' . $newLineLabel . '\' does not match regex pattern ' . LabelName::REGEX . '.'
+        );
+        new LabelName($newLineLabel);
     }
 }


### PR DESCRIPTION
### Changed
- Rollback of the Regex change of III-4783 so newlines are again blocked in new `LabelName`
- updated tests for newlines in `LabelName` to comply with 

---
Ticket: https://jira.uitdatabank.be/browse/III-4796
