### PR TITLE
Fix migrations namespace

### DIFF
--- a/migrations.php
+++ b/migrations.php
@@ -2,7 +2,7 @@
 
 return [
     'name' => 'UDB3 Migrations',
-    'migrations_namespace' => 'CultuurNet\UDB3\Silex\Migrations',
+    'migrations_namespace' => 'CultuurNet\UDB3\Migrations',
     'table_name' => 'doctrine_migration_versions',
     'migrations_directory' => 'app/Migrations',
 ];


### PR DESCRIPTION
### Fixed
- Fixed migrations namespace by removing `Silex`
