### PR TITLE
III-4941 Intercept event projected events when place is projected

### DIFF
--- a/app/Console/ReindexOffersWithPopularityScore.php
+++ b/app/Console/ReindexOffersWithPopularityScore.php
@@ -25,18 +25,18 @@ class ReindexOffersWithPopularityScore extends Command
 
     private EventBus $eventBus;
 
-    private DocumentEventFactory $eventFactoryForEvents;
+    private DocumentEventFactory $eventFactoryForOffers;
 
     public function __construct(
         OfferType $type,
         Connection $connection,
         EventBus $eventBus,
-        DocumentEventFactory $eventFactoryForEvents
+        DocumentEventFactory $eventFactoryForOffers
     ) {
         $this->type = \strtolower($type->toString());
         $this->connection = $connection;
         $this->eventBus = $eventBus;
-        $this->eventFactoryForEvents = $eventFactoryForEvents;
+        $this->eventFactoryForOffers = $eventFactoryForOffers;
 
         // It's important to call the parent constructor after setting the properties.
         // Because the parent constructor calls the `configure` method.
@@ -104,11 +104,11 @@ class ReindexOffersWithPopularityScore extends Command
 
     private function handleEvent(string $id): void
     {
-        $projectedEvent = $this->eventFactoryForEvents->createEvent($id);
+        $offerProjectedToJSONLD = $this->eventFactoryForOffers->createEvent($id);
 
         $this->eventBus->publish(
             new DomainEventStream(
-                [(new DomainMessageBuilder())->create($projectedEvent)]
+                [(new DomainMessageBuilder())->create($offerProjectedToJSONLD)]
             )
         );
     }

--- a/app/Console/ReindexOffersWithPopularityScore.php
+++ b/app/Console/ReindexOffersWithPopularityScore.php
@@ -10,9 +10,7 @@ use Broadway\EventHandling\EventBus;
 use CultuurNet\UDB3\Event\Events\EventProjectedToJSONLD;
 use CultuurNet\UDB3\EventBus\Middleware\InterceptingMiddleware;
 use CultuurNet\UDB3\EventSourcing\DomainMessageBuilder;
-use CultuurNet\UDB3\Offer\Offer;
 use CultuurNet\UDB3\Offer\OfferType;
-use CultuurNet\UDB3\Place\Events\PlaceProjectedToJSONLD;
 use CultuurNet\UDB3\ReadModel\DocumentEventFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
@@ -79,7 +77,7 @@ class ReindexOffersWithPopularityScore extends Command
 
         if ($this->offerType->sameAs(OfferType::place())) {
             InterceptingMiddleware::startIntercepting(
-                static fn(DomainMessage $message) => $message->getPayload() instanceof EventProjectedToJSONLD
+                static fn (DomainMessage $message) => $message->getPayload() instanceof EventProjectedToJSONLD
             );
         }
 
@@ -127,6 +125,5 @@ class ReindexOffersWithPopularityScore extends Command
                 [(new DomainMessageBuilder())->create($offerProjectedToJSONLD)]
             )
         );
-
     }
 }


### PR DESCRIPTION
### Changed
- Intercept event projected events when the popularity score of a place is updated. This should prevent updates to the related events.

---
Ticket: https://jira.uitdatabank.be/browse/III-4941
