### PR TITLE
III-7114 Acceptance tests for search with POST body

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -240,6 +240,11 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
                 $this->bindAddresses($router);
 
                 // Proxy GET requests to /events, /places, /offers and /organizers to SAPI3.
+                // This proxy does not support the POST requests feature of SAPI 3
+                // to avoid confusion with the creation of items. In theory
+                // it should be possible because at the moment we use a different
+                // content-type. But we are not sure that every EntryAPI-partner
+                // uses content-type correctly.
                 $router->get('/events/', ProxyRequestHandler::class);
                 $router->get('/places/', ProxyRequestHandler::class);
                 $router->get('/offers/', ProxyRequestHandler::class);

--- a/features/Steps/RequestSteps.php
+++ b/features/Steps/RequestSteps.php
@@ -60,6 +60,16 @@ trait RequestSteps
     }
 
     /**
+     * @Given I set the plain text request payload to:
+     */
+    public function iSetThePlainTextRequestPayloadTo(PyStringNode $plainTextPayload): void
+    {
+        $this->requestState->setJson(
+            $this->variableState->replaceVariables($plainTextPayload->getRaw())
+        );
+    }
+
+    /**
      * @Given I set the form data properties to:
      */
     public function iSetTheFormDataPropertiesTo(TableNode $table): void

--- a/features/search/post-body.feature
+++ b/features/search/post-body.feature
@@ -1,0 +1,129 @@
+@sapi3
+Feature: Test the Search API v3 via POST requests
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+    And I create a minimal place and save the "id" as "placeId"
+    And I publish the place at "/places/%{placeId}"
+    And I create an event from "events/event-with-workflow-status-ready-for-validation.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I send and accept "text/plain"
+    And I am using the Search API v3 base URL
+
+  Scenario: Only content-type text/plain is accepted
+    When I send and accept "application/json"
+    And I send a POST request to "/offers"
+    Then the response status should be "415"
+    And the JSON response at "detail" should be 'POST requests require Content-Type text/plain.'
+
+  Scenario: I can send parameters via a POST body
+    When I set the plain text request payload to:
+    """
+    locationId=%{placeId}
+    """
+    And I send a POST request to "/offers"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+
+  Scenario: I can send advanced queries via a POST body
+    When I set the plain text request payload to:
+    """
+    q=id:(%{eventId} OR %{placeId})
+    """
+    And I send a POST request to "/offers"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 2
+    And the JSON response should include:
+    """
+    %{placeId}
+    """
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+    When I send a POST request to "/places"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{placeId}
+    """
+    When I send a POST request to "/events"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+
+  Scenario: Endpoint with trailing slashes should work
+    When I set the plain text request payload to:
+    """
+    q=id:(%{eventId} OR %{placeId})
+    """
+    And I send a POST request to "/offers/"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 2
+    And the JSON response should include:
+    """
+    %{placeId}
+    """
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+    When I send a POST request to "/places/"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{placeId}
+    """
+    When I send a POST request to "/events/"
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+
+  Scenario: When using a POST Body, url parameters are ignored.
+    When I set the plain text request payload to:
+    """
+    q=id:%{eventId}
+    """
+    And I send a POST request to "/offers?q=id:%{placeId}"
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId}
+    """
+    And the JSON response should not include:
+    """
+    %{placeId}
+    """
+
+  Scenario: Use a combination of parameters & advanced queries
+    When I set the plain text request payload to:
+    """
+    workflowStatus=APPROVED&id=%{eventId}
+    """
+    And I send a POST request to "/offers"
+    Then the JSON response at "totalItems" should be 0
+    And I set the plain text request payload to:
+    """
+    workflowStatus=READY_FOR_VALIDATION&q=id:%{eventId}
+    """
+    And I send a POST request to "/offers"
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId}
+    """

--- a/features/search/post-body.feature
+++ b/features/search/post-body.feature
@@ -87,21 +87,14 @@ Feature: Test the Search API v3 via POST requests
     %{eventId}
     """
 
-  Scenario: When using a POST Body, url parameters are ignored.
+  Scenario: When using a POST Body, url parameters are not allowed.
     When I set the plain text request payload to:
     """
     q=id:%{eventId}
     """
     And I send a POST request to "/offers?q=id:%{placeId}"
-    Then the JSON response at "totalItems" should be 1
-    And the JSON response should include:
-    """
-    %{eventId}
-    """
-    And the JSON response should not include:
-    """
-    %{placeId}
-    """
+    Then the response status should be "400"
+    And the JSON response at "detail" should be 'POST requests do not allow query parameters in the URL. Use the request body instead.'
 
   Scenario: Use a combination of parameters & advanced queries
     When I set the plain text request payload to:

--- a/features/search/post-body.feature
+++ b/features/search/post-body.feature
@@ -25,7 +25,6 @@ Feature: Test the Search API v3 via POST requests
     locationId=%{placeId}
     """
     And I send a POST request to "/offers"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
@@ -38,7 +37,6 @@ Feature: Test the Search API v3 via POST requests
     q=id:(%{eventId} OR %{placeId})
     """
     And I send a POST request to "/offers"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """
@@ -49,14 +47,12 @@ Feature: Test the Search API v3 via POST requests
     %{eventId}
     """
     When I send a POST request to "/places"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
     %{placeId}
     """
     When I send a POST request to "/events"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
@@ -69,7 +65,6 @@ Feature: Test the Search API v3 via POST requests
     q=id:(%{eventId} OR %{placeId})
     """
     And I send a POST request to "/offers/"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """
@@ -80,14 +75,12 @@ Feature: Test the Search API v3 via POST requests
     %{eventId}
     """
     When I send a POST request to "/places/"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
     %{placeId}
     """
     When I send a POST request to "/events/"
-    Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """

--- a/features/search/post-body.feature
+++ b/features/search/post-body.feature
@@ -120,3 +120,19 @@ Feature: Test the Search API v3 via POST requests
     """
     %{eventId}
     """
+
+    Scenario: I get an error when using unsupported parameters or values
+      When I set the plain text request payload to:
+      """
+      Country=BE
+      """
+      And I send a POST request to "/offers"
+      Then the response status should be "404"
+      And the JSON response at "detail" should be "Unknown query parameter(s): Country"
+      When I set the plain text request payload to:
+      """
+      addressCountry=Belgium
+      """
+      And I send a POST request to "/offers"
+      Then the response status should be "404"
+      And the JSON response at "detail" should be "Unknown country code 'Belgium'."

--- a/features/search/post-body.feature
+++ b/features/search/post-body.feature
@@ -10,11 +10,12 @@ Feature: Test the Search API v3 via POST requests
     And I publish the place at "/places/%{placeId}"
     And I create an event from "events/event-with-workflow-status-ready-for-validation.json" and save the "id" as "eventId"
     And I wait for the event with url "/events/%{eventId}" to be indexed
-    And I send and accept "text/plain"
+    And I send "text/plain"
+    And I accept "application/json"
     And I am using the Search API v3 base URL
 
   Scenario: Only content-type text/plain is accepted
-    When I send and accept "application/json"
+    When I send "application/json"
     And I send a POST request to "/offers"
     Then the response status should be "415"
     And the JSON response at "detail" should be 'POST requests require Content-Type text/plain.'


### PR DESCRIPTION
### Changed

- `post-body.feature`: Acceptance tests for search requests with `POST` body
- `RequestSteps`: Add step `iSetThePlainTextRequestPayloadTo()`

### Related PR's

- https://github.com/cultuurnet/udb3-search-service/pull/441
- https://github.com/cultuurnet/apidocs/pull/502

---

Ticket: https://jira.publiq.be/browse/III-7114
