### PR TITLE
III-4949 Fix missing route parameters in error handling

### DIFF
--- a/app/Error/WebErrorHandler.php
+++ b/app/Error/WebErrorHandler.php
@@ -17,11 +17,14 @@ use CultuurNet\UDB3\Security\CommandAuthorizationException;
 use Error;
 use League\Route\Http\Exception\MethodNotAllowedException;
 use League\Route\Http\Exception\NotFoundException;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Respect\Validation\Exceptions\GroupedValidationException;
 use Throwable;
 
-final class WebErrorHandler
+final class WebErrorHandler implements MiddlewareInterface
 {
     private ErrorLogger $errorLogger;
     private bool $debugMode;
@@ -30,6 +33,15 @@ final class WebErrorHandler
     {
         $this->errorLogger = $errorLogger;
         $this->debugMode = $debugMode;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            return $handler->handle($request);
+        } catch (Throwable $e) {
+            return $this->handle($request, $e);
+        }
     }
 
     public function handle(ServerRequestInterface $request, Throwable $e): ApiProblemJsonResponse

--- a/app/Error/WebErrorHandler.php
+++ b/app/Error/WebErrorHandler.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Silex\Error;
+
+use Broadway\Repository\AggregateNotFoundException;
+use CultureFeed_Exception;
+use CultureFeed_HttpException;
+use CultuurNet\UDB3\Deserializer\DataValidationException;
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
+use CultuurNet\UDB3\Http\Request\RouteParameters;
+use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
+use CultuurNet\UDB3\Security\CommandAuthorizationException;
+use Error;
+use League\Route\Http\Exception\MethodNotAllowedException;
+use League\Route\Http\Exception\NotFoundException;
+use Psr\Http\Message\ServerRequestInterface;
+use Respect\Validation\Exceptions\GroupedValidationException;
+use Throwable;
+
+final class WebErrorHandler
+{
+    public static function createNewApiProblem(ServerRequestInterface $request, Throwable $e, int $defaultStatus, bool $debug = false): ApiProblem
+    {
+        $problem = self::convertThrowableToApiProblem($request, $e, $defaultStatus);
+        if ($debug) {
+            $problem->setDebugInfo(ContextExceptionConverterProcessor::convertThrowableToArray($e));
+        }
+        return $problem;
+    }
+
+    private static function convertThrowableToApiProblem(ServerRequestInterface $request, Throwable $e, int $defaultStatus): ApiProblem
+    {
+        switch (true) {
+            case $e instanceof ApiProblem:
+                return $e;
+
+            case $e instanceof Error:
+                return ApiProblem::internalServerError();
+
+            case $e instanceof ConvertsToApiProblem:
+                return $e->toApiProblem();
+
+            case $e instanceof CommandAuthorizationException:
+                return ApiProblem::forbidden(
+                    sprintf(
+                        'User %s has no permission "%s" on resource %s',
+                        $e->getUserId()->toNative(),
+                        $e->getCommand()->getPermission()->toString(),
+                        $e->getCommand()->getItemId()
+                    )
+                );
+
+            case $e instanceof NotFoundException:
+                return ApiProblem::urlNotFound();
+
+            case $e instanceof MethodNotAllowedException:
+                $details = null;
+                $headers = $e->getHeaders();
+                $allowed = $headers['Allow'] ?? null;
+                if ($allowed !== null) {
+                    $details = 'Allowed: ' . $allowed;
+                }
+                return ApiProblem::methodNotAllowed($details);
+
+            // Do a best effort to convert "not found" exceptions into an ApiProblem with preferably a detail mentioning
+            // what kind of resource and with what id could not be found. Since the exceptions themselves do not contain
+            // enough info to detect this, we need to get this info from the current request. However this is not
+            // perfect because for example an event route might try to load another related resource and if that one is
+            // not found this logic might say that the event is not found. When that happens, try to manually catch the
+            // exception in the request handler or command handler and convert it to an ApiProblem with a better detail.
+            case $e instanceof AggregateNotFoundException:
+            case $e instanceof DocumentDoesNotExist:
+                $routeParameters = new RouteParameters($request);
+                if ($routeParameters->hasEventId()) {
+                    return ApiProblem::eventNotFound($routeParameters->getEventId());
+                }
+                if ($routeParameters->hasPlaceId()) {
+                    return ApiProblem::placeNotFound($routeParameters->getPlaceId());
+                }
+                if ($routeParameters->hasOrganizerId()) {
+                    return ApiProblem::organizerNotFound($routeParameters->getOrganizerId());
+                }
+                if ($routeParameters->hasOfferId() && $routeParameters->hasOfferType()) {
+                    return ApiProblem::offerNotFound($routeParameters->getOfferType(), $routeParameters->getOfferId());
+                }
+                if ($routeParameters->hasRoleId()) {
+                    return ApiProblem::roleNotFound($routeParameters->getRoleId());
+                }
+                return ApiProblem::urlNotFound();
+
+            case $e instanceof DataValidationException:
+                $problem = ApiProblem::blank('Invalid payload.', $e->getCode() ?: $defaultStatus);
+                $problem->setValidationMessages($e->getValidationMessages());
+                return $problem;
+
+            case $e instanceof GroupedValidationException:
+                $problem = ApiProblem::blank($e->getMessage(), $e->getCode() ?: $defaultStatus);
+                $problem->setValidationMessages($e->getMessages());
+                return $problem;
+
+            // Remove "URL CALLED" and everything after it.
+            // E.g. "event is not known in uitpas URL CALLED: https://acc.uitid.be/uitid/rest/uitpas/cultureevent/..."
+            // becomes "event is not known in uitpas ".
+            // The trailing space could easily be removed but it's there for backward compatibility with systems that
+            // might have implemented a comparison on the error message when this was introduced in udb3-uitpas-service
+            // in the past.
+            case $e instanceof CultureFeed_Exception:
+            case $e instanceof CultureFeed_HttpException:
+                $title = $e->getMessage();
+                $formattedTitle = preg_replace('/URL CALLED.*/', '', $title);
+                return ApiProblem::blank($formattedTitle, $e->getCode() ?: $defaultStatus);
+
+            default:
+                return ApiProblem::blank($e->getMessage(), $e->getCode() ?: $defaultStatus);
+        }
+    }
+}

--- a/app/Error/WebErrorHandlerProvider.php
+++ b/app/Error/WebErrorHandlerProvider.php
@@ -47,106 +47,10 @@ class WebErrorHandlerProvider implements ServiceProviderInterface
 
                 $defaultStatus = ErrorLogger::isBadRequestException($e) ? 400 : 500;
 
-                $problem = $this::createNewApiProblem($request, $e, $defaultStatus, $app['debug'] === true);
+                $problem = WebErrorHandler::createNewApiProblem($request, $e, $defaultStatus, $app['debug'] === true);
                 return (new ApiProblemJsonResponse($problem))->toHttpFoundationResponse();
             }
         );
-    }
-
-    public static function createNewApiProblem(ServerRequestInterface $request, Throwable $e, int $defaultStatus, bool $debug = false): ApiProblem
-    {
-        $problem = self::convertThrowableToApiProblem($request, $e, $defaultStatus);
-        if ($debug) {
-            $problem->setDebugInfo(ContextExceptionConverterProcessor::convertThrowableToArray($e));
-        }
-        return $problem;
-    }
-
-    private static function convertThrowableToApiProblem(ServerRequestInterface $request, Throwable $e, int $defaultStatus): ApiProblem
-    {
-        switch (true) {
-            case $e instanceof ApiProblem:
-                return $e;
-
-            case $e instanceof Error:
-                return ApiProblem::internalServerError();
-
-            case $e instanceof ConvertsToApiProblem:
-                return $e->toApiProblem();
-
-            case $e instanceof CommandAuthorizationException:
-                return ApiProblem::forbidden(
-                    sprintf(
-                        'User %s has no permission "%s" on resource %s',
-                        $e->getUserId()->toNative(),
-                        $e->getCommand()->getPermission()->toString(),
-                        $e->getCommand()->getItemId()
-                    )
-                );
-
-            case $e instanceof NotFoundException:
-                return ApiProblem::urlNotFound();
-
-            case $e instanceof MethodNotAllowedException:
-                $details = null;
-                $headers = $e->getHeaders();
-                $allowed = $headers['Allow'] ?? null;
-                if ($allowed !== null) {
-                    $details = 'Allowed: ' . $allowed;
-                }
-                return ApiProblem::methodNotAllowed($details);
-
-            // Do a best effort to convert "not found" exceptions into an ApiProblem with preferably a detail mentioning
-            // what kind of resource and with what id could not be found. Since the exceptions themselves do not contain
-            // enough info to detect this, we need to get this info from the current request. However this is not
-            // perfect because for example an event route might try to load another related resource and if that one is
-            // not found this logic might say that the event is not found. When that happens, try to manually catch the
-            // exception in the request handler or command handler and convert it to an ApiProblem with a better detail.
-            case $e instanceof AggregateNotFoundException:
-            case $e instanceof DocumentDoesNotExist:
-                $routeParameters = new RouteParameters($request);
-                if ($routeParameters->hasEventId()) {
-                    return ApiProblem::eventNotFound($routeParameters->getEventId());
-                }
-                if ($routeParameters->hasPlaceId()) {
-                    return ApiProblem::placeNotFound($routeParameters->getPlaceId());
-                }
-                if ($routeParameters->hasOrganizerId()) {
-                    return ApiProblem::organizerNotFound($routeParameters->getOrganizerId());
-                }
-                if ($routeParameters->hasOfferId() && $routeParameters->hasOfferType()) {
-                    return ApiProblem::offerNotFound($routeParameters->getOfferType(), $routeParameters->getOfferId());
-                }
-                if ($routeParameters->hasRoleId()) {
-                    return ApiProblem::roleNotFound($routeParameters->getRoleId());
-                }
-                return ApiProblem::urlNotFound();
-
-            case $e instanceof DataValidationException:
-                $problem = ApiProblem::blank('Invalid payload.', $e->getCode() ?: $defaultStatus);
-                $problem->setValidationMessages($e->getValidationMessages());
-                return $problem;
-
-            case $e instanceof GroupedValidationException:
-                $problem = ApiProblem::blank($e->getMessage(), $e->getCode() ?: $defaultStatus);
-                $problem->setValidationMessages($e->getMessages());
-                return $problem;
-
-            // Remove "URL CALLED" and everything after it.
-            // E.g. "event is not known in uitpas URL CALLED: https://acc.uitid.be/uitid/rest/uitpas/cultureevent/..."
-            // becomes "event is not known in uitpas ".
-            // The trailing space could easily be removed but it's there for backward compatibility with systems that
-            // might have implemented a comparison on the error message when this was introduced in udb3-uitpas-service
-            // in the past.
-            case $e instanceof CultureFeed_Exception:
-            case $e instanceof CultureFeed_HttpException:
-                $title = $e->getMessage();
-                $formattedTitle = preg_replace('/URL CALLED.*/', '', $title);
-                return ApiProblem::blank($formattedTitle, $e->getCode() ?: $defaultStatus);
-
-            default:
-                return ApiProblem::blank($e->getMessage(), $e->getCode() ?: $defaultStatus);
-        }
     }
 
     public function boot(Application $app): void

--- a/app/Error/WebErrorHandlerProvider.php
+++ b/app/Error/WebErrorHandlerProvider.php
@@ -4,26 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
-use Broadway\Repository\AggregateNotFoundException;
-use CultureFeed_Exception;
-use CultureFeed_HttpException;
-use CultuurNet\UDB3\Deserializer\DataValidationException;
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
-use CultuurNet\UDB3\Http\Request\RouteParameters;
-use CultuurNet\UDB3\Http\Response\ApiProblemJsonResponse;
-use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
-use CultuurNet\UDB3\Security\CommandAuthorizationException;
-use Error;
 use Exception;
-use League\Route\Http\Exception\MethodNotAllowedException;
-use League\Route\Http\Exception\NotFoundException;
-use Psr\Http\Message\ServerRequestInterface;
-use Respect\Validation\Exceptions\GroupedValidationException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
-use Throwable;
 
 class WebErrorHandlerProvider implements ServiceProviderInterface
 {

--- a/app/Http/CustomLeagueRouterStrategy.php
+++ b/app/Http/CustomLeagueRouterStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Http;
 
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
+use CultuurNet\UDB3\Silex\Error\WebErrorHandler;
 use League\Route\ContainerAwareInterface;
 use League\Route\ContainerAwareTrait;
 use League\Route\Http\Exception\MethodNotAllowedException;
@@ -33,6 +34,13 @@ final class CustomLeagueRouterStrategy extends AbstractStrategy implements
 {
     use ContainerAwareTrait;
 
+    private WebErrorHandler $webErrorHandler;
+
+    public function __construct(WebErrorHandler $webErrorHandler)
+    {
+        $this->webErrorHandler = $webErrorHandler;
+    }
+
     public function getOptionsCallable(array $methods): callable
     {
         return static function (): ResponseInterface {
@@ -54,18 +62,7 @@ final class CustomLeagueRouterStrategy extends AbstractStrategy implements
 
     public function getThrowableHandler(): MiddlewareInterface
     {
-        return new class() implements MiddlewareInterface {
-            public function process(
-                ServerRequestInterface $request,
-                RequestHandlerInterface $handler
-            ): ResponseInterface {
-                try {
-                    return $handler->handle($request);
-                } catch (Throwable $e) {
-                    throw $e;
-                }
-            }
-        };
+        return $this->webErrorHandler;
     }
 
     public function invokeRouteCallable(Route $route, ServerRequestInterface $request): ResponseInterface

--- a/app/Http/CustomLeagueRouterStrategy.php
+++ b/app/Http/CustomLeagueRouterStrategy.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Http;
+namespace CultuurNet\UDB3\Silex\Http;
 
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use League\Route\ContainerAwareInterface;

--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Http;
 
+use CultuurNet\UDB3\Silex\Error\WebErrorHandler;
 use CultuurNet\UDB3\Silex\Http\CustomLeagueRouterStrategy;
 use CultuurNet\UDB3\Http\InvokableRequestHandlerContainer;
 use CultuurNet\UDB3\Http\Offer\GetDetailRequestHandler;
@@ -31,7 +32,7 @@ final class PsrRouterServiceProvider implements ServiceProviderInterface
 
                 // Use a custom strategy so we can implement getOptionsCallable() on the strategy, to support CORS
                 // pre-flight requests. We also have to set the container on the strategy.
-                $routerStrategy = new CustomLeagueRouterStrategy();
+                $routerStrategy = new CustomLeagueRouterStrategy($app[WebErrorHandler::class]);
                 $routerStrategy->setContainer($container);
                 $router->setStrategy($routerStrategy);
 

--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Silex\Http;
 
 use CultuurNet\UDB3\Silex\Error\WebErrorHandler;
-use CultuurNet\UDB3\Silex\Http\CustomLeagueRouterStrategy;
 use CultuurNet\UDB3\Http\InvokableRequestHandlerContainer;
 use CultuurNet\UDB3\Http\Offer\GetDetailRequestHandler;
 use CultuurNet\UDB3\Silex\PimplePSRContainerBridge;

--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Http;
 
-use CultuurNet\UDB3\Http\CustomLeagueRouterStrategy;
+use CultuurNet\UDB3\Silex\Http\CustomLeagueRouterStrategy;
 use CultuurNet\UDB3\Http\InvokableRequestHandlerContainer;
 use CultuurNet\UDB3\Http\Offer\GetDetailRequestHandler;
 use CultuurNet\UDB3\Silex\PimplePSRContainerBridge;

--- a/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
+++ b/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
@@ -30,14 +30,11 @@ final class OfferJsonDocumentReadRepository
      */
     public function fetch(OfferType $offerType, string $id, bool $includeMetadata = false): JsonDocument
     {
-        try {
-            if ($offerType->sameAs(OfferType::event())) {
-                return $this->eventDocumentRepository->fetch($id, $includeMetadata);
-            }
-            if ($offerType->sameAs(OfferType::place())) {
-                return $this->placeDocumentRepository->fetch($id, $includeMetadata);
-            }
-        } catch (DocumentDoesNotExist $e) {
+        if ($offerType->sameAs(OfferType::event())) {
+            return $this->eventDocumentRepository->fetch($id, $includeMetadata);
+        }
+        if ($offerType->sameAs(OfferType::place())) {
+            return $this->placeDocumentRepository->fetch($id, $includeMetadata);
         }
 
         throw ApiProblem::offerNotFound($offerType, $id);

--- a/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
+++ b/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
@@ -25,9 +25,6 @@ final class OfferJsonDocumentReadRepository
         $this->placeDocumentRepository = $placeDocumentRepository;
     }
 
-    /**
-     * @throws ApiProblem
-     */
     public function fetch(OfferType $offerType, string $id, bool $includeMetadata = false): JsonDocument
     {
         if ($offerType->sameAs(OfferType::event())) {
@@ -37,6 +34,6 @@ final class OfferJsonDocumentReadRepository
             return $this->placeDocumentRepository->fetch($id, $includeMetadata);
         }
 
-        throw ApiProblem::offerNotFound($offerType, $id);
+        throw DocumentDoesNotExist::withId($id);
     }
 }

--- a/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
+++ b/src/Offer/ReadModel/JSONLD/OfferJsonDocumentReadRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Offer\ReadModel\JSONLD;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\ReadModel\DocumentRepository;

--- a/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
+++ b/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Http\Response\HtmlResponse;

--- a/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
+++ b/tests/Http/Offer/GetCalendarSummaryRequestHandlerTest.php
@@ -33,22 +33,6 @@ class GetCalendarSummaryRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_api_problem_if_the_given_offer_does_not_exist(): void
-    {
-        $request = (new Psr7RequestBuilder())
-            ->withRouteParameter('offerType', 'events')
-            ->withRouteParameter('offerId', '5ba3596f-5682-4cf5-85a9-306f9d0b0c34')
-            ->build('GET');
-
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::eventNotFound('5ba3596f-5682-4cf5-85a9-306f9d0b0c34'),
-            fn () => $this->getCalendarSummaryRequestHandler->handle($request)
-        );
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_a_html_calendar_summary_based_on_the_accept_header(): void
     {
         $eventId = '1a16eff4-7745-4bd6-85b8-5bbbfffe3c96';

--- a/tests/Http/Offer/GetDetailRequestHandlerTest.php
+++ b/tests/Http/Offer/GetDetailRequestHandlerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Http\Offer;
 
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
 use CultuurNet\UDB3\Json;

--- a/tests/Http/Offer/GetDetailRequestHandlerTest.php
+++ b/tests/Http/Offer/GetDetailRequestHandlerTest.php
@@ -241,40 +241,6 @@ class GetDetailRequestHandlerTest extends TestCase
         $this->assertArrayNotHasKey('metadata', $decodedResponseBody);
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_url_not_found_if_the_event_does_not_exist(): void
-    {
-        $request = (new Psr7RequestBuilder())
-            ->withUriFromString('/events/c09b7a51-b17c-4121-b278-eef71ef04e47')
-            ->withRouteParameter('offerType', 'events')
-            ->withRouteParameter('offerId', 'c09b7a51-b17c-4121-b278-eef71ef04e47')
-            ->build('GET');
-
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::eventNotFound('c09b7a51-b17c-4121-b278-eef71ef04e47'),
-            fn () => $this->getDetailRequestHandler->handle($request)
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_url_not_found_if_the_place_does_not_exist(): void
-    {
-        $request = (new Psr7RequestBuilder())
-            ->withUriFromString('/places/1e960233-b724-4c56-89dc-c160d15508c6')
-            ->withRouteParameter('offerType', 'places')
-            ->withRouteParameter('offerId', '1e960233-b724-4c56-89dc-c160d15508c6')
-            ->build('GET');
-
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::placeNotFound('1e960233-b724-4c56-89dc-c160d15508c6'),
-            fn () => $this->getDetailRequestHandler->handle($request)
-        );
-    }
-
     private function mockEventDocument(string $eventId): void
     {
         $jsonLd = Json::encode(

--- a/web/index.php
+++ b/web/index.php
@@ -7,6 +7,7 @@ use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Silex\ApiName;
 use CultuurNet\UDB3\Silex\Curators\CuratorsControllerProvider;
+use CultuurNet\UDB3\Silex\Error\WebErrorHandler;
 use CultuurNet\UDB3\Silex\Http\PsrRouterServiceProvider;
 use CultuurNet\UDB3\Silex\Udb3ControllerCollection;
 use CultuurNet\UDB3\Silex\Error\WebErrorHandlerProvider;
@@ -165,7 +166,7 @@ try {
 
     // Errors always get a status 500, but we still need a default status code in case of runtime exceptions that
     // weren't caught by Silex.
-    $apiProblem = WebErrorHandlerProvider::createNewApiProblem(
+    $apiProblem = WebErrorHandler::createNewApiProblem(
         $app['request_stack']->getCurrentRequest(),
         $throwable,
         500,

--- a/web/index.php
+++ b/web/index.php
@@ -160,22 +160,14 @@ JsonSchemaLocator::setSchemaDirectory(__DIR__ . '/../vendor/publiq/udb3-json-sch
 try {
     $app->run();
 } catch (\Throwable $throwable) {
-    // All Silex kernel exceptions are caught by the ErrorHandlerProvider.
-    // Errors and uncaught runtime exceptions are caught here.
-    $app[ErrorLogger::class]->log($throwable);
-
-    // Errors always get a status 500, but we still need a default status code in case of runtime exceptions that
-    // weren't caught by Silex.
-    $apiProblem = WebErrorHandler::createNewApiProblem(
-        $app['request_stack']->getCurrentRequest(),
-        $throwable,
-        500,
-        $app['debug'] === true
-    );
+    /** @var WebErrorHandler $webErrorHandler */
+    $webErrorHandler = $app[WebErrorHandler::class];
+    $request = (new DiactorosFactory())->createRequest($app['request_stack']->getCurrentRequest());
+    $response = $webErrorHandler->handle($request, $throwable);
 
     // We're outside of the Silex app, so we cannot use the standard way to return a Response object.
-    http_response_code($apiProblem->getStatus());
+    http_response_code($response->getStatusCode());
     header('Content-Type: application/json');
-    echo json_encode($apiProblem->toArray());
+    echo $response->getBody()->getContents();
     exit;
 }

--- a/web/index.php
+++ b/web/index.php
@@ -168,7 +168,8 @@ try {
     $apiProblem = WebErrorHandlerProvider::createNewApiProblem(
         $app['request_stack']->getCurrentRequest(),
         $throwable,
-        500
+        500,
+        $app['debug'] === true
     );
 
     // We're outside of the Silex app, so we cannot use the standard way to return a Response object.


### PR DESCRIPTION
### Fixed

- Fixed missing route parameters in error handling caused by the exceptions occurring in the new router being handled by Silex, which does not know about the route parameters of the routes handled by the new router. Fixed by letting the new router handle throwables itself.

### Changed

- Moved some of the web error handling logic to a more framework-agnostic class so we wouldn't tie the new router to Silex-specific classes like a ServiceProvider
- `OfferJsonDocumentReadRepository` no longer throws `ApiProblem`, but `DocumentDoesNotExist` instead. This makes it easier to test this since the only route registered in the new router uses this class. And `OfferJsonDocumentReadRepository` is not in the HTTP layer so it should not throw HTTP-specific exceptions (= ApiProblem)

---
Ticket: https://jira.uitdatabank.be/browse/III-4949
