### PR TITLE
III-4968 PSR-11 Error service providers

### DIFF
--- a/app/Error/CliErrorHandlerProvider.php
+++ b/app/Error/CliErrorHandlerProvider.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Error;
+namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
-use CultuurNet\UDB3\Error\ErrorLogger;
-use CultuurNet\UDB3\Error\LoggerFactory;
-use CultuurNet\UDB3\Error\LoggerName;
 
 final class CliErrorHandlerProvider extends AbstractServiceProvider
 {

--- a/app/Error/ContextExceptionConverterProcessor.php
+++ b/app/Error/ContextExceptionConverterProcessor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Error;
+namespace CultuurNet\UDB3\Error;
 
 use Monolog\Processor\ProcessorInterface;
 use Throwable;

--- a/app/Error/LoggerFactory.php
+++ b/app/Error/LoggerFactory.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
-use CultuurNet\UDB3\Silex\Error\ContextExceptionConverterProcessor;
 use CultuurNet\UDB3\Silex\Error\SentryHandlerScopeDecorator;
 use Monolog\Handler\GroupHandler;
 use Monolog\Handler\StreamHandler;

--- a/app/Error/LoggerFactory.php
+++ b/app/Error/LoggerFactory.php
@@ -6,7 +6,6 @@ namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
-use CultuurNet\UDB3\Silex\Error\SentryHandlerScopeDecorator;
 use Monolog\Handler\GroupHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;

--- a/app/Error/SentryHandlerScopeDecorator.php
+++ b/app/Error/SentryHandlerScopeDecorator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Error;
+namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;

--- a/app/Error/SentryServiceProvider.php
+++ b/app/Error/SentryServiceProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Error;
+namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use Sentry\SentrySdk;

--- a/app/Error/WebErrorHandler.php
+++ b/app/Error/WebErrorHandler.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\ApiProblemJsonResponse;
 use CultuurNet\UDB3\ReadModel\DocumentDoesNotExist;
 use CultuurNet\UDB3\Security\CommandAuthorizationException;
-use CultuurNet\UDB3\Silex\Error\ContextExceptionConverterProcessor;
 use Error;
 use League\Route\Http\Exception\MethodNotAllowedException;
 use League\Route\Http\Exception\NotFoundException;

--- a/app/Silex/Error/CliErrorHandlerProvider.php
+++ b/app/Silex/Error/CliErrorHandlerProvider.php
@@ -4,27 +4,29 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Error\ErrorLogger;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
-use Silex\Application;
-use Silex\ServiceProviderInterface;
 
-class CliErrorHandlerProvider implements ServiceProviderInterface
+final class CliErrorHandlerProvider extends AbstractServiceProvider
 {
-    public function register(Application $app): void
+    protected function getProvidedServiceNames(): array
     {
-        $app[ErrorLogger::class] = $app::share(
-            function (HybridContainerApplication $app): ErrorLogger {
+        return [ErrorLogger::class];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            ErrorLogger::class,
+            function () use ($container): ErrorLogger {
                 return new ErrorLogger(
-                    LoggerFactory::create($app->getLeagueContainer(), LoggerName::forCli())
+                    LoggerFactory::create($container, LoggerName::forCli())
                 );
             }
         );
-    }
-
-    public function boot(Application $app): void
-    {
     }
 }

--- a/app/Silex/Error/SentryServiceProvider.php
+++ b/app/Silex/Error/SentryServiceProvider.php
@@ -4,29 +4,32 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Error;
 
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
-use Silex\Application;
-use Silex\ServiceProviderInterface;
 use function Sentry\init;
 
-class SentryServiceProvider implements ServiceProviderInterface
+final class SentryServiceProvider extends AbstractServiceProvider
 {
-    public function register(Application $app): void
+    protected function getProvidedServiceNames(): array
     {
-        $app[HubInterface::class] = $app->share(
-            function (Application $app) {
+        return [HubInterface::class];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            HubInterface::class,
+            function () use ($container) {
                 init([
-                    'dsn' => $app['config']['sentry']['dsn'],
-                    'environment' => $app['config']['sentry']['environment'],
+                    'dsn' => $container->get('config')['sentry']['dsn'],
+                    'environment' => $container->get('config')['sentry']['environment'],
                 ]);
 
                 return SentrySdk::getCurrentHub();
             }
         );
-    }
-
-    public function boot(Application $app): void
-    {
     }
 }

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -36,7 +36,7 @@ use CultuurNet\UDB3\Silex\Console\UpdateOfferStatusCommand;
 use CultuurNet\UDB3\Silex\Console\UpdateUniqueLabels;
 use CultuurNet\UDB3\Silex\Console\UpdateUniqueOrganizers;
 use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
-use CultuurNet\UDB3\Silex\Error\CliErrorHandlerProvider;
+use CultuurNet\UDB3\Error\CliErrorHandlerProvider;
 use CultuurNet\UDB3\Error\ErrorLogger;
 use CultuurNet\UDB3\Silex\Event\EventJSONLDServiceProvider;
 use CultuurNet\UDB3\Silex\Organizer\OrganizerJSONLDServiceProvider;

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -53,7 +53,7 @@ const API_NAME = ApiName::CLI;
 $app = require __DIR__ . '/../bootstrap.php';
 $container = $app->getLeagueContainer();
 
-$app->register(new CliErrorHandlerProvider());
+$container->addServiceProvider(new CliErrorHandlerProvider());
 
 $app->register(
     new ConsoleServiceProvider(),

--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -35,6 +35,7 @@ use CultuurNet\UDB3\Silex\Console\UpdateEventsAttendanceMode;
 use CultuurNet\UDB3\Silex\Console\UpdateOfferStatusCommand;
 use CultuurNet\UDB3\Silex\Console\UpdateUniqueLabels;
 use CultuurNet\UDB3\Silex\Console\UpdateUniqueOrganizers;
+use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use CultuurNet\UDB3\Silex\Error\CliErrorHandlerProvider;
 use CultuurNet\UDB3\Error\ErrorLogger;
 use CultuurNet\UDB3\Silex\Event\EventJSONLDServiceProvider;
@@ -48,8 +49,9 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 const API_NAME = ApiName::CLI;
 
-/** @var \Silex\Application $app */
+/** @var HybridContainerApplication $app */
 $app = require __DIR__ . '/../bootstrap.php';
+$container = $app->getLeagueContainer();
 
 $app->register(new CliErrorHandlerProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -164,7 +164,7 @@ $app['event_store_factory'] = $app->protect(
     }
 );
 
-$app->register(new SentryServiceProvider());
+$container->addServiceProvider(new SentryServiceProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\SavedSearches\SavedSearchesServiceProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -72,7 +72,7 @@ use CultuurNet\UDB3\Silex\CultureFeed\CultureFeedServiceProvider;
 use CultuurNet\UDB3\Silex\Curators\CuratorsServiceProvider;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
-use CultuurNet\UDB3\Silex\Error\SentryServiceProvider;
+use CultuurNet\UDB3\Error\SentryServiceProvider;
 use CultuurNet\UDB3\Silex\Event\EventCommandHandlerProvider;
 use CultuurNet\UDB3\Silex\Event\EventHistoryServiceProvider;
 use CultuurNet\UDB3\Silex\Event\EventJSONLDServiceProvider;


### PR DESCRIPTION
### Changed

- Converted service providers from `CultuurNet\UDB3\Silex\Error` namespace to service providers for the new PSR-11 container.
- Moved all classes from this `CultuurNet\UDB3\Silex\Error` to `CultuurNet\UDB3\Error` as they are not related to Silex anymore.

---
Ticket: https://jira.uitdatabank.be/browse/III-4968
