### PR TITLE
III-4891 Refactor image uploader to use `UploadedFileInterface`

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -89,6 +89,7 @@ use CultuurNet\UDB3\Silex\Search\Sapi3SearchServiceProvider;
 use CultuurNet\UDB3\Silex\Security\GeneralSecurityServiceProvider;
 use CultuurNet\UDB3\Silex\Security\OrganizerSecurityServiceProvider;
 use CultuurNet\UDB3\Silex\Term\TermServiceProvider;
+use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceEventControllerProvider;
 use CultuurNet\UDB3\Silex\UiTPASService\UiTPASServiceLabelsControllerProvider;
 use CultuurNet\UDB3\Silex\Yaml\YamlConfigServiceProvider;
 use CultuurNet\UDB3\User\Auth0UserIdentityResolver;
@@ -866,6 +867,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Role\RoleReadingServiceProvider());
 $app->register(new UserPermissionsServiceProvider());
 $app->register(new \CultuurNet\UDB3\Silex\Event\ProductionServiceProvider());
 $app->register(new UiTPASServiceLabelsControllerProvider());
+$app->register(new UiTPASServiceEventControllerProvider());
 
 $app->register(
     new \CultuurNet\UDB3\Silex\Media\MediaServiceProvider(),

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 
 final class UploadMediaRequestHandler implements RequestHandlerInterface
 {
@@ -54,12 +53,8 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
             return new JsonResponse(['error' => 'language required'], 400);
         }
 
-        $httpFoundationFactory = new HttpFoundationFactory();
-        $httpRequest = $httpFoundationFactory->createRequest($request);
-        $file = $httpRequest->files->get('file');
-
         $imageId = $this->imageUploader->upload(
-            $file,
+            $request->getUploadedFiles()['file'],
             new StringLiteral($description),
             new CopyrightHolder($copyrightHolder),
             new Language($language)

--- a/src/Media/ImageUploaderInterface.php
+++ b/src/Media/ImageUploaderInterface.php
@@ -7,13 +7,13 @@ namespace CultuurNet\UDB3\Media;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use CultuurNet\UDB3\StringLiteral;
+use Psr\Http\Message\UploadedFileInterface;
 
 interface ImageUploaderInterface
 {
     public function upload(
-        UploadedFile $file,
+        UploadedFileInterface $file,
         StringLiteral $description,
         CopyrightHolder $copyrightHolder,
         Language $language

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -14,7 +14,7 @@ use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\Identity\UUID;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 use Zend\Diactoros\UploadedFile;
 
 final class UploadMediaRequestHandlerTest extends TestCase
@@ -57,9 +57,9 @@ final class UploadMediaRequestHandlerTest extends TestCase
         $this->imageUploader
             ->expects($this->once())
             ->method('upload')
-            ->willReturnCallback(function (SymfonyUploadedFile $uploadedFile) use ($imageId) {
-                $this->assertEquals('test.txt', $uploadedFile->getClientOriginalName());
-                $this->assertEquals('text/plain', $uploadedFile->getMimeType());
+            ->willReturnCallback(function (UploadedFileInterface $uploadedFile) use ($imageId) {
+                $this->assertEquals('test.txt', $uploadedFile->getClientFilename());
+                $this->assertEquals('text/plain', $uploadedFile->getClientMediaType());
                 $this->assertEquals(UPLOAD_ERR_OK, $uploadedFile->getError());
                 $this->assertEquals(3, $uploadedFile->getSize());
 

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\UploadedFileInterface;
+use Zend\Diactoros\Stream;
 
 class ImageUploaderServiceTest extends TestCase
 {
@@ -99,6 +100,11 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getClientMediaType')
             ->willReturn('image/png');
 
+        $image
+            ->expects($this->once())
+            ->method('getStream')
+            ->willReturn(new Stream(fopen(__DIR__ . '/files/my-image.png', 'rb')));
+
         $description = new StringLiteral('file description');
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
@@ -113,7 +119,7 @@ class ImageUploaderServiceTest extends TestCase
 
         $this->filesystem
             ->expects($this->once())
-            ->method('writeStream')
+            ->method('write')
             ->with($expectedDestination, $this->anything());
 
         $this->commandBus
@@ -276,6 +282,11 @@ class ImageUploaderServiceTest extends TestCase
             ->method('getSize')
             ->willReturn(5000);
 
+        $image
+            ->expects($this->once())
+            ->method('getStream')
+            ->willReturn(new Stream(fopen(__DIR__ . '/files/my-image.png', 'rb')));
+
         $uploader = new ImageUploaderService(
             $this->uuidGenerator,
             $this->commandBus,
@@ -298,7 +309,7 @@ class ImageUploaderServiceTest extends TestCase
 
         $this->filesystem
             ->expects($this->once())
-            ->method('writeStream')
+            ->method('write')
             ->with($expectedDestination, $this->anything());
 
         $this->commandBus


### PR DESCRIPTION
### Changed
- Refactor image uploader to use `UploadedFileInterface`

---
Ticket: https://jira.uitdatabank.be/browse/III-4891
