### PR TITLE
III-4991 Refactor worker_bootstrap.php to use PSR-11 container

### DIFF
--- a/worker_bootstrap.php
+++ b/worker_bootstrap.php
@@ -2,13 +2,14 @@
 
 use CultuurNet\UDB3\CommandHandling\QueueJob;
 use CultuurNet\UDB3\Log\ContextEnrichingLogger;
+use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 
 require_once 'vendor/autoload.php';
 
 Resque_Event::listen(
     'beforePerform',
     function (Resque_Job $job) {
-        /** @var \Silex\Application $app */
+        /** @var HybridContainerApplication $app */
         $app = require __DIR__ . '/bootstrap.php';
 
         $logger = new ContextEnrichingLogger(
@@ -44,7 +45,7 @@ Resque_Event::listen(
 Resque_Event::listen(
     'afterPerform',
     function (Resque_Job $job) {
-        /** @var \Silex\Application $app */
+        /** @var HybridContainerApplication $app */
         $app = require __DIR__ . '/bootstrap.php';
 
         $logger = new ContextEnrichingLogger(

--- a/worker_bootstrap.php
+++ b/worker_bootstrap.php
@@ -10,7 +10,6 @@ Resque_Event::listen(
     function (Resque_Job $job) {
         /** @var \Silex\Application $app */
         $app = require __DIR__ . '/bootstrap.php';
-        $app->boot();
 
         $logger = new ContextEnrichingLogger(
             $app['logger_factory.resque_worker']($job->queue),
@@ -47,7 +46,6 @@ Resque_Event::listen(
     function (Resque_Job $job) {
         /** @var \Silex\Application $app */
         $app = require __DIR__ . '/bootstrap.php';
-        $app->boot();
 
         $logger = new ContextEnrichingLogger(
             $app['logger_factory.resque_worker']($job->queue),


### PR DESCRIPTION
### Changed

- The `worker_bootstrap.php` file (used by the Resque worker scripts) now fetches all required services from the PSR-11 container

---
Ticket: https://jira.uitdatabank.be/browse/III-4991
