### PR TITLE
III-5006 Fix internal server error in `/labels` when start is higher than result window

### DIFF
--- a/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
+++ b/src/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepository.php
@@ -90,23 +90,20 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
         $query = new Query($name, $userId);
         $foundLabels = $this->search($query);
 
-        if ($foundLabels) {
-            $nameLowerCase = mb_strtolower($name);
-            foreach ($foundLabels as $foundLabel) {
-                $foundLabelLowerCase = mb_strtolower($foundLabel->getName()->toNative());
-                if ($nameLowerCase === $foundLabelLowerCase) {
-                    return true;
-                }
+        $nameLowerCase = mb_strtolower($name);
+        foreach ($foundLabels as $foundLabel) {
+            $foundLabelLowerCase = mb_strtolower($foundLabel->getName()->toNative());
+            if ($nameLowerCase === $foundLabelLowerCase) {
+                return true;
             }
         }
-
         return false;
     }
 
     /**
-     * @return Entity[]|null
+     * @return Entity[]
      */
-    public function search(Query $query): ?array
+    public function search(Query $query): array
     {
         $queryBuilder = $this->createSearchQuery($query);
 
@@ -252,11 +249,11 @@ final class DBALReadRepository extends AbstractDBALRepository implements ReadRep
     }
 
     /**
-     * @return Entity[]|null
+     * @return Entity[]
      */
-    private function getResults(QueryBuilder $queryBuilder): ?array
+    private function getResults(QueryBuilder $queryBuilder): array
     {
-        $entities = null;
+        $entities = [];
 
         $statement = $queryBuilder->execute();
         $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);

--- a/src/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecorator.php
+++ b/src/Label/ReadModels/JSON/Repository/GodUserReadRepositoryDecorator.php
@@ -41,7 +41,7 @@ final class GodUserReadRepositoryDecorator implements ReadRepositoryInterface
         return $this->repository->canUseLabel($userId, $name);
     }
 
-    public function search(Query $query): ?array
+    public function search(Query $query): array
     {
         return $this->repository->search($query);
     }

--- a/src/Label/ReadModels/JSON/Repository/ReadRepositoryInterface.php
+++ b/src/Label/ReadModels/JSON/Repository/ReadRepositoryInterface.php
@@ -14,7 +14,7 @@ interface ReadRepositoryInterface
 
     public function canUseLabel(string $userId, string $name): bool;
 
-    public function search(Query $query): ?array;
+    public function search(Query $query): array;
 
     public function searchTotalLabels(Query $query): int;
 }

--- a/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
+++ b/tests/Label/ReadModels/JSON/Repository/Doctrine/DBALReadRepositoryTest.php
@@ -313,13 +313,11 @@ final class DBALReadRepositoryTest extends BaseDBALRepositoryTest
     /**
      * @test
      */
-    public function it_returns_null_when_nothing_matches_search(): void
+    public function it_returns_an_empty_array_when_nothing_matches_search(): void
     {
         $search = new Query('nothing_please');
-
         $entities = $this->dbalReadRepository->search($search);
-
-        $this->assertNull($entities);
+        $this->assertEquals([], $entities);
     }
 
     /**


### PR DESCRIPTION
### Fixed

- When making a request to the `/labels` endpoint with a `start` parameter than the total result count, an empty result page is returned instead of a 500 Internal Server (this only happened if there were actual results and the start was higher than the total result count)

---
Ticket: https://jira.uitdatabank.be/browse/III-5006
