### PR TITLE
III-5005 Improve file upload errors

### DIFF
--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 final class UploadMediaRequestHandler implements RequestHandlerInterface
@@ -28,9 +29,11 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        if (empty($request->getUploadedFiles())) {
+        $uploadedFiles = $request->getUploadedFiles();
+        if (!isset($uploadedFiles['file']) || !$uploadedFiles['file'] instanceof UploadedFileInterface) {
             throw ApiProblem::fileMissing('The file property is required');
         }
+        $uploadedFile = $uploadedFiles['file'];
 
         if (count($request->getUploadedFiles()) > 1) {
             throw ApiProblem::fileMissing('Only one file is allowed');
@@ -54,7 +57,7 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
         }
 
         $imageId = $this->imageUploader->upload(
-            $request->getUploadedFiles()['file'],
+            $uploadedFile,
             new StringLiteral($description),
             new CopyrightHolder($copyrightHolder),
             new Language($language)

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -107,7 +107,7 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileSize = $file->getSize();
 
         if ($this->maxFileSize && !$fileSize) {
-            throw new \RuntimeException('The size of the uploaded image could not be determined.');
+            throw new InvalidFileSize('The size of the uploaded image could not be determined.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
 
 class ImageUploaderService implements ImageUploaderInterface
 {
@@ -47,7 +48,7 @@ class ImageUploaderService implements ImageUploaderInterface
         int $maxFileSize = null
     ) {
         if ($maxFileSize < 0) {
-            throw new \RuntimeException('Max file size should be 0 or bigger inside config.yml.');
+            throw new RuntimeException('Max file size should be 0 or bigger inside config.yml.');
         }
 
         $this->uuidGenerator = $uuidGenerator;
@@ -106,8 +107,12 @@ class ImageUploaderService implements ImageUploaderInterface
     {
         $fileSize = $file->getSize();
 
-        if ($this->maxFileSize && !$fileSize) {
-            throw new InvalidFileSize('The size of the uploaded image could not be determined.');
+        if ($fileSize === null) {
+            throw new RuntimeException('The size of the uploaded image could not be determined.');
+        }
+
+        if ($fileSize === 0) {
+            throw new InvalidFileSize('The size of the uploaded image must not be 0 bytes.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -144,6 +144,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
 
     /**
      * @test
+     * @bugfix https://jira.uitdatabank.be/browse/III-5005
      */
     public function it_throws_if_no_a_file_was_uploaded_with_the_wrong_form_data_name(): void
     {

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -81,7 +81,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
      * @test
      * @dataProvider incompleteRequestProvider
      */
-    public function it_returns_400_if_file_is_missing(array $body, JsonResponse $expectedResponse): void
+    public function it_returns_400_if_field_is_missing(array $body, JsonResponse $expectedResponse): void
     {
         $uploadedFile = $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain');
 
@@ -126,7 +126,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_if_description_is_missing(): void
+    public function it_throws_if_no_file_is_uploaded(): void
     {
         $request = (new Psr7RequestBuilder())
             ->withParsedBody([
@@ -134,6 +134,28 @@ final class UploadMediaRequestHandlerTest extends TestCase
                 'copyrightHolder' => ' Dwight Hooker',
                 'language' => 'nl',
             ])
+            ->build('POST');
+
+        $this->expectException(ApiProblem::class);
+        $this->expectExceptionMessage('File missing');
+
+        $this->uploadMediaRequestHandler->handle($request);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_no_a_file_was_uploaded_with_the_wrong_form_data_name(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withParsedBody([
+                'description' => 'Lenna',
+                'copyrightHolder' => ' Dwight Hooker',
+                'language' => 'nl',
+            ])
+            ->withFiles(
+                ['another_file' => $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain')]
+            )
             ->build('POST');
 
         $this->expectException(ApiProblem::class);

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -254,7 +254,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidFileSize::class);
         $this->expectExceptionMessage('The size of the uploaded image could not be determined.');
 
         $uploader->upload($image, $description, $copyrightHolder, $language);


### PR DESCRIPTION
### Fixed

- If there is one uploaded file but its form data name is not `file`, we no longer get a type error but return an appropriate ApiProblem
- If the size of the uploaded file is `0` we return an ApiProblem instead of throwing a RuntimeException. If the size is `null` we still throw a `RuntimeException` because it could be a server issue (we'll need to see if it happens again or not after this is deployed)

---
Ticket: https://jira.uitdatabank.be/browse/III-5005
