### PR TITLE
III-4997 Return `$container` instead of `$app` from `bootstrap.php`

### DIFF
--- a/bin/udb3.php
+++ b/bin/udb3.php
@@ -4,9 +4,9 @@
 use Broadway\Domain\Metadata;
 use CultuurNet\UDB3\Console\ConsoleServiceProvider;
 use CultuurNet\UDB3\ApiName;
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use CultuurNet\UDB3\Error\CliErrorHandlerProvider;
 use CultuurNet\UDB3\Error\ErrorLogger;
+use League\Container\DefinitionContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -15,9 +15,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 const API_NAME = ApiName::CLI;
 
-/** @var HybridContainerApplication $app */
-$app = require __DIR__ . '/../bootstrap.php';
-$container = $app->getLeagueContainer();
+/** @var DefinitionContainerInterface $container */
+$container = require __DIR__ . '/../bootstrap.php';
 
 $container->addServiceProvider(new CliErrorHandlerProvider());
 $container->addServiceProvider(new ConsoleServiceProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -907,4 +907,4 @@ if (isset($app['config']['bookable_event']['dummy_place_ids'])) {
     LocationId::setDummyPlaceForEducationIds($app['config']['bookable_event']['dummy_place_ids']);
 }
 
-return $app;
+return $container;

--- a/config/cli-config.php
+++ b/config/cli-config.php
@@ -1,7 +1,10 @@
 <?php
 
+/** @var HybridContainerApplication $application */
 $application = require __DIR__ . '/../bootstrap.php';
+$container = $application->getLeagueContainer();
 
+use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
@@ -10,7 +13,7 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\DBAL\Tools\Console\ConsoleRunner;
 use Symfony\Component\Console\Helper\QuestionHelper;
 
-$connection = $application['dbal_connection'];
+$connection = $container->get('dbal_connection');
 
 $commands = [
     new ExecuteCommand(),

--- a/config/cli-config.php
+++ b/config/cli-config.php
@@ -1,18 +1,16 @@
 <?php
 
-/** @var HybridContainerApplication $application */
-$application = require __DIR__ . '/../bootstrap.php';
-$container = $application->getLeagueContainer();
-
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\DBAL\Tools\Console\ConsoleRunner;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 
+/** @var ContainerInterface $container */
+$container = require __DIR__ . '/../bootstrap.php';
 $connection = $container->get('dbal_connection');
 
 $commands = [

--- a/web/index.php
+++ b/web/index.php
@@ -7,20 +7,19 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use CultuurNet\UDB3\Http\LegacyPathRewriter;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\ApiName;
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use CultuurNet\UDB3\Error\WebErrorHandler;
 use CultuurNet\UDB3\Http\PsrRouterServiceProvider;
 use CultuurNet\UDB3\Proxy\ProxyRequestHandlerServiceProvider;
 use CultuurNet\UDB3\Error\WebErrorHandlerProvider;
 use Laminas\HttpHandlerRunner\Emitter\SapiStreamEmitter;
+use League\Container\DefinitionContainerInterface;
 use League\Route\Router;
 use Slim\Psr7\Factory\ServerRequestFactory;
 
 const API_NAME = ApiName::JSONLD;
 
-/** @var HybridContainerApplication $app */
-$app = require __DIR__ . '/../bootstrap.php';
-$container = $app->getLeagueContainer();
+/** @var DefinitionContainerInterface $container */
+$container = require __DIR__ . '/../bootstrap.php';
 
 $container->addServiceProvider(new WebErrorHandlerProvider());
 

--- a/worker_bootstrap.php
+++ b/worker_bootstrap.php
@@ -2,16 +2,15 @@
 
 use CultuurNet\UDB3\CommandHandling\QueueJob;
 use CultuurNet\UDB3\Log\ContextEnrichingLogger;
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
+use Psr\Container\ContainerInterface;
 
 require_once 'vendor/autoload.php';
 
 Resque_Event::listen(
     'beforePerform',
     function (Resque_Job $job) {
-        /** @var HybridContainerApplication $app */
-        $app = require __DIR__ . '/bootstrap.php';
-        $container = $app->getLeagueContainer();
+        /** @var ContainerInterface $container */
+        $container = require __DIR__ . '/bootstrap.php';
 
         $logger = new ContextEnrichingLogger(
             $container->get('logger_factory.resque_worker')($job->queue),
@@ -46,9 +45,8 @@ Resque_Event::listen(
 Resque_Event::listen(
     'afterPerform',
     function (Resque_Job $job) {
-        /** @var HybridContainerApplication $app */
-        $app = require __DIR__ . '/bootstrap.php';
-        $container = $app->getLeagueContainer();
+        /** @var ContainerInterface $container */
+        $container = require __DIR__ . '/bootstrap.php';
 
         $logger = new ContextEnrichingLogger(
             $container->get('logger_factory.resque_worker')($job->queue),


### PR DESCRIPTION
### Changed

- `bootstrap.php` now returns the `$container` variable with the new League container instead of the Silex application `$app` variable
- `config/cli-config.php`, used by the Doctrine Migrations, has been updated to fetch the necessary service (the DB connection) from the PSR-11 container
- All places where `bootstrap.php` are included now use the returned container directly instead of assuming that the return value is the Silex application and getting it from that. (All those files only used the `$container` already after refactorings in other PRs)

---
Ticket: https://jira.uitdatabank.be/browse/III-4997
