### PR TITLE
III-4950 Allow an empty list of card system ids for events

### DIFF
--- a/src/UiTPASService/Controller/SetCardSystemsOnEventRequestHandler.php
+++ b/src/UiTPASService/Controller/SetCardSystemsOnEventRequestHandler.php
@@ -25,9 +25,9 @@ final class SetCardSystemsOnEventRequestHandler implements RequestHandlerInterfa
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $content = $request->getBody()->getContents();
-        $cardSystemIds = empty($content) ? [] : Json::decodeAssociatively($content);
+        $cardSystemIds = !empty($content) ? Json::decodeAssociatively($content) : null;
 
-        if (!is_array($cardSystemIds) || empty($cardSystemIds)) {
+        if (!is_array($cardSystemIds)) {
             throw ApiProblem::bodyInvalidDataWithDetail('Payload should be an array of card system ids');
         }
 

--- a/tests/UiTPASService/Controller/SetCardSystemsOnEventRequestHandlerTest.php
+++ b/tests/UiTPASService/Controller/SetCardSystemsOnEventRequestHandlerTest.php
@@ -55,23 +55,24 @@ final class SetCardSystemsOnEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_on_missing_card_systems(): void
+    public function it_allows_an_empty_list_of_card_system_ids(): void
     {
         $eventId = '52943e99-51c8-4ba9-95ef-ec7d93f16ed9';
         $cardSystemIds = [];
-
-        $this->uitpas->expects($this->never())
-            ->method('setCardSystemsForEvent');
 
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('eventId', $eventId)
             ->withJsonBodyFromArray($cardSystemIds)
             ->build('GET');
 
-        $this->assertCallableThrowsApiProblem(
-            ApiProblem::bodyInvalidDataWithDetail('Payload should be an array of card system ids'),
-            fn () => $this->setCardSystemsOnEventRequestHandler->handle($request),
-        );
+        $this->uitpas->expects($this->once())
+            ->method('setCardSystemsForEvent')
+            ->with($eventId, $cardSystemIds)
+            ->willReturn(null);
+
+        $response = $this->setCardSystemsOnEventRequestHandler->handle($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
### Fixed

- When updating an event's UiTPAS card systems, an empty list of card systems is allowed (again)

---
Ticket: https://jira.uitdatabank.be/browse/III-4950
