### PR TITLE
III-4758 Convert `ChangeNotAllowedByTicketSales` to `ApiProblem`

### DIFF
--- a/src/Http/ApiProblem/ApiProblem.php
+++ b/src/Http/ApiProblem/ApiProblem.php
@@ -421,8 +421,16 @@ final class ApiProblem extends Exception
         );
     }
 
-    public static function eventHasUitpasTicketSales($detail): self
+    public static function eventHasUitpasTicketSales(?string $eventId = null): self
     {
+        $detail = 'Event has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.';
+        if ($eventId) {
+            $detail = sprintf(
+                'Event with id \'%s\' has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.',
+                $eventId
+            );
+        }
+
         return self::create(
             'https://api.publiq.be/probs/uitdatabank/event-has-uitpas-ticket-sales',
             'Event has UiTPAS ticket sales',

--- a/src/Http/ApiProblem/ApiProblemFactory.php
+++ b/src/Http/ApiProblem/ApiProblemFactory.php
@@ -193,14 +193,8 @@ final class ApiProblemFactory
         }
 
         if (strpos($title, 'event already has ticketsales') !== false) {
-            $message = 'Event has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.';
-            if ($routeParameters && $routeParameters->hasEventId()) {
-                $message = sprintf(
-                    'Event with id \'%s\' has ticket sales in UiTPAS, which makes it impossible to change its organizer, UiTPAS card systems, and UiTPAS distribution keys.',
-                    $routeParameters->getEventId()
-                );
-            }
-            return ApiProblem::eventHasUitpasTicketSales($message);
+            $eventId = $routeParameters && $routeParameters->hasEventId() ? $routeParameters->getEventId() : null;
+            return ApiProblem::eventHasUitpasTicketSales($eventId);
         }
 
         // In some cases the UiTPAS servers return a 404 error with an HTML page. In this case we treat it as UiTPAS

--- a/src/UiTPAS/Validation/ChangeNotAllowedByTicketSales.php
+++ b/src/UiTPAS/Validation/ChangeNotAllowedByTicketSales.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPAS\Validation;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
 use Exception;
 
-final class ChangeNotAllowedByTicketSales extends Exception
+final class ChangeNotAllowedByTicketSales extends Exception implements ConvertsToApiProblem
 {
+    private string $eventId;
+
     public function __construct(string $eventId)
     {
         parent::__construct('Organizer change not allowed because event ' . $eventId . ' has ticket sales in UiTPAS');
+        $this->eventId = $eventId;
+    }
+
+    public function toApiProblem(): ApiProblem
+    {
+        return ApiProblem::eventHasUitpasTicketSales($this->eventId);
     }
 }


### PR DESCRIPTION
### Fixed

- The custom `ChangeNotAllowedByTicketSales` exception now also converts to the new `https://api.publiq.be/probs/uitdatabank/event-has-uitpas-ticket-sales` api problem type (based on QA feedback from @corneelwille)

---
Ticket: https://jira.uitdatabank.be/browse/III-4758
