### PR TITLE
III-7084 Project `audienceType` in `RDF`

### DIFF
--- a/features/data/events/rdf/event-with-all-fields.ttl
+++ b/features/data/events/rdf/event-with-all-fields.ttl
@@ -22,6 +22,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-8b563a39>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-5da8175b> ;
   dcterms:description "Nederlandse beschrijving"@nl, "English description"@en ;

--- a/features/data/events/rdf/event-with-audience-type-children-only.json
+++ b/features/data/events/rdf/event-with-audience-type-children-only.json
@@ -1,0 +1,20 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{baseUrl}/places/%{placeId}"
+  },
+  "calendarType": "permanent",
+  "audience": {
+    "audienceType": "childrenOnly"
+  }
+}

--- a/features/data/events/rdf/event-with-audience-type-children-only.ttl
+++ b/features/data/events/rdf/event-with-audience-type-children-only.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}>
+  a cidoc:E7_Activity ;
+  dcterms:created ""^^xsd:dateTime ;
+  dcterms:modified ""^^xsd:dateTime ;
+  adms:identifier <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}> ;
+  dcterms:title "Permanent event"@nl ;
+  dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/childrenOnly> ;
+  cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
+  prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
+  a adms:Identifier ;
+  skos:notation "http://data.uitdatabank.local:80/events/%{eventId}"^^xsd:anyURI ;
+  generiek:gestructureerdeIdentificator <http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}>
+  a generiek:GestructureerdeIdentificator ;
+  generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
+  generiek:lokaleIdentificator "%{eventId}" .

--- a/features/data/events/rdf/event-with-audience-type-education.json
+++ b/features/data/events/rdf/event-with-audience-type-education.json
@@ -1,0 +1,20 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{baseUrl}/places/%{placeId}"
+  },
+  "calendarType": "permanent",
+  "audience": {
+    "audienceType": "education"
+  }
+}

--- a/features/data/events/rdf/event-with-audience-type-education.ttl
+++ b/features/data/events/rdf/event-with-audience-type-education.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}>
+  a cidoc:E7_Activity ;
+  dcterms:created ""^^xsd:dateTime ;
+  dcterms:modified ""^^xsd:dateTime ;
+  adms:identifier <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}> ;
+  dcterms:title "Permanent event"@nl ;
+  dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/education> ;
+  cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
+  prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
+  a adms:Identifier ;
+  skos:notation "http://data.uitdatabank.local:80/events/%{eventId}"^^xsd:anyURI ;
+  generiek:gestructureerdeIdentificator <http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}>
+  a generiek:GestructureerdeIdentificator ;
+  generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
+  generiek:lokaleIdentificator "%{eventId}" .

--- a/features/data/events/rdf/event-with-audience-type-members.json
+++ b/features/data/events/rdf/event-with-audience-type-members.json
@@ -1,0 +1,20 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{baseUrl}/places/%{placeId}"
+  },
+  "calendarType": "permanent",
+  "audience": {
+    "audienceType": "members"
+  }
+}

--- a/features/data/events/rdf/event-with-audience-type-members.ttl
+++ b/features/data/events/rdf/event-with-audience-type-members.ttl
@@ -1,0 +1,31 @@
+@prefix cidoc: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix udb: <https://data.publiq.be/ns/uitdatabank#> .
+@prefix cpa: <https://data.vlaanderen.be/ns/cultuurparticipatie#Activiteit.> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}>
+  a cidoc:E7_Activity ;
+  dcterms:created ""^^xsd:dateTime ;
+  dcterms:modified ""^^xsd:dateTime ;
+  adms:identifier <http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}> ;
+  dcterms:title "Permanent event"@nl ;
+  dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
+  udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/members> ;
+  cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
+  prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#identifier-%{identifier}>
+  a adms:Identifier ;
+  skos:notation "http://data.uitdatabank.local:80/events/%{eventId}"^^xsd:anyURI ;
+  generiek:gestructureerdeIdentificator <http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}> .
+
+<http://data.uitdatabank.local:80/events/%{eventId}#gestructureerdeIdentificator-%{identifier}>
+  a generiek:GestructureerdeIdentificator ;
+  generiek:naamruimte "http://data.uitdatabank.local:80/events/" ;
+  generiek:lokaleIdentificator "%{eventId}" .

--- a/features/data/events/rdf/event-with-booking-info.ttl
+++ b/features/data/events/rdf/event-with-booking-info.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   cpa:boeking <http://data.uitdatabank.local:80/events/%{eventId}#boekingsinfo-1cb41cc5> .

--- a/features/data/events/rdf/event-with-contact-point.ttl
+++ b/features/data/events/rdf/event-with-contact-point.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   schema:contactPoint <http://data.uitdatabank.local:80/events/%{eventId}#contactPoint-f20d8319>, <http://data.uitdatabank.local:80/events/%{eventId}#contactPoint-35306b47>, <http://data.uitdatabank.local:80/events/%{eventId}#contactPoint-953ce804>, <http://data.uitdatabank.local:80/events/%{eventId}#contactPoint-94fe8233> .

--- a/features/data/events/rdf/event-with-image-object.ttl
+++ b/features/data/events/rdf/event-with-image-object.ttl
@@ -17,6 +17,7 @@
   dcterms:title "Faith no more"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   schema:image <http://data.uitdatabank.local:80/events/%{eventId}#imageObject-%{imageHash}> .

--- a/features/data/events/rdf/event-with-labels.ttl
+++ b/features/data/events/rdf/event-with-labels.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   dcat:keyword "public-visible-1"^^labeltype:publiek, "public-visible-2"^^labeltype:publiek, "public-invisible-1"^^labeltype:verborgen, "public-invisible-2"^^labeltype:verborgen .

--- a/features/data/events/rdf/event-with-organizer.ttl
+++ b/features/data/events/rdf/event-with-organizer.ttl
@@ -19,6 +19,7 @@
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.2.0.0> ;
   cidoc:P14_carried_out_by <http://data.uitdatabank.local:80/organizers/%{organizerId}> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .
 

--- a/features/data/events/rdf/event-with-periodic-calendar-and-opening-hours.ttl
+++ b/features/data/events/rdf/event-with-periodic-calendar-and-opening-hours.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://taxonomy-test.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-7d299e51> ;
   cpa:beschikbaarheid <http://data.uitdatabank.local:80/events/%{eventId}#beschikbaarheid-2450812e> .

--- a/features/data/events/rdf/event-with-permanent-calendar-and-opening-hours.ttl
+++ b/features/data/events/rdf/event-with-permanent-calendar-and-opening-hours.ttl
@@ -18,6 +18,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   cpa:beschikbaarheid <http://data.uitdatabank.local:80/events/%{eventId}#beschikbaarheid-6bc21d1d> .

--- a/features/data/events/rdf/event-with-price-info.ttl
+++ b/features/data/events/rdf/event-with-price-info.ttl
@@ -18,6 +18,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   cpa:prijs <http://data.uitdatabank.local:80/events/%{eventId}#priceSpecification-77836465>, <http://data.uitdatabank.local:80/events/%{eventId}#priceSpecification-2daf745e> .

--- a/features/data/events/rdf/event-with-required-fields.ttl
+++ b/features/data/events/rdf/event-with-required-fields.ttl
@@ -16,6 +16,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .
 

--- a/features/data/events/rdf/event-with-videos.ttl
+++ b/features/data/events/rdf/event-with-videos.ttl
@@ -17,6 +17,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> ;
   schema:video <http://data.uitdatabank.local:80/events/%{eventId}#videoObject-06299af1>, <http://data.uitdatabank.local:80/events/%{eventId}#videoObject-a46c333b> .

--- a/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-8b563a39>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-5da8175b> .

--- a/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -18,6 +18,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   prov:atLocation <http://data.uitdatabank.local:80/places/%{placeId}> .

--- a/features/data/events/rdf/online-event-with-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-multiple-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-cbeaaec0> .

--- a/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-multiple-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> ;
   cp:ruimtetijd <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-2aac7354>, <http://data.uitdatabank.local:80/events/%{eventId}#e92_Spacetime_Volume-cbeaaec0> .

--- a/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/features/data/events/rdf/online-event-with-online-url-and-permanent-calendar.ttl
@@ -17,6 +17,7 @@
   dcterms:title "Permanent event"@nl ;
   dcterms:type <https://taxonomy-test.uitdatabank.be/terms/0.50.4.0.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <http://data.uitdatabank.local:80/events/%{eventId}#virtualLocation-61d7772d> .
 

--- a/features/event/rdf.feature
+++ b/features/event/rdf.feature
@@ -128,17 +128,19 @@ Feature: Test RDF projection of events
     And I calculate the image hash with description "A cute dog", copyright "publiq vzw" and language "nl" for "%{imageId}" as "imageHash"
     Then the RDF response should match event projection "events/rdf/event-with-all-fields.ttl"
 
-  Scenario: Create an event with a not for everyone audienceType
+  Scenario: Create an event with audienceType members
     Given I create an event from "events/rdf/event-with-audience-type-members.json" and save the "id" as "eventId"
     And I accept "text/turtle"
     When I get the RDF of event with id "%{eventId}"
     Then the RDF response should match event projection "events/rdf/event-with-audience-type-members.ttl"
 
+  Scenario: Create an event with audienceType education
     Given I create an event from "events/rdf/event-with-audience-type-education.json" and save the "id" as "eventId"
     And I accept "text/turtle"
     When I get the RDF of event with id "%{eventId}"
     Then the RDF response should match event projection "events/rdf/event-with-audience-type-education.ttl"
 
+  Scenario: Create an event with audienceType children only
     Given I create an event from "events/rdf/event-with-audience-type-children-only.json" and save the "id" as "eventId"
     And I accept "text/turtle"
     When I get the RDF of event with id "%{eventId}"

--- a/features/event/rdf.feature
+++ b/features/event/rdf.feature
@@ -127,3 +127,19 @@ Feature: Test RDF projection of events
     When I get the RDF of event with id "%{eventId}"
     And I calculate the image hash with description "A cute dog", copyright "publiq vzw" and language "nl" for "%{imageId}" as "imageHash"
     Then the RDF response should match event projection "events/rdf/event-with-all-fields.ttl"
+
+  Scenario: Create an event with a not for everyone audienceType
+    Given I create an event from "events/rdf/event-with-audience-type-members.json" and save the "id" as "eventId"
+    And I accept "text/turtle"
+    When I get the RDF of event with id "%{eventId}"
+    Then the RDF response should match event projection "events/rdf/event-with-audience-type-members.ttl"
+
+    Given I create an event from "events/rdf/event-with-audience-type-education.json" and save the "id" as "eventId"
+    And I accept "text/turtle"
+    When I get the RDF of event with id "%{eventId}"
+    Then the RDF response should match event projection "events/rdf/event-with-audience-type-education.ttl"
+
+    Given I create an event from "events/rdf/event-with-audience-type-children-only.json" and save the "id" as "eventId"
+    And I accept "text/turtle"
+    When I get the RDF of event with id "%{eventId}"
+    Then the RDF response should match event projection "events/rdf/event-with-audience-type-children-only.ttl"

--- a/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
+++ b/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
@@ -19,6 +19,7 @@ use CultuurNet\UDB3\Model\Serializer\ValueObject\Geography\TranslatedAddressNorm
 use CultuurNet\UDB3\Model\Serializer\ValueObject\MediaObject\VideoNormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Price\MoneyNormalizer;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Price\TariffNormalizer;
+use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
@@ -115,6 +116,8 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
     private const PROPERTY_PRIJS_CATEGORY = 'cpp:prijscategorie';
     private const PROPERTY_PREF_LABEL = 'skos:prefLabel';
 
+    private const PROPERTY_AUDIENCE_TYPE = 'udb:audienceType';
+
     public function __construct(
         IriGeneratorInterface $eventsIriGenerator,
         IriGeneratorInterface $placesIriGenerator,
@@ -207,6 +210,8 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
         if ($event->getAvailableFrom()) {
             $workflowStatusEditor->setAvailableFrom($resource, $event->getAvailableFrom());
         }
+
+        $this->setAudienceType($resource, $event->getAudienceType());
 
         $this->setLocatieType($resource, $event->getAttendanceMode());
 
@@ -600,5 +605,13 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
             'from' => $subEvent->getDateRange()->getFrom()->format(DateTime::ATOM),
             'to' => $subEvent->getDateRange()->getTo()->format(DateTime::ATOM),
         ];
+    }
+
+    private function setAudienceType(Resource $resource, AudienceType $audienceType): void
+    {
+        $resource->set(
+            self::PROPERTY_AUDIENCE_TYPE,
+            new Resource('https://data.publiq.be/concepts/audienceType/' . $audienceType->toString())
+        );
     }
 }

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -1077,6 +1077,22 @@ class EventJsonToTurtleConverterTest extends TestCase
     /**
      * @test
      */
+    public function it_converts_an_event_with_audience_type(): void
+    {
+        $this->givenThereIsAnEvent([
+            'audience' => [
+                'audienceType' => 'education',
+            ],
+        ]);
+
+        $turtle = $this->eventJsonToTurtleConverter->convert($this->eventId);
+
+        $this->assertEquals(SampleFiles::read(__DIR__ . '/ttl/event-with-audience-type.ttl'), $turtle);
+    }
+
+    /**
+     * @test
+     */
     public function it_converts_an_event_with_images(): void
     {
         $url = 'https://images-acc.uitdatabank.be/6bab1cba-18d0-42e7-b0c9-3b869eb68934.jpeg';

--- a/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
+++ b/tests/Event/ReadModel/RDF/EventJsonToTurtleConverterTest.php
@@ -1077,7 +1077,7 @@ class EventJsonToTurtleConverterTest extends TestCase
     /**
      * @test
      */
-    public function it_converts_an_event_with_audience_type(): void
+    public function it_converts_an_event_with_an_audience_type_other_than_everyone(): void
     {
         $this->givenThereIsAnEvent([
             'audience' => [

--- a/tests/Event/ReadModel/RDF/ttl/event-with-audience-type.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-audience-type.ttl
@@ -8,8 +8,6 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
-@prefix cpr: <https://data.vlaanderen.be/ns/cultuurparticipatie#Realisator.> .
-@prefix schema: <https://schema.org/> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea>
   a cidoc:E7_Activity ;
@@ -19,9 +17,8 @@
   dcterms:title "Faith no more"@nl ;
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
-  cidoc:P14_carried_out_by <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#organisator-1f5bd80e> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
-  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/education> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 
@@ -34,16 +31,3 @@
   a generiek:GestructureerdeIdentificator ;
   generiek:naamruimte "https://mock.data.publiq.be/events/" ;
   generiek:lokaleIdentificator "d4b46fba-6433-4f86-bcb5-edeef6689fea" .
-
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#organisator-1f5bd80e>
-  a cp:Organisator ;
-  cpr:naam "Dummy Organizer"@nl ;
-  schema:contactPoint <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-ea81c639>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-1b0f9b07> .
-
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-ea81c639>
-  a schema:ContactPoint ;
-  schema:url "http://www.dummy-organizer.be" .
-
-<https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-1b0f9b07>
-  a schema:ContactPoint ;
-  schema:telephone "016 666 666" .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-booking-info.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-booking-info.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cpa:boeking <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#boekingsinfo-3e57fdcd> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-calendar-multiple.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-calendar-multiple.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a889f286> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-calendar-periodic-and-opening-hours.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-calendar-periodic-and-opening-hours.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a41ac158> ;
   cpa:beschikbaarheid <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#beschikbaarheid-958e340a> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-calendar-periodic.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-calendar-periodic.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a41ac158> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-calendar-permanent-and-opening-hours.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-calendar-permanent-and-opening-hours.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cpa:beschikbaarheid <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#beschikbaarheid-e2840d14> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-calendar-single.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-calendar-single.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-contact-point.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-contact-point.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   schema:contactPoint <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-66b969e2>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-b3906750>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-f3142b66>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-3979bafd>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-953ce804>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#contactPoint-08ebd0bd> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-description.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-description.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   dcterms:description "Dit is het laatste concert van Faith no more"@nl .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-multiple-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-dda33cdc>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-51afa81f> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-and-single-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-dda33cdc> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-multiple-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-62db2f98>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-5219ecee> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name-and-single-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-62db2f98> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location-name.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-location.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> .
 
 <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#identifier-fc28bf15>

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-organizer-with-translated-name.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-organizer-with-translated-name.ttl
@@ -20,6 +20,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   cidoc:P14_carried_out_by <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#organisator-cc485dab> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-dummy-organizer.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-dummy-organizer.ttl
@@ -20,6 +20,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   cidoc:P14_carried_out_by <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#organisator-5c61ffc5> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-labels.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-labels.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   dcat:keyword "public_label_1"^^labeltype:publiek, "public_label_2"^^labeltype:publiek, "hidden_label_1"^^labeltype:verborgen, "hidden_label_2"^^labeltype:verborgen .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-media-object.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-media-object.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   schema:image <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#imageObject-9dd47a29> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-organizer.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-organizer.ttl
@@ -19,6 +19,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   cidoc:P14_carried_out_by <https://mock.data.publiq.be/organizers/331a966d-d8ff-4e3c-a6f4-83b901f6c3af> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-price-info.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-price-info.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   cpa:prijs <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#priceSpecification-77836465>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#priceSpecification-2daf745e> .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-publication-date.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-publication-date.ttl
@@ -19,6 +19,7 @@
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/approved> ;
   udb:availableFrom "2023-04-23T12:30:15+02:00"^^xsd:dateTime ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-status-approved.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-status-approved.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/approved> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-status-deleted.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-status-deleted.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/deleted> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-status-ready-for-validation.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-status-ready-for-validation.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/ready-for-validation> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-status-rejected.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-status-rejected.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/rejected> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/event-with-translations.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-translations.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   dcterms:description "Dit is het laatste concert van Faith no more"@nl, "Ceci est le dernier concert de Foi non plus"@fr, "This is the last concert of Faith no more"@en .

--- a/tests/Event/ReadModel/RDF/ttl/event-with-videos.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event-with-videos.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> ;
   schema:video <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#videoObject-06299af1>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#videoObject-a46c333b> .

--- a/tests/Event/ReadModel/RDF/ttl/event.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/event.ttl
@@ -18,6 +18,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/fysiek> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .
 

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-multiple-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a889f286> .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-permanent-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-online-url-and-single-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-permanent-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   prov:atLocation <https://mock.data.publiq.be/places/bfc60a14-6208-4372-942e-86e63744769a> .

--- a/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/mixed-event-with-single-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/hybride> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-multiple-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4>, <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-a889f286> .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-permanent-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> .
 

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-online-url-and-single-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-61d7772d> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-permanent-calendar.ttl
@@ -19,6 +19,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> .
 

--- a/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
+++ b/tests/Event/ReadModel/RDF/ttl/online-event-with-single-calendar.ttl
@@ -20,6 +20,7 @@
   dcterms:type <https://mock.taxonomy.uitdatabank.be/terms/0.50.4.0.0> ;
   cp:thema <https://mock.taxonomy.uitdatabank.be/terms/1.8.3.1.0> ;
   udb:workflowStatus <https://data.publiq.be/concepts/workflowStatus/draft> ;
+  udb:audienceType <https://data.publiq.be/concepts/audienceType/everyone> ;
   cpa:locatieType <https://data.cultuurparticipatie.be/id/concept/Aanwezigheidsmodus/online> ;
   platform:virtueleLocatie <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#virtualLocation-b4e9ae58> ;
   cp:ruimtetijd <https://mock.data.publiq.be/events/d4b46fba-6433-4f86-bcb5-edeef6689fea#e92_Spacetime_Volume-8de5b7f4> .


### PR DESCRIPTION
### Added

- `event-with-audience-type*.{json|ttl}`: Add test files for Unit & Acceptance Test with `audienceType` other than `everyone`.

### Changed

- `EventJsonToTurtleConverter`: Project `audienceType` in `RDF`.
- `EventJsonToTurtleConverterTest`: Add Unit test.
- `/event/rdf.feature`: Add Acceptance test for `audiencetypes` other than `everyone`.
- `features/data/events/rdf/*`: Updated existing data files for Acceptance tests.
- `tests/Event/ReadModel/RDF/ttl/*`: Updated existing data files for Unit tests.

### Fixed

- `AudienceType` is now projected in `RDF`.

---

Ticket: https://jira.publiq.be/browse/III-7084
