### PR TITLE
III-4976 make Media PSR-11 Comliant

### DIFF
--- a/app/Media/ImageStorageProvider.php
+++ b/app/Media/ImageStorageProvider.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Media;
+namespace CultuurNet\UDB3\Media;
 
 use Aws\S3\S3Client;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
-use CultuurNet\UDB3\Media\ImageStorage;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;

--- a/app/Media/ImageStorageProvider.php
+++ b/app/Media/ImageStorageProvider.php
@@ -28,7 +28,7 @@ final class ImageStorageProvider extends AbstractServiceProvider
         $container->addShared(
             'local_file_system',
             function (): Filesystem {
-                $localAdapter = new LocalFilesystemAdapter(__DIR__ . '/../../../');
+                $localAdapter = new LocalFilesystemAdapter(__DIR__ . '/../../');
                 return new Filesystem($localAdapter);
             }
         );

--- a/app/Media/MediaImportServiceProvider.php
+++ b/app/Media/MediaImportServiceProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Media;
+namespace CultuurNet\UDB3\Media;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Model\Import\MediaObject\MediaManagerImageCollectionFactory;

--- a/app/Media/MediaServiceProvider.php
+++ b/app/Media/MediaServiceProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex\Media;
+namespace CultuurNet\UDB3\Media;
 
 use Broadway\EventHandling\EventBus;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
@@ -10,12 +10,7 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Http\Media\GetMediaRequestHandler;
 use CultuurNet\UDB3\Http\Media\UploadMediaRequestHandler;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
-use CultuurNet\UDB3\Media\ImageUploaderService;
-use CultuurNet\UDB3\Media\MediaUrlMapping;
-use CultuurNet\UDB3\Media\MediaManager;
-use CultuurNet\UDB3\Media\MediaObjectRepository;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
-use CultuurNet\UDB3\Media\SimplePathGenerator;
 use CultuurNet\UDB3\AggregateType;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;

--- a/app/Silex/Media/ImageStorageProvider.php
+++ b/app/Silex/Media/ImageStorageProvider.php
@@ -43,7 +43,7 @@ class ImageStorageProvider implements ServiceProviderInterface
                 return new ImageStorage(
                     $app['local_file_system'],
                     $app['s3_file_system'],
-                    $app['media.media_directory']
+                    $app['config']['media']['media_directory']
                 );
             }
         );

--- a/app/Silex/Media/ImageStorageProvider.php
+++ b/app/Silex/Media/ImageStorageProvider.php
@@ -12,7 +12,7 @@ use League\Flysystem\Local\LocalFilesystemAdapter;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
-class ImageStorageProvider implements ServiceProviderInterface
+final class ImageStorageProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {

--- a/app/Silex/Media/ImageStorageProvider.php
+++ b/app/Silex/Media/ImageStorageProvider.php
@@ -18,14 +18,14 @@ final class ImageStorageProvider extends AbstractServiceProvider
         return [
             'local_file_system',
             's3_file_system',
-            'image_storage'
+            'image_storage',
         ];
     }
 
     public function register(): void
     {
         $container = $this->getContainer();
-        
+
         $container->addShared(
             'local_file_system',
             function (): Filesystem {
@@ -33,7 +33,7 @@ final class ImageStorageProvider extends AbstractServiceProvider
                 return new Filesystem($localAdapter);
             }
         );
-        
+
         $container->addShared(
             's3_file_system',
             function () use ($container): Filesystem {
@@ -49,7 +49,7 @@ final class ImageStorageProvider extends AbstractServiceProvider
                 return new Filesystem($s3Adapter);
             }
         );
-        
+
         $container->addShared(
             'image_storage',
             function () use ($container): ImageStorage {

--- a/app/Silex/Media/MediaImportServiceProvider.php
+++ b/app/Silex/Media/MediaImportServiceProvider.php
@@ -9,7 +9,6 @@ use CultuurNet\UDB3\Model\Import\MediaObject\MediaManagerImageCollectionFactory;
 
 final class MediaImportServiceProvider extends AbstractServiceProvider
 {
-
     protected function getProvidedServiceNames(): array
     {
         return ['import_image_collection_factory'];

--- a/app/Silex/Media/MediaImportServiceProvider.php
+++ b/app/Silex/Media/MediaImportServiceProvider.php
@@ -4,30 +4,28 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Silex\Media;
 
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Model\Import\MediaObject\MediaManagerImageCollectionFactory;
-use Silex\Application;
-use Silex\ServiceProviderInterface;
 
-class MediaImportServiceProvider implements ServiceProviderInterface
+class MediaImportServiceProvider extends AbstractServiceProvider
 {
-    /**
-     * @inheritdoc
-     */
-    public function register(Application $app)
+
+    protected function getProvidedServiceNames(): array
     {
-        $app['import_image_collection_factory'] = $app->share(
-            function (Application $app) {
+        return ['import_image_collection_factory'];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            'import_image_collection_factory',
+            function () use ($container) {
                 return new MediaManagerImageCollectionFactory(
-                    $app['media_manager']
+                    $container->get('media_manager')
                 );
             }
         );
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function boot(Application $app)
-    {
     }
 }

--- a/app/Silex/Media/MediaImportServiceProvider.php
+++ b/app/Silex/Media/MediaImportServiceProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Silex\Media;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Model\Import\MediaObject\MediaManagerImageCollectionFactory;
 
-finalclass MediaImportServiceProvider extends AbstractServiceProvider
+final class MediaImportServiceProvider extends AbstractServiceProvider
 {
 
     protected function getProvidedServiceNames(): array

--- a/app/Silex/Media/MediaImportServiceProvider.php
+++ b/app/Silex/Media/MediaImportServiceProvider.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\Silex\Media;
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Model\Import\MediaObject\MediaManagerImageCollectionFactory;
 
-class MediaImportServiceProvider extends AbstractServiceProvider
+finalclass MediaImportServiceProvider extends AbstractServiceProvider
 {
 
     protected function getProvidedServiceNames(): array

--- a/app/Silex/Media/MediaServiceProvider.php
+++ b/app/Silex/Media/MediaServiceProvider.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Silex\Media;
 
 use Broadway\EventHandling\EventBus;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Http\Media\GetMediaRequestHandler;
 use CultuurNet\UDB3\Http\Media\UploadMediaRequestHandler;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
@@ -16,118 +17,139 @@ use CultuurNet\UDB3\Media\MediaObjectRepository;
 use CultuurNet\UDB3\Media\Serialization\MediaObjectSerializer;
 use CultuurNet\UDB3\Media\SimplePathGenerator;
 use CultuurNet\UDB3\AggregateType;
-use CultuurNet\UDB3\Silex\Container\HybridContainerApplication;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
-use Silex\Application;
-use Silex\ServiceProviderInterface;
 
-class MediaServiceProvider implements ServiceProviderInterface
+class MediaServiceProvider extends AbstractServiceProvider
 {
-    public function register(Application $app): void
+    protected function getProvidedServiceNames(): array
     {
-        $app['image_uploader'] = $app->share(
-            function (Application $app) {
+        return [
+            'image_uploader',
+            'media_object_store',
+            'media_object_repository',
+            'media_object_iri_generator',
+            'content_url_generator',
+            'media_object_serializer',
+            'media_manager',
+            'media_url_mapping',
+            GetMediaRequestHandler::class,
+            UploadMediaRequestHandler::class,
+        ];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            'image_uploader',
+            function () use ($container) {
                 return new ImageUploaderService(
                     new Version4Generator(),
-                    $app['event_command_bus'],
-                    $app['local_file_system'],
-                    $app['media.upload_directory'],
-                    $app['media.file_size_limit']
+                    $container->get('event_command_bus'),
+                    $container->get('local_file_system'),
+                    $container->get('config')['media']['upload_directory'],
+                    $container->get('config')['media']['file_size_limit'] ?? 1000000
                 );
             }
         );
 
-        $app['media_object_store'] = $app->share(
-            function ($app) {
-                return $app['event_store_factory'](
+        $container->addShared(
+            'media_object_store',
+            function () use ($container) {
+                return $container->get('event_store_factory')(
                     AggregateType::media_object()
                 );
             }
         );
 
-        $app['media_object_repository'] = $app->share(
-            function ($app) {
+        $container->addShared(
+            'media_object_repository',
+            function () use ($container) {
                 return new MediaObjectRepository(
-                    $app['media_object_store'],
-                    $app[EventBus::class],
+                    $container->get('media_object_store'),
+                    $container->get(EventBus::class),
                     [
-                        $app['event_stream_metadata_enricher'],
+                        $container->get('event_stream_metadata_enricher'),
                     ]
                 );
             }
         );
 
-        $app['media_object_iri_generator'] = $app->share(
-            function (Application $app) {
+        $container->addShared(
+            'media_object_iri_generator',
+            function () use ($container) {
                 return new CallableIriGenerator(
-                    function ($filePath) use ($app) {
-                        return $app['config']['url'] . '/images/' . $filePath;
+                    function ($filePath) use ($container) {
+                        return $container->get('config')['url'] . '/images/' . $filePath;
                     }
                 );
             }
         );
 
-        $app['content_url_generator'] = $app->share(
-            function (Application $app) {
+        $container->addShared(
+            'content_url_generator',
+            function () use ($container) {
                 return new CallableIriGenerator(
-                    function ($filePath) use ($app) {
-                        return $app['config']['media']['content_url'] . '/' . $filePath;
+                    function ($filePath) use ($container) {
+                        return $container->get('config')['media']['content_url'] . '/' . $filePath;
                     }
                 );
             }
         );
 
-        $app['media_object_serializer'] = $app->share(
-            function (Application $app) {
+        $container->addShared(
+            'media_object_serializer',
+            function () use ($container) {
                 return new MediaObjectSerializer(
-                    $app['media_object_iri_generator']
+                    $container->get('media_object_iri_generator')
                 );
             }
         );
 
-        $app['media_manager'] = $app->share(
-            function (HybridContainerApplication $app) {
+        $container->addShared(
+            'media_manager',
+            function () use ($container) {
                 $mediaManager = new MediaManager(
-                    $app['content_url_generator'],
+                    $container->get('content_url_generator'),
                     new SimplePathGenerator(),
-                    $app['media_object_repository'],
-                    $app['image_storage']
+                    $container->get('media_object_repository'),
+                    $container->get('image_storage')
                 );
 
-                $mediaManager->setLogger(LoggerFactory::create($app->getLeagueContainer(), LoggerName::forService('media', 'manager')));
+                $mediaManager->setLogger(LoggerFactory::create($container, LoggerName::forService('media', 'manager')));
 
                 return $mediaManager;
             }
         );
 
-        $app['media_url_mapping'] = $app->share(
-            function (Application $app) {
-                return new MediaUrlMapping($app['config']['media']['media_url_mapping']);
+        $container->addShared(
+            'media_url_mapping',
+            function () use ($container) {
+                return new MediaUrlMapping($container->get('config')['media']['media_url_mapping']);
             }
         );
 
-        $app[GetMediaRequestHandler::class] = $app->share(
-            function (Application $app) {
+        $container->addShared(
+            GetMediaRequestHandler::class,
+            function () use ($container) {
                 return new GetMediaRequestHandler(
-                    $app['media_manager'],
-                    $app['media_object_serializer'],
-                    $app['media_url_mapping']
+                    $container->get('media_manager'),
+                    $container->get('media_object_serializer'),
+                    $container->get('media_url_mapping')
                 );
             }
         );
 
-        $app[UploadMediaRequestHandler::class] = $app->share(
-            function (Application $app) {
+        $container->addShared(
+            UploadMediaRequestHandler::class,
+            function () use ($container) {
                 return new UploadMediaRequestHandler(
-                    $app['image_uploader'],
-                    $app['media_object_iri_generator']
+                    $container->get('image_uploader'),
+                    $container->get('media_object_iri_generator')
                 );
             }
         );
-    }
-
-    public function boot(Application $app): void
-    {
     }
 }

--- a/app/Silex/Media/MediaServiceProvider.php
+++ b/app/Silex/Media/MediaServiceProvider.php
@@ -20,7 +20,7 @@ use CultuurNet\UDB3\AggregateType;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 
-class MediaServiceProvider extends AbstractServiceProvider
+final class MediaServiceProvider extends AbstractServiceProvider
 {
     protected function getProvidedServiceNames(): array
     {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -842,13 +842,8 @@ $app->register(new UiTPASServiceLabelsServiceProvider());
 $app->register(new UiTPASServiceEventServiceProvider());
 $app->register(new UiTPASServiceOrganizerServiceProvider());
 
-$app->register(
-    new \CultuurNet\UDB3\Silex\Media\MediaServiceProvider(),
-    [
-        'media.upload_directory' => $app['config']['media']['upload_directory'],
-        'media.media_directory' => $app['config']['media']['media_directory'],
-        'media.file_size_limit' => $app['config']['media']['file_size_limit'] ?? 1000000
-     ],
+$container->addServiceProvider(
+    new \CultuurNet\UDB3\Silex\Media\MediaServiceProvider()
 );
 
 $app->register(new ImageStorageProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -888,7 +888,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Organizer\OrganizerGeoCoordinatesServi
 $app->register(new EventHistoryServiceProvider());
 $app->register(new PlaceHistoryServiceProvider());
 
-$app->register(new \CultuurNet\UDB3\Silex\Media\MediaImportServiceProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\Silex\Media\MediaImportServiceProvider());
 
 $app->register(new CuratorsServiceProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -846,7 +846,7 @@ $container->addServiceProvider(
     new \CultuurNet\UDB3\Silex\Media\MediaServiceProvider()
 );
 
-$app->register(new ImageStorageProvider());
+$container->addServiceProvider(new ImageStorageProvider());
 
 $app['predis.client'] = $app->share(function ($app) {
     $redisURI = isset($app['config']['redis']['uri']) ?

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -80,7 +80,7 @@ use CultuurNet\UDB3\Silex\Event\EventRequestHandlerServiceProvider;
 use CultuurNet\UDB3\Silex\EventBus\EventBusServiceProvider;
 use CultuurNet\UDB3\Jobs\JobsServiceProvider;
 use CultuurNet\UDB3\Silex\Labels\LabelServiceProvider;
-use CultuurNet\UDB3\Silex\Media\ImageStorageProvider;
+use CultuurNet\UDB3\Media\ImageStorageProvider;
 use CultuurNet\UDB3\Silex\Metadata\MetadataServiceProvider;
 use CultuurNet\UDB3\Silex\Organizer\OrganizerJSONLDServiceProvider;
 use CultuurNet\UDB3\Silex\Organizer\OrganizerCommandHandlerProvider;
@@ -843,7 +843,7 @@ $app->register(new UiTPASServiceEventServiceProvider());
 $app->register(new UiTPASServiceOrganizerServiceProvider());
 
 $container->addServiceProvider(
-    new \CultuurNet\UDB3\Silex\Media\MediaServiceProvider()
+    new \CultuurNet\UDB3\Media\MediaServiceProvider()
 );
 
 $container->addServiceProvider(new ImageStorageProvider());
@@ -888,7 +888,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Organizer\OrganizerGeoCoordinatesServi
 $app->register(new EventHistoryServiceProvider());
 $app->register(new PlaceHistoryServiceProvider());
 
-$container->addServiceProvider(new \CultuurNet\UDB3\Silex\Media\MediaImportServiceProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\Media\MediaImportServiceProvider());
 
 $app->register(new CuratorsServiceProvider());
 


### PR DESCRIPTION
### Added

### Changed

- `ImageStorageProvider`, `MediaImportServiceProvider` & `MediaServiceProvider` are now shared via the Container instead of the Silex App.
- `ImageStorageProvider`, `MediaImportServiceProvider` & `MediaServiceProvider` were moved outside the Silex folder.

---
Ticket: https://jira.uitdatabank.be/browse/III-4976
