### PR TITLE
III-5412 keep logic the same if toggle is set to true

### DIFF
--- a/src/Http/Auth/RequestAuthenticatorMiddleware.php
+++ b/src/Http/Auth/RequestAuthenticatorMiddleware.php
@@ -92,17 +92,13 @@ final class RequestAuthenticatorMiddleware implements MiddlewareInterface
             return;
         }
 
+        if ($this->isPublicRoute($request) && empty($request->getHeader('authorization'))) {
+            return;
+        }
+
         // For requests to public routes, if authenticationToggle is enabled,
         // that provide extra information to Authenticated Users. eg. show contributors
-        try {
-            $this->authenticateToken($request);
-        } catch (\Exception $exception) {
-            if ($this->isPublicRoute($request)) {
-                $this->token = null;
-                return;
-            }
-            throw $exception;
-        }
+        $this->authenticateToken($request);
 
         // Requests that use a token from the JWT provider (v1 or v2) require an API key from UiTID v1.
         // Requests that use a token that they got directly from Auth0 do not require an API key.


### PR DESCRIPTION
### Fixed

- Refactored `authenticate()` in `RequestAuthenticatorMiddleware` so that exception is thrown on invalid token & unauthorized `apiKey`, if toggle `authenticate_public_routes` is enbled.

---
Ticket: https://jira.uitdatabank.be/browse/III-5412
