### PR TITLE
III-5020 Internalize SwiftmailerServiceProvider

### DIFF
--- a/app/SwiftMailer/SwiftMailerServiceProvider.php
+++ b/app/SwiftMailer/SwiftMailerServiceProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\SwiftMailer;
+
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use Swift_Events_SimpleEventDispatcher;
+use Swift_Mailer;
+use Swift_StreamFilters_StringReplacementFilterFactory;
+use Swift_Transport_Esmtp_Auth_CramMd5Authenticator;
+use Swift_Transport_Esmtp_Auth_LoginAuthenticator;
+use Swift_Transport_Esmtp_Auth_PlainAuthenticator;
+use Swift_Transport_Esmtp_AuthHandler;
+use Swift_Transport_EsmtpTransport;
+use Swift_Transport_StreamBuffer;
+
+final class SwiftMailerServiceProvider extends AbstractServiceProvider
+{
+    protected function getProvidedServiceNames(): array
+    {
+        return ['mailer'];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            'mailer',
+            static function () use ($container) {
+                $transport = new Swift_Transport_EsmtpTransport(
+                    new Swift_Transport_StreamBuffer(
+                        new Swift_StreamFilters_StringReplacementFilterFactory()
+                    ),
+                    [
+                        new Swift_Transport_Esmtp_AuthHandler(
+                            [
+                                new Swift_Transport_Esmtp_Auth_CramMd5Authenticator(),
+                                new Swift_Transport_Esmtp_Auth_LoginAuthenticator(),
+                                new Swift_Transport_Esmtp_Auth_PlainAuthenticator(),
+                            ]
+                         )
+                    ],
+                    new Swift_Events_SimpleEventDispatcher()
+                );
+
+                $options = array_replace(
+                    [
+                        'host' => 'localhost',
+                        'port' => 25,
+                        'username' => '',
+                        'password' => '',
+                        'encryption' => null,
+                        'auth_mode' => null,
+                    ],
+                    $container->get('config')['swiftmailer.options']
+                );
+
+                $transport->setHost($options['host']);
+                $transport->setPort($options['port']);
+                $transport->setEncryption($options['encryption']);
+                $transport->setUsername($options['username']);
+                $transport->setPassword($options['password']);
+                $transport->setAuthMode($options['auth_mode']);
+
+                return new Swift_Mailer($transport);
+            }
+        );
+    }
+}

--- a/app/SwiftMailer/SwiftMailerServiceProvider.php
+++ b/app/SwiftMailer/SwiftMailerServiceProvider.php
@@ -60,9 +60,12 @@ final class SwiftMailerServiceProvider extends AbstractServiceProvider
                 $transport->setHost($options['host']);
                 $transport->setPort($options['port']);
                 $transport->setEncryption($options['encryption']);
-                $transport->setUsername($options['username']);
-                $transport->setPassword($options['password']);
-                $transport->setAuthMode($options['auth_mode']);
+
+                // The following methods are "magic" methods which PHPStan does not recognize on this class for some
+                // reason.
+                $transport->setUsername($options['username']); /** @phpstan-ignore-line */
+                $transport->setPassword($options['password']); /** @phpstan-ignore-line */
+                $transport->setAuthMode($options['auth_mode']); /** @phpstan-ignore-line */
 
                 return new Swift_Mailer($transport);
             }

--- a/app/SwiftMailer/SwiftMailerServiceProvider.php
+++ b/app/SwiftMailer/SwiftMailerServiceProvider.php
@@ -40,7 +40,7 @@ final class SwiftMailerServiceProvider extends AbstractServiceProvider
                                 new Swift_Transport_Esmtp_Auth_LoginAuthenticator(),
                                 new Swift_Transport_Esmtp_Auth_PlainAuthenticator(),
                             ]
-                         )
+                        ),
                     ],
                     new Swift_Events_SimpleEventDispatcher()
                 );

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -58,6 +58,7 @@ use CultuurNet\UDB3\Place\PlaceHistoryServiceProvider;
 use CultuurNet\UDB3\Place\PlaceJSONLDServiceProvider;
 use CultuurNet\UDB3\Place\PlaceRequestHandlerServiceProvider;
 use CultuurNet\UDB3\Search\Sapi3SearchServiceProvider;
+use CultuurNet\UDB3\SwiftMailer\SwiftMailerServiceProvider;
 use CultuurNet\UDB3\UiTPASService\UiTPASServiceEventServiceProvider;
 use CultuurNet\UDB3\UiTPASService\UiTPASServiceLabelsServiceProvider;
 use CultuurNet\UDB3\UiTPASService\UiTPASServiceOrganizerServiceProvider;
@@ -151,11 +152,7 @@ $container->addServiceProvider(new CultureFeedServiceProvider());
 /**
  * Mailing service.
  */
-$app->register(new Silex\Provider\SwiftmailerServiceProvider());
-$app['swiftmailer.use_spool'] = false;
-if ($app['config']['swiftmailer.options']) {
-    $app['swiftmailer.options'] = $app['config']['swiftmailer.options'];
-}
+$container->addServiceProvider(new SwiftMailerServiceProvider());
 
 $app['timezone'] = $app->share(
     function (Application $app) {


### PR DESCRIPTION
### Changed

- The `mailer` service definition (a `Swift_Mailer` class instance) is now registered using a custom service provider on the new League container instead of a ServiceProvider provided by `silex/silex`

---
Ticket: https://jira.uitdatabank.be/browse/III-5020

Since this is hard to test with an acceptance test or unit test, I tested it manually by reloading the supervisor commands (so the `udb3-event-export-worker` was restarted and loaded the new code), and then doing an export of some events via the UI. I then verified that there was a new email in the local mailcatcher:

![Screen Shot 2022-10-11 at 18 50 27](https://user-images.githubusercontent.com/959026/195152935-f6babd60-7bf1-4bf9-8d18-481c35437035.png)

