### PR TITLE
Make sure to use HTTPS and no explicit port when proxying a request

### DIFF
--- a/src/Http/Proxy/ProxyRequestHandler.php
+++ b/src/Http/Proxy/ProxyRequestHandler.php
@@ -22,8 +22,13 @@ final class ProxyRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        // Make sure to explicitly set the scheme to https and remove the port (if set), because our load balancer on
+        // AWS that handles SSL forwards the request to the backend server using the HTTP scheme and port 80, while
+        // we want to proxy the request using HTTPS.
         $rewrittenUri = $request->getUri()
-            ->withHost($this->newDomain);
+            ->withHost($this->newDomain)
+            ->withScheme('https')
+            ->withPort(null);
 
         $rewrittenRequest = $request->withUri($rewrittenUri);
 

--- a/tests/Http/Proxy/ProxyRequestHandlerTest.php
+++ b/tests/Http/Proxy/ProxyRequestHandlerTest.php
@@ -28,7 +28,7 @@ final class ProxyRequestHandlerTest extends TestCase
     public function it_changes_the_domain_and_then_resends_it_and_returns_the_response(): void
     {
         $originalRequest = (new Psr7RequestBuilder())
-            ->withUriFromString('https://mock.local/test/foo/bar')
+            ->withUriFromString('http://mock.local:80/test/foo/bar')
             ->withJsonBodyFromArray(['foo' => 'bar'])
             ->withHeader('x-test-header', 'example value')
             ->build('POST');


### PR DESCRIPTION
### Fixed

- Fixed the proxy endpoints for `/events`, `/places`, `/offers` and `/organizers` on acc where they were broken because the incoming request was e.g. `http://io-acc.uitdatabank.be:80/events` (due to the load balancer handling SSL and then forwarding the request using plain HTTP), and the proxy endpoints rewrote that to `https://search-acc.uitdatabank.be:80/events` which does not work since port 80 is not the right port for SSL (on our servers)
