### PR TITLE
III-6944 Remove queue_declare

### DIFF
--- a/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
+++ b/app/UiTPAS/UiTPASIncomingEventServicesProvider.php
@@ -67,7 +67,8 @@ final class UiTPASIncomingEventServicesProvider extends AbstractServiceProvider
                     new DBALDatabaseConnectionChecker(
                         $container->get('dbal_connection'),
                         $logger
-                    )
+                    ),
+                    $container->get('config')['amqp']['declare_queues'] ?? true
                 );
 
                 $consumerConfig = $container->get('config')['amqp']['consumers']['uitpas'];

--- a/src/Broadway/AMQP/AbstractConsumer.php
+++ b/src/Broadway/AMQP/AbstractConsumer.php
@@ -41,7 +41,8 @@ abstract class AbstractConsumer implements ConsumerInterface
         string $exchangeName,
         string $queueName,
         int $delay = 0,
-        string $messageHandlerName = 'message handler'
+        string $messageHandlerName = 'message handler',
+        bool $declareQueue = true
     ) {
         $this->connection = $connection;
         $this->channel = $connection->channel();
@@ -54,7 +55,10 @@ abstract class AbstractConsumer implements ConsumerInterface
         $this->delay = $delay;
         $this->messageHandlerName = $messageHandlerName;
 
-        $this->declareQueue();
+        if ($declareQueue) {
+            $this->declareQueue();
+        }
+
         $this->registerConsumeCallback();
     }
 

--- a/src/Broadway/AMQP/EventBusForwardingConsumer.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumer.php
@@ -31,7 +31,8 @@ final class EventBusForwardingConsumer extends AbstractConsumer
         string $queueName,
         UuidFactory $uuidFactory,
         DatabaseConnectionChecker $databaseConnectionChecker,
-        int $delay = 0
+        int $delay = 0,
+        bool $declareQueue = true
     ) {
         $this->eventBus = $eventBus;
         $this->uuidFactory = $uuidFactory;
@@ -44,7 +45,8 @@ final class EventBusForwardingConsumer extends AbstractConsumer
             $exchangeName,
             $queueName,
             $delay,
-            'event bus'
+            'event bus',
+            $declareQueue
         );
     }
 

--- a/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
+++ b/src/Broadway/AMQP/EventBusForwardingConsumerFactory.php
@@ -36,6 +36,8 @@ final class EventBusForwardingConsumerFactory
 
     private DatabaseConnectionChecker $databaseConnectionChecker;
 
+    private bool $declareQueue;
+
     public function __construct(
         int $executionDelay,
         AMQPStreamConnection $connection,
@@ -44,7 +46,8 @@ final class EventBusForwardingConsumerFactory
         EventBus $eventBus,
         string $consumerTag,
         UuidFactory $uuidFactory,
-        DatabaseConnectionChecker $databaseConnectionChecker
+        DatabaseConnectionChecker $databaseConnectionChecker,
+        bool $declareQueue = true
     ) {
         if ($executionDelay < 0) {
             throw new InvalidArgumentException('Execution delay should be zero or higher.');
@@ -58,6 +61,7 @@ final class EventBusForwardingConsumerFactory
         $this->consumerTag = $consumerTag;
         $this->uuidFactory = $uuidFactory;
         $this->databaseConnectionChecker = $databaseConnectionChecker;
+        $this->declareQueue = $declareQueue;
     }
 
     public function create(
@@ -73,7 +77,8 @@ final class EventBusForwardingConsumerFactory
             $queue,
             $this->uuidFactory,
             $this->databaseConnectionChecker,
-            $this->executionDelay
+            $this->executionDelay,
+            $this->declareQueue
         );
 
         $eventBusForwardingConsumer->setLogger($this->logger);


### PR DESCRIPTION
### Changed
- The application does not call `queue_declare` anymore. Queues should have been declared by the infrastructure.

---

Ticket: https://jira.uitdatabank.be/browse/III-6944
