### PR TITLE
III-4719 Convert (some) `CultureFeed_HttpException` errors to 502 Bad Gateway

### DIFF
--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -24,7 +24,9 @@ final class ErrorLogger
 
     public function log(Throwable $throwable): void
     {
-        if (self::isBadRequestException($throwable) || self::isBadCLIInput($throwable)) {
+        if (self::isBadRequestException($throwable) ||
+            self::isBadGateway($throwable) ||
+            self::isBadCLIInput($throwable)) {
             return;
         }
 
@@ -48,5 +50,11 @@ final class ErrorLogger
     {
         $apiProblem = ApiProblemFactory::createFromThrowable($e);
         return $apiProblem->getStatus() >= 400 && $apiProblem->getStatus() < 500;
+    }
+
+    public static function isBadGateway(Throwable $e): bool
+    {
+        $apiProblem = ApiProblemFactory::createFromThrowable($e);
+        return $apiProblem->getStatus() === 502;
     }
 }

--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -455,4 +455,17 @@ final class ApiProblem extends Exception
     {
         return self::bodyInvalidData(new SchemaError('/', "The property '$field' is required."));
     }
+
+    public static function badGateway(string $detail): self
+    {
+        // For 502 Bad Gateway we use about:blank because a) 502 is always type "bad gateway" and b) we don't want to
+        // document self-explanatory 5xx error codes, especially because an integrator cannot fix them in their own
+        // code.
+        return self::create(
+            'about:blank',
+            'Bad Gateway',
+            502,
+            $detail
+        );
+    }
 }

--- a/src/Http/ApiProblem/ApiProblemFactory.php
+++ b/src/Http/ApiProblem/ApiProblemFactory.php
@@ -149,6 +149,17 @@ final class ApiProblemFactory
             return ApiProblem::urlNotFound($message);
         }
 
+        // In some cases the UiTPAS servers return a 404 error with an HTML page. In this case we treat it as UiTPAS
+        // being down and return a Bad Gateway error, because the response is caused by the UiTPAS web server not
+        // being configured / running correctly.
+        // Note: The "reponse" below is not a typo, that's actually the wording in the message of the
+        // CultureFeed_HttpException when a response is not 200...
+        if ($e instanceof CultureFeed_HttpException &&
+            strpos($title, 'The reponse for the HTTP request was not 200') !== false &&
+            strpos($title, '<html') !== false) {
+            return ApiProblem::badGateway('Could not contact the UiTPAS servers. Please try again later.');
+        }
+
         return ApiProblem::blank($title, $e->getCode() ?: 500);
     }
 


### PR DESCRIPTION
### Changed

- Some specific `CultureFeed_HttpException` errors are converted to 502 Bad Gateway responses, and those are now excluded from logs and Sentry (since we cannot fix them on our end, and we have different monitoring to keep an eye on UiTPAS)

---
Ticket: https://jira.uitdatabank.be/browse/III-4719

I tested this manually by temporary making a request handler throw the exception as it was logged in Sentry (locally). We cannot cover this with acceptance tests sadly.
