### PR TITLE
III-4988 Remaining providers in Silex folder

### DIFF
--- a/app/Geocoding/GeocodingServiceProvider.php
+++ b/app/Geocoding/GeocodingServiceProvider.php
@@ -27,7 +27,7 @@ final class GeocodingServiceProvider extends AbstractServiceProvider
         $container->addShared(
             GeocodingService::class,
             function () use ($container) {
-                $googleMapsApiKey = isset($container->get('config')['google_maps_api_key']) ? $container->get('config')['google_maps_api_key'] : null;
+                $googleMapsApiKey = $container->get('config')['google_maps_api_key'] ?? null;
 
                 $geocodingService = new DefaultGeocodingService(
                     new StatefulGeocoder(

--- a/app/Geocoding/GeocodingServiceProvider.php
+++ b/app/Geocoding/GeocodingServiceProvider.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex;
+namespace CultuurNet\UDB3\Geocoding;
 
 use CultuurNet\UDB3\Container\AbstractServiceProvider;
-use CultuurNet\UDB3\Geocoding\CachedGeocodingService;
-use CultuurNet\UDB3\Geocoding\DefaultGeocodingService;
-use CultuurNet\UDB3\Geocoding\GeocodingService;
 use CultuurNet\UDB3\Error\LoggerFactory;
 use CultuurNet\UDB3\Error\LoggerName;
 use Geocoder\Provider\GoogleMaps\GoogleMaps;

--- a/app/Silex/GeocodingServiceProvider.php
+++ b/app/Silex/GeocodingServiceProvider.php
@@ -22,11 +22,7 @@ class GeocodingServiceProvider implements ServiceProviderInterface
     {
         $app[GeocodingService::class] = $app->share(
             function (HybridContainerApplication $app) {
-                $googleMapsApiKey = null;
-
-                if (isset($app['geocoding_service.google_maps_api_key'])) {
-                    $googleMapsApiKey = $app['geocoding_service.google_maps_api_key'];
-                }
+                $googleMapsApiKey = isset($app['config']['google_maps_api_key']) ? $app['config']['google_maps_api_key'] : null;
 
                 $geocodingService = new DefaultGeocodingService(
                     new StatefulGeocoder(

--- a/app/Silex/UDB2EventServicesProvider.php
+++ b/app/Silex/UDB2EventServicesProvider.php
@@ -13,6 +13,9 @@ class UDB2EventServicesProvider implements ServiceProviderInterface
 {
     public function register(Application $app): void
     {
+        $udb2PlaceExternalIdMappingFileLocation = __DIR__ . '../../config.external_id_mapping_place.php';
+        $udb2OrganizerExternalIdMappingFileLocation = __DIR__ . '../../config.external_id_mapping_organizer.php';
+
         $app['udb2_event_cdbid_extractor'] = $app->share(
             function (Application $app) {
                 return new EventCdbIdExtractor(
@@ -23,15 +26,15 @@ class UDB2EventServicesProvider implements ServiceProviderInterface
         );
 
         $app['udb2_place_external_id_mapping_service'] = $app->share(
-            function (Application $app) {
-                $mappingFileLocation = $app['udb2_place_external_id_mapping.file_location'];
+            function (Application $app) use ($udb2PlaceExternalIdMappingFileLocation) {
+                $mappingFileLocation = $udb2PlaceExternalIdMappingFileLocation;
                 return $app['udb2_external_id_mapping_service_factory']($mappingFileLocation);
             }
         );
 
         $app['udb2_organizer_external_id_mapping_service'] = $app->share(
-            function (Application $app) {
-                $mappingFileLocation = $app['udb2_organizer_external_id_mapping.file_location'];
+            function (Application $app) use ($udb2OrganizerExternalIdMappingFileLocation) {
+                $mappingFileLocation = $udb2OrganizerExternalIdMappingFileLocation;
                 return $app['udb2_external_id_mapping_service_factory']($mappingFileLocation);
             }
         );

--- a/app/Silex/UDB2EventServicesProvider.php
+++ b/app/Silex/UDB2EventServicesProvider.php
@@ -13,9 +13,6 @@ class UDB2EventServicesProvider implements ServiceProviderInterface
 {
     public function register(Application $app): void
     {
-        $udb2PlaceExternalIdMappingFileLocation = __DIR__ . '../../config.external_id_mapping_place.php';
-        $udb2OrganizerExternalIdMappingFileLocation = __DIR__ . '../../config.external_id_mapping_organizer.php';
-
         $app['udb2_event_cdbid_extractor'] = $app->share(
             function (Application $app) {
                 return new EventCdbIdExtractor(
@@ -26,16 +23,14 @@ class UDB2EventServicesProvider implements ServiceProviderInterface
         );
 
         $app['udb2_place_external_id_mapping_service'] = $app->share(
-            function (Application $app) use ($udb2PlaceExternalIdMappingFileLocation) {
-                $mappingFileLocation = $udb2PlaceExternalIdMappingFileLocation;
-                return $app['udb2_external_id_mapping_service_factory']($mappingFileLocation);
+            function (Application $app) {
+                return $app['udb2_external_id_mapping_service_factory'](__DIR__ . '../../config.external_id_mapping_place.php');
             }
         );
 
         $app['udb2_organizer_external_id_mapping_service'] = $app->share(
-            function (Application $app) use ($udb2OrganizerExternalIdMappingFileLocation) {
-                $mappingFileLocation = $udb2OrganizerExternalIdMappingFileLocation;
-                return $app['udb2_external_id_mapping_service_factory']($mappingFileLocation);
+            function (Application $app) {
+                return $app['udb2_external_id_mapping_service_factory'](__DIR__ . '../../config.external_id_mapping_organizer.php');
             }
         );
 

--- a/app/UDB2/UDB2EventServicesProvider.php
+++ b/app/UDB2/UDB2EventServicesProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CultuurNet\UDB3\Silex;
+namespace CultuurNet\UDB3\UDB2;
 
 use CultuurNet\UDB3\Cdb\CdbId\EventCdbIdExtractor;
 use CultuurNet\UDB3\Cdb\ExternalId\ArrayMappingService;

--- a/app/UDB2/UDB2EventServicesProvider.php
+++ b/app/UDB2/UDB2EventServicesProvider.php
@@ -23,15 +23,10 @@ final class UDB2EventServicesProvider extends AbstractServiceProvider
 
         $container->addShared(
             'udb2_event_cdbid_extractor',
-            fn () => $this->buildUdb2EventCbidExtractor(),
-        );
-    }
-
-    private function buildUdb2EventCbidExtractor(): EventCdbIdExtractor
-    {
-        return new EventCdbIdExtractor(
-            $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_place.php'),
-            $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_organizer.php'),
+            fn () => new EventCdbIdExtractor(
+                $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_place.php'),
+                $this->buildMappingServiceForLocation(__DIR__ . '../../config.external_id_mapping_organizer.php'),
+            ),
         );
     }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -98,10 +98,6 @@ $container->delegate(new ReflectionContainer(true));
 
 $app['api_name'] = defined('API_NAME') ? API_NAME : ApiName::UNKNOWN;
 
-if (!isset($udb3ConfigLocation)) {
-    $udb3ConfigLocation = __DIR__;
-}
-
 $app['config'] = file_exists(__DIR__ . '/config.php') ? require __DIR__ . '/config.php' : [];
 
 $app['system_user_id'] = $app::share(
@@ -745,8 +741,8 @@ $container->addServiceProvider(new AuthServiceProvider());
 $app->register(
     new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider(),
     [
-        'udb2_place_external_id_mapping.file_location' => $udb3ConfigLocation . '/config.external_id_mapping_place.php',
-        'udb2_organizer_external_id_mapping.file_location' => $udb3ConfigLocation . '/config.external_id_mapping_organizer.php',
+        'udb2_place_external_id_mapping.file_location' => __DIR__ . '/config.external_id_mapping_place.php',
+        'udb2_organizer_external_id_mapping.file_location' => __DIR__ . '/config.external_id_mapping_organizer.php',
     ]
 );
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -738,13 +738,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Offer\BulkLabelOfferServiceProvider())
 // user who triggered the job is being impersonated.
 $container->addServiceProvider(new AuthServiceProvider());
 
-$app->register(
-    new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider(),
-    [
-        'udb2_place_external_id_mapping.file_location' => __DIR__ . '/config.external_id_mapping_place.php',
-        'udb2_organizer_external_id_mapping.file_location' => __DIR__ . '/config.external_id_mapping_organizer.php',
-    ]
-);
+$app->register(new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -752,7 +752,7 @@ $app->register(
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 
-$container->addServiceProvider(new \CultuurNet\UDB3\Silex\GeocodingServiceProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\Geocoding\GeocodingServiceProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\Place\PlaceGeoCoordinatesServiceProvider());
 $container->addServiceProvider(new EventGeoCoordinatesServiceProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -738,7 +738,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Offer\BulkLabelOfferServiceProvider())
 // user who triggered the job is being impersonated.
 $container->addServiceProvider(new AuthServiceProvider());
 
-$container->addServiceProvider(new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\UDB2\UDB2EventServicesProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -738,7 +738,7 @@ $app->register(new \CultuurNet\UDB3\Silex\Offer\BulkLabelOfferServiceProvider())
 // user who triggered the job is being impersonated.
 $container->addServiceProvider(new AuthServiceProvider());
 
-$app->register(new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\Silex\UDB2EventServicesProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -752,12 +752,7 @@ $app->register(
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 
-$app->register(
-    new \CultuurNet\UDB3\Silex\GeocodingServiceProvider(),
-    [
-        'geocoding_service.google_maps_api_key' => isset($app['config']['google_maps_api_key']) ? $app['config']['google_maps_api_key'] : null,
-    ]
-);
+$app->register(new \CultuurNet\UDB3\Silex\GeocodingServiceProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\Place\PlaceGeoCoordinatesServiceProvider());
 $container->addServiceProvider(new EventGeoCoordinatesServiceProvider());

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -752,7 +752,7 @@ $app->register(
 
 $app->register(new \CultuurNet\UDB3\Silex\UiTPAS\UiTPASIncomingEventServicesProvider());
 
-$app->register(new \CultuurNet\UDB3\Silex\GeocodingServiceProvider());
+$container->addServiceProvider(new \CultuurNet\UDB3\Silex\GeocodingServiceProvider());
 
 $app->register(new \CultuurNet\UDB3\Silex\Place\PlaceGeoCoordinatesServiceProvider());
 $container->addServiceProvider(new EventGeoCoordinatesServiceProvider());


### PR DESCRIPTION
### Changed
- `GeocodingServiceProvider` is now PSR-11 compliant
- `UDB2EventServicesProvider` is now PSR-11 compliant

### Removed
- `udb2_place_external_id_mapping_service`, `udb2_organizer_external_id_mapping_service`, `udb2_external_id_mapping_service_factory` service definitions as they were unused by other services and it made more sense to construct them inline.

---
Ticket: https://jira.uitdatabank.be/browse/III-4988
