### PR TITLE
III-4913 Remove calendarSummary property fallback in Excel exports

### DIFF
--- a/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
+++ b/src/EventExport/Format/TabularData/TabularDataEventFormatter.php
@@ -13,7 +13,6 @@ use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use CultuurNet\UDB3\EventExport\CalendarSummary\CalendarSummaryRepositoryInterface;
 use CultuurNet\UDB3\EventExport\CalendarSummary\ContentType;
 use CultuurNet\UDB3\EventExport\CalendarSummary\Format;
-use CultuurNet\UDB3\EventExport\CalendarSummary\SummaryUnavailableException;
 use CultuurNet\UDB3\EventExport\Format\HTML\Uitpas\EventInfo\EventInfoServiceInterface;
 use CultuurNet\UDB3\EventExport\Media\MediaFinder;
 use CultuurNet\UDB3\EventExport\Media\Url;
@@ -22,6 +21,7 @@ use CultuurNet\UDB3\EventExport\UitpasInfoFormatter;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\StringFilter\StripHtmlStringFilter;
 use DateTimeInterface;
+use Exception;
 use stdClass;
 
 class TabularDataEventFormatter
@@ -751,7 +751,6 @@ class TabularDataEventFormatter
 
     /**
      * Gives a formatter that tries to fetch a summary in plain text.
-     * If the formatted summary is missing, the summary that is available on the event will be used as fallback.
      */
     private function calendarSummaryFormatter(
         Format $format,
@@ -762,13 +761,11 @@ class TabularDataEventFormatter
 
             if ($calendarSummaryRepository) {
                 try {
-                    $calendarSummary = $calendarSummaryRepository->get($eventId, ContentType::plain(), $format);
-                } catch (SummaryUnavailableException $exception) {
-                    //TODO: Log the missing summaries.
-                };
+                    return $calendarSummaryRepository->get($eventId, ContentType::plain(), $format);
+                } catch (Exception $exception) {
+                    return '';
+                }
             }
-
-            return $calendarSummary ?? $event->calendarSummary;
         };
     }
 

--- a/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
+++ b/tests/EventExport/Format/TabularData/TabularDataEventFormatterTest.php
@@ -536,14 +536,30 @@ class TabularDataEventFormatterTest extends TestCase
             'calendarSummary',
         ];
 
+        $calendarSummaryRepository = $this->createMock(CalendarSummaryRepositoryInterface::class);
+
+        $calendarSummaryRepository->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(
+                function (string $eventId, ContentType $contentType, Format $format): string {
+                    if ($contentType->sameAs(ContentType::plain()) && $format->sameAs(Format::md())) {
+                        return 'SHORT CALENDAR SUMMARY';
+                    }
+                    if ($contentType->sameAs(ContentType::plain()) && $format->sameAs(Format::lg())) {
+                        return 'LONG CALENDAR SUMMARY';
+                    }
+                    return '';
+                }
+            );
+
         $event = $this->getJSONEventFromFile('event_with_dates.json');
-        $formatter = new TabularDataEventFormatter($includedProperties);
+        $formatter = new TabularDataEventFormatter($includedProperties, null, $calendarSummaryRepository);
         $formattedEvent = $formatter->formatEvent($event);
 
         $expectedFormattedEvent = [
             'id' => 'd1f0e71d-a9a8-4069-81fb-530134502c58',
-            'calendarSummary.short' => 'ma 02/03/15 van 13:30 tot 16:30  ma 09/03/15 van 13:30 tot 16:30  ' . 'ma 16/03/15 van 13:30 tot 16:30  ma 23/03/15 van 13:30 tot 16:30  ma 30/03/15 van 13:30 tot 16:30 ',
-            'calendarSummary.long' => 'ma 02/03/15 van 13:30 tot 16:30  ma 09/03/15 van 13:30 tot 16:30  ' . 'ma 16/03/15 van 13:30 tot 16:30  ma 23/03/15 van 13:30 tot 16:30  ma 30/03/15 van 13:30 tot 16:30 ',
+            'calendarSummary.short' => 'SHORT CALENDAR SUMMARY',
+            'calendarSummary.long' => 'LONG CALENDAR SUMMARY',
         ];
 
         $this->assertEquals($expectedFormattedEvent, $formattedEvent);

--- a/tests/EventExport/samples/event_with_dates.json
+++ b/tests/EventExport/samples/event_with_dates.json
@@ -4,7 +4,6 @@
   "name": {"nl": "Koran, kaliefen en kruistochten - De fundamenten van de islam"},
   "description": {"nl": "De islam is niet meer weg te denken uit onze maatschappij. Aan de hand van boeiende anekdotes doet Urbain Vermeulen de ontstaansgeschiedenis van de godsdienst uit de doeken. Hij verklaart hoe de islam zich verhoudt tot de andere wereldgodsdiensten en legt de oorsprong van de fundamentalistische strekkingen bloot. Dit historische perspectief helpt u om actuele ontwikkelingen beter te begrijpen."},
   "image": "http:\/\/media.uitdatabank.be\/20141211\/558bb7cf-5ff8-40b4-872b-5f5b46bb16c2.jpg",
-  "calendarSummary": "ma 02\/03\/15 van 13:30 tot 16:30  ma 09\/03\/15 van 13:30 tot 16:30  ma 16\/03\/15 van 13:30 tot 16:30  ma 23\/03\/15 van 13:30 tot 16:30  ma 30\/03\/15 van 13:30 tot 16:30 ",
   "location": {
     "@type": "Place",
     "@id": "http:\/\/culudb-silex.dev:8080\/place\/A871DB85-01DB-DBD3-DAF62CDB2DD7B871",


### PR DESCRIPTION
### Fixed

- Tabular data exports no longer look for a non-existent `calendarSummary` property on the event JSON-LD if the calendar summary cannot be generated
- The related unit test now actually tests that the calendar summary is generated, instead of testing the fallback

---
Ticket: https://jira.uitdatabank.be/browse/III-4913
