### PR TITLE
III-7132 Fix `id` and `location.id` to always be plural

### DIFF
--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -42,6 +42,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         $document = $this->removeMainImageWhenMediaObjectIsEmpty($document);
         $document = $this->removeActorType($document);
         $document = $this->removeBookingInfoWhenEmpty($document);
+        $document = $this->fixSingularId($document);
         return $this->fixDuplicateLabelVisibility($document);
     }
 
@@ -363,5 +364,27 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                 return $json;
             }
         );
+    }
+
+    private function fixSingularId(JsonDocument $jsonDocument): JsonDocument
+    {
+        return $jsonDocument->applyAssoc(
+            function (array $json) {
+                if (isset($json['@id']) && is_string($json['@id'])) {
+                    $json['@id'] = $this->pluralizeUrl($json['@id']);
+                }
+
+                if (isset($json['location']['@id']) && is_string($json['location']['@id'])) {
+                    $json['location']['@id'] = $this->pluralizeUrl($json['location']['@id']);
+                }
+
+                return $json;
+            }
+        );
+    }
+
+    private function pluralizeUrl(string $url): string
+    {
+        return str_replace(['/event/', '/place/'], ['/events/', '/places/'], $url);
     }
 }

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -612,7 +612,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                         ],
                     ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'mainLanguage' => 'nl',
                 'name' => [
                     'nl' => 'Kopieertest',
@@ -634,7 +634,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 ],
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'mainLanguage' => 'nl',
                 'name' => [
                     'fr' => 'Kopieertest',
@@ -656,7 +656,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 ],
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'name' => [
                     'fr' => 'Test de copie',
                 ],

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -811,6 +811,82 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
         ->assertReturnedDocumentDoesNotContainKey('image');
     }
 
+    /**
+     * @test
+     */
+    public function it_fixes_singular_event_id_to_plural(): void
+    {
+        $this
+            ->given([
+                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
+            ])
+            ->assertReturnedDocumentContains([
+                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fixes_singular_location_id_to_plural(): void
+    {
+        $placeId = '1a2b3c4d-5e6f-7890-abcd-ef1234567890';
+        $this
+            ->given([
+                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+                'location' => [
+                    '@id' => 'https://io.uitdatabank.dev/place/' . $placeId,
+                    '@type' => 'Place',
+                ],
+            ])
+            ->assertReturnedDocumentContains([
+                'location' => [
+                    '@id' => 'https://io.uitdatabank.dev/places/' . $placeId,
+                    '@type' => 'Place',
+                    'status' => [
+                        'type' => 'Available',
+                    ],
+                    'bookingAvailability' => [
+                        'type' => 'Available',
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fixes_singular_place_id_to_plural(): void
+    {
+        $this->repository = new PropertyPolyfillOfferRepository(
+            new InMemoryDocumentRepository(),
+            $this->labelReadRepository,
+            OfferType::place()
+        );
+
+        $this
+            ->given([
+                '@id' => 'https://io.uitdatabank.dev/place/' . self::DOCUMENT_ID,
+            ])
+            ->assertReturnedDocumentContains([
+                '@id' => 'https://io.uitdatabank.dev/places/' . self::DOCUMENT_ID,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_change_already_plural_id(): void
+    {
+        $this
+            ->given([
+                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+            ])
+            ->assertReturnedDocumentContains([
+                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+            ]);
+    }
+
     private function given(array $given): self
     {
         $this->repository->save(


### PR DESCRIPTION
### Fixed
- Fixed `id` and `location.id` to always be plural

---

Ticket: https://jira.uitdatabank.be/browse/III-7132
