### PR TITLE
III-4758 Convert `Culturefeed_Exception` with "event already has ticket sales" to correct ApiProblem

### DIFF
--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -421,6 +421,16 @@ final class ApiProblem extends Exception
         );
     }
 
+    public static function eventHasUitpasTicketSales($detail): self
+    {
+        return self::create(
+            'https://api.publiq.be/probs/uitdatabank/event-has-uitpas-ticket-sales',
+            'Event has UiTPAS ticket sales',
+            400,
+            $detail
+        );
+    }
+
     public static function fileMissing($detail): self
     {
         return self::create(

--- a/src/Http/ApiProblem/ApiProblemFactory.php
+++ b/src/Http/ApiProblem/ApiProblemFactory.php
@@ -186,6 +186,17 @@ final class ApiProblemFactory
             return ApiProblem::urlNotFound($message);
         }
 
+        if (strpos($title, 'event already has ticketsales') !== false) {
+            $message = 'Event has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.';
+            if ($routeParameters && $routeParameters->hasEventId()) {
+                $message = sprintf(
+                    'Event with id \'%s\' has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.',
+                    $routeParameters->getEventId()
+                );
+            }
+            return ApiProblem::eventHasUitpasTicketSales($message);
+        }
+
         // In some cases the UiTPAS servers return a 404 error with an HTML page. In this case we treat it as UiTPAS
         // being down and return a Bad Gateway error, because the response is caused by the UiTPAS web server not
         // being configured / running correctly.


### PR DESCRIPTION
### Added

- `ApiProblem::eventHasUitpasTicketSales()` - see https://github.com/cultuurnet/apidocs/pull/73 for the documentation update

### Changed

- `CultureFeed_Exception` is converted to `ApiProblem::eventHasUitpasTicketSales()` if the message contains "event already has ticketsales"

---
Ticket: https://jira.uitdatabank.be/browse/III-4758
