### PR TITLE
III-4901 Fix some permission routes that are accidentally public

### DIFF
--- a/app/Authentication/AuthServiceProvider.php
+++ b/app/Authentication/AuthServiceProvider.php
@@ -52,9 +52,9 @@ final class AuthServiceProvider implements ServiceProviderInterface
                 $authenticator->addPublicRoute('~^/(events?|places?)/?$~', ['GET']);
                 $authenticator->addPublicRoute('~^/(events?|places?)/[\w\-]+/?$~', ['GET']);
                 $authenticator->addPublicRoute('~^/(events?|places?)/[\w\-]+/calendar-summary/?$~', ['GET']);
-                $authenticator->addPublicRoute('~^/(events?|places?)/[\w\-]+/permissions?/?$~', ['GET']);
+                $authenticator->addPublicRoute('~^/(events?|places?)/[\w\-]+/permissions?/.+$~', ['GET']);
                 $authenticator->addPublicRoute('~^/organizers/[\w\-]+/?$~', ['GET']);
-                $authenticator->addPublicRoute('~^/organizers/[\w\-]+/permissions/?$~', ['GET']);
+                $authenticator->addPublicRoute('~^/organizers/[\w\-]+/permissions/.+$~', ['GET']);
                 $authenticator->addPublicRoute('~^/labels/?$~', ['GET']);
                 $authenticator->addPublicRoute('~^/label/[\w\-]+/?$~', ['GET']);
                 $authenticator->addPublicRoute('~^/media/[\w\-]+/?$~', ['GET']);


### PR DESCRIPTION
Examples that should be public:

- /events/{eventId}/permission/{userId}
- /places/{placeId}/permission/{userId}
- /organizers/{placeId}/permission/{userId}
- /events/{eventId}/permissions/{userId}
- /places/{placeId}/permissions/{userId}
- /organizers/{placeId}/permissions/{userId}

(and also singular event / place)

Examples that should NOT be public:

- /events/{eventId}/permission/
- /places/{placeId}/permission/
- /organizers/{placeId}/permission/
- /events/{eventId}/permissions/
- /places/{placeId}/permissions/
- /organizers/{placeId}/permissions/

(and also singular event / place, and without trailing slash)

-> These are to check the permission for the user based on the Authorization header

I accidentally removed the `.+` that was originally in the Symfony firewall config for these routes. See old version at https://github.com/cultuurnet/udb3-silex/blob/45d9653accd183065b665b9abce5b2a7b262966f/web/index.php#L62-L66

---
Ticket: https://jira.uitdatabank.be/browse/III-4901
