### PR TITLE
III-4941 Prevent updating related events

### DIFF
--- a/app/Console/ReindexOffersWithPopularityScore.php
+++ b/app/Console/ReindexOffersWithPopularityScore.php
@@ -8,6 +8,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
 use CultuurNet\UDB3\Offer\OfferType;
+use CultuurNet\UDB3\Place\Events\PlaceProjectedToJSONLD;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
@@ -105,6 +106,10 @@ class ReindexOffersWithPopularityScore extends Command
     private function handleEvent(string $id): void
     {
         $projectedEvent = $this->eventFactoryForEvents->createEvent($id);
+
+        if ($projectedEvent instanceof PlaceProjectedToJSONLD) {
+            $projectedEvent = $projectedEvent->disableUpdatingEventsLocatedAtPlace();
+        }
 
         $this->eventBus->publish(
             new DomainEventStream(

--- a/src/Offer/ProcessManagers/RelatedDocumentProjectedToJSONLDDispatcher.php
+++ b/src/Offer/ProcessManagers/RelatedDocumentProjectedToJSONLDDispatcher.php
@@ -67,6 +67,10 @@ final class RelatedDocumentProjectedToJSONLDDispatcher implements EventListener
 
     private function handlePlaceProjectedToJSONLD(PlaceProjectedToJSONLD $placeProjectedToJSONLD): void
     {
+        if ($placeProjectedToJSONLD->isUpdatingEventsLocatedAtPlaceDisabled()) {
+            return;
+        }
+
         $placeId = $placeProjectedToJSONLD->getItemId();
 
         // In theory the event relations repository should only return unique event ids for a given place id, but to be

--- a/src/Place/Events/PlaceProjectedToJSONLD.php
+++ b/src/Place/Events/PlaceProjectedToJSONLD.php
@@ -8,4 +8,17 @@ use CultuurNet\UDB3\Offer\Events\AbstractEventWithIri;
 
 final class PlaceProjectedToJSONLD extends AbstractEventWithIri
 {
+    private bool $disableUpdatingEventsLocatedAtPlace = false;
+
+    public function disableUpdatingEventsLocatedAtPlace(): PlaceProjectedToJSONLD
+    {
+        $c = clone $this;
+        $c->disableUpdatingEventsLocatedAtPlace = true;
+        return $c;
+    }
+
+    public function isUpdatingEventsLocatedAtPlaceDisabled(): bool
+    {
+        return $this->disableUpdatingEventsLocatedAtPlace;
+    }
 }


### PR DESCRIPTION
### Changed
- Prevent updating related events when updating the popularity score of a place.

Note: maybe there are more general solutions for this but I took a straightforward approach to fix the queue issue.

---
Ticket: https://jira.uitdatabank.be/browse/III-4941
