### PR TITLE
III-4818 Do not log AMQP exceptions or send them to Sentry

### DIFF
--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Error;
 
 use CultuurNet\UDB3\Http\ApiProblem\ApiProblemFactory;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
+use PhpAmqpLib\Exception\AMQPIOException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyConsoleRuntimeException;
 use Throwable;
@@ -13,6 +15,8 @@ final class ErrorLogger
 {
     private const CLI_RUNTIME_EXCEPTIONS = [
         SymfonyConsoleRuntimeException::class,
+        AMQPIOException::class,
+        AMQPConnectionClosedException::class,
     ];
 
     private LoggerInterface $logger;

--- a/app/Error/ErrorLogger.php
+++ b/app/Error/ErrorLogger.php
@@ -11,7 +11,7 @@ use Throwable;
 
 final class ErrorLogger
 {
-    private const BAD_CLI_INPUT = [
+    private const CLI_RUNTIME_EXCEPTIONS = [
         SymfonyConsoleRuntimeException::class,
     ];
 
@@ -26,7 +26,7 @@ final class ErrorLogger
     {
         if (self::isBadRequestException($throwable) ||
             self::isBadGateway($throwable) ||
-            self::isBadCLIInput($throwable)) {
+            self::isCliRuntimeException($throwable)) {
             return;
         }
 
@@ -34,12 +34,12 @@ final class ErrorLogger
         $this->logger->error($throwable->getMessage(), ['exception' => $throwable]);
     }
 
-    public static function isBadCLIInput(Throwable $e): bool
+    public static function isCliRuntimeException(Throwable $e): bool
     {
         // Use foreach + instanceof instead of in_array() to also filter out child classes and/or interface
         // implementations.
-        foreach (self::BAD_CLI_INPUT as $badCLIInputExceptionClass) {
-            if ($e instanceof $badCLIInputExceptionClass) {
+        foreach (self::CLI_RUNTIME_EXCEPTIONS as $cliRuntimeExceptionClass) {
+            if ($e instanceof $cliRuntimeExceptionClass) {
                 return true;
             }
         }


### PR DESCRIPTION
### Changed

- AMQP exceptions that commonly pop up in Sentry are no longer sent to Sentry to avoid noise of exceptions that we cannot fix in code. Usually these are caused by CloudAMQP having issues, which we cannot fix on our end

---
Ticket: https://jira.uitdatabank.be/browse/III-4818
