### PR TITLE
III-5028 Make sure `ROLE_SEARCH_V3_REPOSITORY_TABLE_NAME` is only defined once

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -544,7 +544,9 @@ $app['user_roles_repository'] = $app->share(
 /**
  * @todo move this to a class.
  */
-const ROLE_SEARCH_V3_REPOSITORY_TABLE_NAME = 'roles_search_v3';
+if (!defined('ROLE_SEARCH_V3_REPOSITORY_TABLE_NAME')) {
+    define('ROLE_SEARCH_V3_REPOSITORY_TABLE_NAME', 'roles_search_v3');
+}
 
 $app['role_search_v3_repository'] = $app->share(
     function ($app) {


### PR DESCRIPTION
### Fixed

- When `bootstrap.php` is required/included twice in the same file, as in `worker_bootstrap.php` (which I'm not sure we can change to only require/include it once because it needs the returned container in both places), the `ROLE_SEARCH_V3_REPOSITORY_TABLE_NAME` is no longer re-defined which would otherwise result in a notice that gets converted to an ErrorException

---
Ticket: https://jira.uitdatabank.be/browse/III-5028
