### PR TITLE
III-5010 Improve file field errors

### DIFF
--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -45,15 +45,15 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
         $language = $parsedBody['language'] ?? null;
 
         if (!$description) {
-            return new JsonResponse(['error' => 'description required'], 400);
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "description" is required.');
         }
 
         if (!$copyrightHolder) {
-            return new JsonResponse(['error' => 'copyright holder required'], 400);
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.');
         }
 
         if (!$language) {
-            return new JsonResponse(['error' => 'language required'], 400);
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is required.');
         }
 
         $imageId = $this->imageUploader->upload(

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -13,6 +13,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 final class UploadMediaRequestHandler implements RequestHandlerInterface
@@ -28,9 +29,11 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        if (empty($request->getUploadedFiles())) {
+        $uploadedFiles = $request->getUploadedFiles();
+        if (!isset($uploadedFiles['file']) || !$uploadedFiles['file'] instanceof UploadedFileInterface) {
             throw ApiProblem::fileMissing('The file property is required');
         }
+        $uploadedFile = $uploadedFiles['file'];
 
         if (count($request->getUploadedFiles()) > 1) {
             throw ApiProblem::fileMissing('Only one file is allowed');
@@ -54,7 +57,7 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
         }
 
         $imageId = $this->imageUploader->upload(
-            $request->getUploadedFiles()['file'],
+            $uploadedFile,
             new StringLiteral($description),
             new CopyrightHolder($copyrightHolder),
             new Language($language)

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -49,12 +49,14 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
             throw ApiProblem::bodyInvalidDataWithDetail('Form data field "description" is required.');
         }
 
-        if (!$copyrightHolder) {
+        if ($copyrightHolder === null) {
             throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.');
         }
 
-        if (strlen($copyrightHolder) < 2) {
-            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" must be at least 2 characters long.');
+        try {
+            $copyrightHolder = new CopyrightHolder($copyrightHolder);
+        } catch (InvalidArgumentException $e) {
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is invalid: ' . $e->getMessage());
         }
 
         if (!$language) {
@@ -70,7 +72,7 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
         $imageId = $this->imageUploader->upload(
             $uploadedFile,
             new StringLiteral($description),
-            new CopyrightHolder($copyrightHolder),
+            $copyrightHolder,
             $language
         );
 

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -11,6 +11,7 @@ use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;
 use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -60,11 +61,17 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
             throw ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is required.');
         }
 
+        try {
+            $language = new Language($language);
+        } catch (InvalidArgumentException $e) {
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is must be exactly 2 lowercase letters long (for example "nl").');
+        }
+
         $imageId = $this->imageUploader->upload(
             $uploadedFile,
             new StringLiteral($description),
             new CopyrightHolder($copyrightHolder),
-            new Language($language)
+            $language
         );
 
         return new JsonResponse(

--- a/src/Http/Media/UploadMediaRequestHandler.php
+++ b/src/Http/Media/UploadMediaRequestHandler.php
@@ -52,6 +52,10 @@ final class UploadMediaRequestHandler implements RequestHandlerInterface
             throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.');
         }
 
+        if (strlen($copyrightHolder) < 2) {
+            throw ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" must be at least 2 characters long.');
+        }
+
         if (!$language) {
             throw ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is required.');
         }

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -107,7 +107,7 @@ class ImageUploaderService implements ImageUploaderInterface
         $fileSize = $file->getSize();
 
         if ($this->maxFileSize && !$fileSize) {
-            throw new \RuntimeException('The size of the uploaded image could not be determined.');
+            throw new InvalidFileSize('The size of the uploaded image could not be determined.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -16,6 +16,7 @@ use CultuurNet\UDB3\Model\ValueObject\MediaObject\CopyrightHolder;
 use CultuurNet\UDB3\StringLiteral;
 use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
 
 class ImageUploaderService implements ImageUploaderInterface
 {
@@ -47,7 +48,7 @@ class ImageUploaderService implements ImageUploaderInterface
         int $maxFileSize = null
     ) {
         if ($maxFileSize < 0) {
-            throw new \RuntimeException('Max file size should be 0 or bigger inside config.yml.');
+            throw new RuntimeException('Max file size should be 0 or bigger inside config.yml.');
         }
 
         $this->uuidGenerator = $uuidGenerator;
@@ -106,8 +107,12 @@ class ImageUploaderService implements ImageUploaderInterface
     {
         $fileSize = $file->getSize();
 
-        if ($this->maxFileSize && !$fileSize) {
-            throw new InvalidFileSize('The size of the uploaded image could not be determined.');
+        if ($fileSize === null) {
+            throw new RuntimeException('The size of the uploaded image could not be determined.');
+        }
+
+        if ($fileSize === 0) {
+            throw new InvalidFileSize('The size of the uploaded image must not be 0 bytes.');
         }
 
         if ($this->maxFileSize && $fileSize > $this->maxFileSize) {

--- a/src/Media/ImageUploaderService.php
+++ b/src/Media/ImageUploaderService.php
@@ -48,7 +48,7 @@ class ImageUploaderService implements ImageUploaderInterface
         int $maxFileSize = null
     ) {
         if ($maxFileSize < 0) {
-            throw new RuntimeException('Max file size should be 0 or bigger inside config.yml.');
+            throw new RuntimeException('Max file size should be 0 or higher if not null.');
         }
 
         $this->uuidGenerator = $uuidGenerator;

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -144,6 +144,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
 
     /**
      * @test
+     * @bugfix https://jira.uitdatabank.be/browse/III-5005
      */
     public function it_throws_if_no_a_file_was_uploaded_with_the_wrong_form_data_name(): void
     {

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -81,7 +81,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
      * @test
      * @dataProvider incompleteRequestProvider
      */
-    public function it_returns_400_if_field_is_missing(array $body, JsonResponse $expectedResponse): void
+    public function it_throws_an_api_problem_if_a_field_is_missing(array $body, ApiProblem $apiProblem): void
     {
         $uploadedFile = $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain');
 
@@ -90,10 +90,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
             ->withFiles(['file' => $uploadedFile])
             ->build('POST');
 
-        $response = $this->uploadMediaRequestHandler->handle($request);
-
-        $this->assertEquals($expectedResponse->getStatusCode(), $response->getStatusCode());
-        $this->assertEquals($expectedResponse->getBody()->getContents(), $response->getBody()->getContents());
+        $this->assertCallableThrowsApiProblem($apiProblem, fn () => $this->uploadMediaRequestHandler->handle($request));
     }
 
     public function incompleteRequestProvider(): array
@@ -104,21 +101,21 @@ final class UploadMediaRequestHandlerTest extends TestCase
                     'copyrightHolder' => ' Dwight Hooker',
                     'language' => 'nl',
                 ],
-                new JsonResponse(['error' => 'description required'], 400),
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "description" is required.'),
             ],
             'missing copyright holder' => [
                 [
                     'description' => 'Lenna',
                     'language' => 'nl',
                 ],
-                new JsonResponse(['error' => 'copyright holder required'], 400),
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.'),
             ],
             'missing language' => [
                 [
                     'description' => 'Lenna',
                     'copyrightHolder' => ' Dwight Hooker',
                 ],
-                new JsonResponse(['error' => 'language required'], 400),
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is required.'),
             ],
         ];
     }

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -110,13 +110,29 @@ final class UploadMediaRequestHandlerTest extends TestCase
                 ],
                 ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.'),
             ],
-            'invalid copyright holder' => [
+            'copyright holder empty' => [
+                [
+                    'description' => 'Lenna',
+                    'language' => 'nl',
+                    'copyrightHolder' => '',
+                ],
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is invalid: Given string should not be empty.'),
+            ],
+            'copyright holder too short' => [
                 [
                     'description' => 'Lenna',
                     'language' => 'nl',
                     'copyrightHolder' => 'a',
                 ],
-                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" must be at least 2 characters long.'),
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is invalid: CopyrightHolder \'a\' should not be shorter than 2 chars.'),
+            ],
+            'copyright holder too long' => [
+                [
+                    'description' => 'Lenna',
+                    'language' => 'nl',
+                    'copyrightHolder' => str_repeat('a', 251),
+                ],
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is invalid: CopyrightHolder \'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\' should not be longer than 250 chars.'),
             ],
             'missing language' => [
                 [

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -81,7 +81,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
      * @test
      * @dataProvider incompleteRequestProvider
      */
-    public function it_returns_400_if_file_is_missing(array $body, JsonResponse $expectedResponse): void
+    public function it_returns_400_if_field_is_missing(array $body, JsonResponse $expectedResponse): void
     {
         $uploadedFile = $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain');
 
@@ -126,7 +126,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_if_description_is_missing(): void
+    public function it_throws_if_no_file_is_uploaded(): void
     {
         $request = (new Psr7RequestBuilder())
             ->withParsedBody([
@@ -134,6 +134,28 @@ final class UploadMediaRequestHandlerTest extends TestCase
                 'copyrightHolder' => ' Dwight Hooker',
                 'language' => 'nl',
             ])
+            ->build('POST');
+
+        $this->expectException(ApiProblem::class);
+        $this->expectExceptionMessage('File missing');
+
+        $this->uploadMediaRequestHandler->handle($request);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_if_no_a_file_was_uploaded_with_the_wrong_form_data_name(): void
+    {
+        $request = (new Psr7RequestBuilder())
+            ->withParsedBody([
+                'description' => 'Lenna',
+                'copyrightHolder' => ' Dwight Hooker',
+                'language' => 'nl',
+            ])
+            ->withFiles(
+                ['another_file' => $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain')]
+            )
             ->build('POST');
 
         $this->expectException(ApiProblem::class);

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -7,7 +7,6 @@ namespace CultuurNet\UDB3\Http\Media;
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
 use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
-use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Media\ImageUploaderInterface;

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -81,7 +81,7 @@ final class UploadMediaRequestHandlerTest extends TestCase
      * @test
      * @dataProvider incompleteRequestProvider
      */
-    public function it_throws_an_api_problem_if_a_field_is_missing(array $body, ApiProblem $apiProblem): void
+    public function it_throws_an_api_problem_if_a_field_is_missing_or_invalid(array $body, ApiProblem $apiProblem): void
     {
         $uploadedFile = $this->createUploadedFile('ABC', UPLOAD_ERR_OK, 'test.txt', 'text/plain');
 
@@ -109,6 +109,14 @@ final class UploadMediaRequestHandlerTest extends TestCase
                     'language' => 'nl',
                 ],
                 ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" is required.'),
+            ],
+            'invalid copyright holder' => [
+                [
+                    'description' => 'Lenna',
+                    'language' => 'nl',
+                    'copyrightHolder' => 'a',
+                ],
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "copyrightHolder" must be at least 2 characters long.'),
             ],
             'missing language' => [
                 [

--- a/tests/Http/Media/UploadMediaRequestHandlerTest.php
+++ b/tests/Http/Media/UploadMediaRequestHandlerTest.php
@@ -125,6 +125,14 @@ final class UploadMediaRequestHandlerTest extends TestCase
                 ],
                 ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is required.'),
             ],
+            'invalid language' => [
+                [
+                    'description' => 'Lenna',
+                    'copyrightHolder' => ' Dwight Hooker',
+                    'language' => 'foo',
+                ],
+                ApiProblem::bodyInvalidDataWithDetail('Form data field "language" is must be exactly 2 lowercase letters long (for example "nl").'),
+            ],
         ];
     }
 

--- a/tests/Media/ImageUploaderServiceTest.php
+++ b/tests/Media/ImageUploaderServiceTest.php
@@ -254,7 +254,7 @@ class ImageUploaderServiceTest extends TestCase
         $copyrightHolder = new CopyrightHolder('Dude Man');
         $language = new Language('en');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidFileSize::class);
         $this->expectExceptionMessage('The size of the uploaded image could not be determined.');
 
         $uploader->upload($image, $description, $copyrightHolder, $language);


### PR DESCRIPTION
### Fixed

- When the `copyrightHolder` field is invalid according to the `CopyrightHolder` VO a `body/invalid-data` ApiProblem is returned
- When the `language` field is invalid according to the `Language` VO a `body/invalid-data` ApiProblem is returned
- When a field is missing a `body/invalid-data` ApiProblem is returned

---
Ticket: https://jira.uitdatabank.be/browse/III-5010
