### PR TITLE
III-6786 Saved searches should hide deleted orgs

### DIFF
--- a/src/SavedSearches/OwnershipSavedSearchRepository.php
+++ b/src/SavedSearches/OwnershipSavedSearchRepository.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\SavedSearches;
 use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebToken;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
-use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
+use CultuurNet\UDB3\Model\ValueObject\Moderation\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Offer\ExtractOfferName;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\Ownership\Repositories\Search\OwnershipSearchRepository;
@@ -69,8 +69,7 @@ class OwnershipSavedSearchRepository implements SavedSearchesOwnedByCurrentUser
             $organizerId = $ownershipItem->getItemId();
             $organizer = $this->organizerDocumentRepository->fetch($organizerId)->getAssocBody();
 
-            if ($organizer['workflowStatus'] === WorkflowStatus::DELETED()->toString() ||
-               $organizer['workflowStatus'] === WorkflowStatus::REJECTED()->toString()) {
+            if ($organizer['workflowStatus'] !== WorkflowStatus::ACTIVE()->toString()) {
                 continue;
             }
 

--- a/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
+++ b/tests/SavedSearches/OwnershipSavedSearchRepositoryTest.php
@@ -8,7 +8,7 @@ use CultuurNet\UDB3\Http\Auth\Jwt\JsonWebTokenFactory;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchParameter;
 use CultuurNet\UDB3\Http\Ownership\Search\SearchQuery;
 use CultuurNet\UDB3\Json;
-use CultuurNet\UDB3\Model\ValueObject\Moderation\WorkflowStatus;
+use CultuurNet\UDB3\Model\ValueObject\Moderation\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Ownership\OwnershipState;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItem;
 use CultuurNet\UDB3\Ownership\Repositories\OwnershipItemCollection;
@@ -76,10 +76,9 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
 
     public function SavedSearchDataprovider(): array
     {
-        $itemId1 = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
-        $itemId2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
-        $itemId3 = '68b84192-487c-832a-a344-86f8e3f29c38';
-        $itemId4 = '03dcda8e-fc37-4197-a964-27dacee68ae2';
+        $approvedOrganizer = 'c84d6167-5e71-4f2c-aedf-ad346e569e03';
+        $approvedOrganizer2 = '24bc3c50-5c9e-4e34-8bc7-1c9826352775';
+        $deletedOrganizer = '68b84192-487c-832a-a344-86f8e3f29c38';
 
         $ownershipItemId1 = 'a700c463-1401-4d91-a85c-fa289b6d8d8e';
         $ownershipItemId2 = '8ba5ee51-8e0c-4179-8516-3942ac4ab6d2';
@@ -95,12 +94,12 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
             'approved_ownership_were_found' => [
                 [
                     new JsonDocument(
-                        $itemId1,
+                        $approvedOrganizer,
                         Json::encode(
                             [
                                 '@type' => 'organizer',
                                 'mainLanguage' => 'nl',
-                                'workflowStatus' => WorkflowStatus::APPROVED()->toString(),
+                                'workflowStatus' => WorkflowStatus::ACTIVE()->toString(),
                                 'name' => [
                                     'nl' => 'Foobar NL',
                                     'fr' => 'Foobar FR',
@@ -109,12 +108,12 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                         )
                     ),
                     new JsonDocument(
-                        $itemId2,
+                        $approvedOrganizer2,
                         Json::encode(
                             [
                                 '@type' => 'organizer',
                                 'mainLanguage' => 'fr',
-                                'workflowStatus' => WorkflowStatus::APPROVED()->toString(),
+                                'workflowStatus' => WorkflowStatus::ACTIVE()->toString(),
                                 'name' => [
                                     'nl' => 'Bar Foo NL',
                                     'fr' => 'Bar Foo FR',
@@ -123,7 +122,7 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                         )
                     ),
                     new JsonDocument(
-                        $itemId3,
+                        $deletedOrganizer,
                         Json::encode(
                             [
                                 '@type' => 'organizer',
@@ -136,65 +135,44 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                             ]
                         )
                     ),
-                    new JsonDocument(
-                        $itemId4,
-                        Json::encode(
-                            [
-                                '@type' => 'organizer',
-                                'mainLanguage' => 'fr',
-                                'workflowStatus' => WorkflowStatus::REJECTED()->toString(),
-                                'name' => [
-                                    'nl' => 'Rejected Bar Foo NL',
-                                    'fr' => 'Rejected Bar Foo FR',
-                                ],
-                            ]
-                        )
-                    ),
                 ],
                 new OwnershipItemCollection(
                     new OwnershipItem(
                         $ownershipItemId1,
-                        $itemId1,
+                        $approvedOrganizer,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
                         $ownershipItemId2,
-                        $itemId2,
+                        $approvedOrganizer2,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
                         $ownershipItemId3,
-                        $itemId3,
+                        $deletedOrganizer,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
-                    new OwnershipItem(
-                        $ownershipItemId4,
-                        $itemId4,
-                        'organizer',
-                        self::USER_ID,
-                        OwnershipState::approved()->toString()
-                    )
                 ),
                 [
-                    new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $itemId1)),
-                    new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $itemId2)),
+                    new SavedSearch('Aanbod Foobar NL', new QueryString('organizer.id:' . $approvedOrganizer)),
+                    new SavedSearch('Aanbod Bar Foo FR', new QueryString('organizer.id:' . $approvedOrganizer2)),
                 ],
             ],
             'faulty_data' => [
                 [
                     new JsonDocument(
-                        $itemId1,
+                        $approvedOrganizer,
                         Json::encode(
                             [
                                 '@type' => 'organizer',
                                 'mainLanguage' => 'en',
-                                'workflowStatus' => WorkflowStatus::APPROVED()->toString(),
+                                'workflowStatus' => WorkflowStatus::ACTIVE()->toString(),
                                 'name' => [
                                     'nl' => 'Wrong mainlangue NL',
                                     'fr' => 'Wrong mainlangue FR',
@@ -203,11 +181,11 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                         )
                     ),
                     new JsonDocument(
-                        $itemId2,
+                        $approvedOrganizer2,
                         Json::encode(
                             [
                                 '@type' => 'organizer',
-                                'workflowStatus' => WorkflowStatus::APPROVED()->toString(),
+                                'workflowStatus' => WorkflowStatus::ACTIVE()->toString(),
                                 'name' => [
                                     'nl' => 'No Mainlanguage NL',
                                     'fr' => 'No Mainlanguage FR',
@@ -219,22 +197,22 @@ final class OwnershipSavedSearchRepositoryTest extends TestCase
                 new OwnershipItemCollection(
                     new OwnershipItem(
                         $ownershipItemId1,
-                        $itemId1,
+                        $approvedOrganizer,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                     new OwnershipItem(
                         $ownershipItemId2,
-                        $itemId2,
+                        $approvedOrganizer2,
                         'organizer',
                         self::USER_ID,
                         OwnershipState::approved()->toString()
                     ),
                 ),
                 [
-                    new SavedSearch('Aanbod Wrong mainlangue NL', new QueryString('organizer.id:' . $itemId1)),
-                    new SavedSearch('Aanbod No Mainlanguage NL', new QueryString('organizer.id:' . $itemId2)),
+                    new SavedSearch('Aanbod Wrong mainlangue NL', new QueryString('organizer.id:' . $approvedOrganizer)),
+                    new SavedSearch('Aanbod No Mainlanguage NL', new QueryString('organizer.id:' . $approvedOrganizer2)),
                 ],
             ],
         ];


### PR DESCRIPTION
### Fixed
- Based on bugreport from Robin: Do not show ownerships saved queries for deleted or rejected organizers.

---

Ticket: https://jira.uitdatabank.be/browse/III-6786 
