### PR TITLE
Remove unused CDBXML and CURATORS_LISTENER ApiName constants

### DIFF
--- a/app/ApiName.php
+++ b/app/ApiName.php
@@ -7,9 +7,7 @@ namespace CultuurNet\UDB3;
 final class ApiName
 {
     public const JSONLD = 'JSON-LD API';
-    public const CDBXML = 'cdbXML API';
     public const UITPAS_LISTENER = 'UiTPAS Listener';
-    public const CURATORS_LISTENER = 'Curators Listener';
     public const CLI = 'CLI';
     public const UNKNOWN = 'Unknown';
 }


### PR DESCRIPTION
### Removed

- Removed two unused `ApiName` constants (unused since #1166)

---

Just noticed these by coincidence
