### PR TITLE
III-7108 [PR 1/3] Add overnight boolean to subEvent domain model

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -25,6 +25,7 @@ When working on this codebase, prefer:
 - Inline expressions over unnecessary local variables (if a variable is only used once and doesn't improve readability, inline it)
 - When one needs to serialize() or deserialize(), implement a new NormalizerInterface or DenormalizerInterface, this Normalizer can be called in the serialize method of Broadway\Serializer\Serializable
 - When making collections, try to extend from \CultuurNet\UDB3\Model\ValueObject\Collection\Collection.
+- **Avoid early-exit optimizations that duplicate domain guards**: if an apply method already checks for actual changes (e.g. via `sameCalendars`) before persisting, there is no need to pre-check whether anything changed before calling `apply()`.
 
 ## Comments & Self-Documenting Code
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -25,7 +25,7 @@ When working on this codebase, prefer:
 - Inline expressions over unnecessary local variables (if a variable is only used once and doesn't improve readability, inline it)
 - When one needs to serialize() or deserialize(), implement a new NormalizerInterface or DenormalizerInterface, this Normalizer can be called in the serialize method of Broadway\Serializer\Serializable
 - When making collections, try to extend from \CultuurNet\UDB3\Model\ValueObject\Collection\Collection.
-- **Avoid early-exit optimizations that duplicate domain guards**: if an apply method already checks for actual changes (e.g. via `sameCalendars`) before persisting, there is no need to pre-check whether anything changed before calling `apply()`.
+- **Use `sameCalendars` as the guard before `apply(new CalendarUpdated(...))`**: do not manually inspect individual fields (e.g. looping to check if any sub-event has `overnight = true`) to decide whether to call `apply()`. Build the updated calendar and let `sameCalendars` determine whether anything actually changed.
 
 ## Comments & Self-Documenting Code
 

--- a/docs/plan-overnight-subevent.md
+++ b/docs/plan-overnight-subevent.md
@@ -1,0 +1,229 @@
+# Implementation Plan: `overnight` boolean on subEvents
+
+## Overview
+
+Add an optional `overnight` boolean property to subEvents for events with `calendarType = single` or `calendarType = multiple`. The property is only meaningful for events of type "Kamp of vakantie" (term id `0.57.0.0.0`). When omitted or `false`, it is hidden from the read model.
+
+---
+
+## JSON Schema Status
+
+The vendor package `publiq/udb3-json-schemas` already has `overnight` defined in:
+- `event-subEvent-patch.json` ✅ (PATCH /events/{id}/subEvents)
+- `event-subEvent-put.json` ✅ (used by PUT /events and POST /events import)
+- `event-subEvent.json` ✅ (response shape)
+
+Still missing:
+- `event-calendar-put.json` ❌ — needs `overnight: { type: boolean }` added to the subEvent item schema
+
+---
+
+## Central Configuration
+
+The term id `0.57.0.0.0` must be defined as a single named constant. The right home is `EventTypeResolver`, which already references this id in `isOnlyAvailableUntilStartDate()`:
+
+```php
+// src/Event/EventTypeResolver.php
+public const KAMP_OF_VAKANTIE_TERM_ID = '0.57.0.0.0';
+```
+
+Update `isOnlyAvailableUntilStartDate()` to use `self::KAMP_OF_VAKANTIE_TERM_ID` instead of a raw string. Every other reference throughout the codebase (validation, reset logic, tests) must use this constant — never a raw string.
+
+---
+
+## PR 1 — Domain Model: `overnight` on `SubEvent` and `SubEventUpdate`
+
+**Goal:** Add the `overnight` field to the core value objects and calendar classes. No HTTP or projection concerns yet.
+
+### Files to change
+
+**`src/Model/ValueObject/Calendar/SubEvent.php`**
+- Add `private bool $overnight = false`
+- Add `withOvernight(bool $overnight): self`
+- Add `isOvernight(): bool`
+
+**`src/Model/ValueObject/Calendar/SubEventUpdate.php`**
+- Add `private ?bool $overnight = null`
+- Add `withOvernight(?bool $overnight): self`
+- Add `getOvernight(): ?bool`
+
+**`src/Event/EventTypeResolver.php`**
+- Add `public const KAMP_OF_VAKANTIE_TERM_ID = '0.57.0.0.0'`
+- Replace the hardcoded `'0.57.0.0.0'` string in `isOnlyAvailableUntilStartDate()` with `self::KAMP_OF_VAKANTIE_TERM_ID`
+
+**`src/Event/Event.php`** — update `updateSubEvents()`
+- When merging a `SubEventUpdate` into a `SubEvent`, apply `overnight` if it is not `null` in the update
+- When `overnight` is `true` in any subEvent or subEventUpdate, verify the event's current type is `EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID`; throw a domain exception otherwise
+- In `updateType()` (or wherever the type change is applied in the aggregate): if the new type id is no longer `EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID`, reset `overnight` to `false` on all subEvents before recording the `CalendarUpdated` event
+
+**`src/Offer/Offer.php`** — update `updateCalendar()`
+- After receiving a new `Calendar`, if any subEvent has `overnight = true`, verify the event's current type is `EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID`; throw a domain exception otherwise
+
+### Tests
+- `tests/Model/ValueObject/Calendar/SubEventTest.php` — getter and fluent setter
+- `tests/Model/ValueObject/Calendar/SubEventUpdateTest.php` — getter and fluent setter
+- `tests/Event/EventTest.php` — overnight validation, overnight preserved across unrelated updates, reset when term changes away from `0.57.0.0.0`
+
+---
+
+## PR 2 — Write Path: Deserialization, JSON Schema, and Validation
+
+**Goal:** Accept `overnight` in request bodies and wire it through to the domain. Includes the one remaining schema change.
+
+### Files to change
+
+**`vendor/publiq/udb3-json-schemas` (upstream package)**
+- `event-calendar-put.json` — add `overnight: { type: boolean }` to the subEvent item schema (mirrors the definition already in `event-subEvent-patch.json`)
+
+**`src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php`**
+- In `denormalizeSubEvent()`: read `overnight` from the raw data; call `->withOvernight(true)` when present and `true`
+
+**`src/Model/Serializer/ValueObject/Calendar/SubEventUpdatesDenormalizer.php`**
+- Read `overnight` from each patch item; call `->withOvernight()` when the key is present (pass `false` explicitly to allow clearing)
+
+### Validation summary
+
+| Rule | Where enforced |
+|------|---------------|
+| `overnight` only for `calendarType` single/multiple | JSON schema (`event-calendar-put.json` and `event-subEvent-patch.json` include it; place schemas do not) |
+| `overnight` only when term `0.57.0.0.0` is present | Domain (`Event::updateCalendar`, `Event::updateSubEvents`) |
+| Auto-reset when term removed | Domain (`Event::updateType`) |
+| `overnight` must be boolean | JSON schema (`type: boolean`) |
+
+### New test cases — `UpdateCalendarRequestHandlerTest::validEventDataProvider()`
+
+| Case key | What it covers |
+|----------|----------------|
+| `single_with_overnight_true` | `calendarType=single`, one subEvent with `overnight: true` → command includes `SubEvent::createAvailable(…)->withOvernight(true)` |
+| `multiple_with_overnight_on_one_subevent` | `calendarType=multiple`, two subEvents, only the first has `overnight: true` |
+| `single_overnight_false_omitted_from_command` | `overnight: false` in request → command carries `withOvernight(false)` (or default false, same shape) |
+
+### New test cases — `UpdateCalendarRequestHandlerTest::invalidEventDataProvider()`
+
+| Case key | What it covers |
+|----------|----------------|
+| `single_overnight_wrong_type_string` | `overnight: "yes"` → JSON schema error `/subEvent/0/overnight` "The data (string) must match the type: boolean" |
+| `single_overnight_wrong_type_integer` | `overnight: 1` → JSON schema error `/subEvent/0/overnight` "The data (integer) must match the type: boolean" |
+
+### New test cases — `UpdateSubEventsRequestHandlerTest::validDataProvider()`
+
+| Case key | What it covers |
+|----------|----------------|
+| `one_subEvent_with_overnight_true` | `id: 0, overnight: true` → command: `(new SubEventUpdate(0))->withOvernight(true)` |
+| `one_subEvent_with_overnight_false` | `id: 0, overnight: false` → command: `(new SubEventUpdate(0))->withOvernight(false)` |
+
+### New test cases — `UpdateSubEventsRequestHandlerTest::invalidDataProvider()`
+
+| Case key | What it covers |
+|----------|----------------|
+| `one_subEvent_overnight_wrong_type_string` | `overnight: "yes"` → schema error `/0/overnight` "The data (string) must match the type: boolean" |
+| `one_subEvent_overnight_wrong_type_integer` | `overnight: 1` → schema error `/0/overnight` "The data (integer) must match the type: boolean" |
+
+### Tests
+- `tests/Model/Serializer/ValueObject/Calendar/CalendarDenormalizerTest.php`
+- `tests/Model/Serializer/ValueObject/Calendar/SubEventUpdatesDenormalizerTest.php`
+
+---
+
+## PR 3 — Read Model: Projection, Normalization, and Feature Tests
+
+**Goal:** Include `overnight: true` in JSON-LD output only when set; omit it when `false`. Add end-to-end feature tests.
+
+### Files to change
+
+**`src/Model/Serializer/ValueObject/Calendar/SubEventNormalizer.php`**
+- After serializing existing fields: `if ($subEvent->isOvernight()) { $data['overnight'] = true; }`
+
+**`src/Model/Serializer/ValueObject/Calendar/SubEventDenormalizer.php`** (used during import/replay)
+- Read `overnight` from stored JSON and call `->withOvernight(true)` if present and `true`
+
+### Tests
+- `tests/Model/Serializer/ValueObject/Calendar/SubEventNormalizerTest.php`
+  - `overnight: true` → included in output
+  - `overnight: false` (default) → absent from output
+- `tests/Model/Serializer/ValueObject/Calendar/SubEventDenormalizerTest.php`
+  - stored JSON with `overnight: true` → denormalized with `isOvernight() === true`
+  - stored JSON without `overnight` → denormalized with `isOvernight() === false`
+- `tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php` — projection round-trip
+
+### Feature tests — new file `features/event/sub-event-overnight.feature`
+
+Each scenario follows the pattern established in `sub-event-childcare-time.feature`. Fixture JSON files go in `features/data/events/sub-event-overnight/`.
+
+**Fixture: `event-kamp-single.json`**
+```json
+{
+  "mainLanguage": "nl",
+  "name": {"nl": "Zomerkamp"},
+  "terms": [{"id": "0.57.0.0.0", "label": "Kamp of vakantie", "domain": "eventtype"}],
+  "location": {"@id": "%{placeUrl}"},
+  "calendarType": "single",
+  "startDate": "2026-07-01T09:00:00+02:00",
+  "endDate": "2026-07-05T17:00:00+02:00",
+  "subEvent": [
+    {
+      "startDate": "2026-07-01T09:00:00+02:00",
+      "endDate": "2026-07-05T17:00:00+02:00",
+      "overnight": true
+    }
+  ]
+}
+```
+
+**Scenarios to write:**
+
+1. **Create `single` event with `overnight: true` — visible in GET**
+   - POST with `event-kamp-single.json` (term `0.57.0.0.0`)
+   - GET → `subEvent/0/overnight` should be `true`
+
+2. **Create `multiple` event with `overnight: true` on one subEvent**
+   - POST with multiple calendarType, two subEvents, first has `overnight: true`
+   - GET → `subEvent/0/overnight` is `true`, `subEvent/1` has no `overnight`
+
+3. **`overnight: false` is omitted from GET response**
+   - POST with `overnight: false` explicitly set
+   - GET → JSON response should not have `subEvent/0/overnight`
+
+4. **`overnight` omitted entirely is also absent from GET response**
+   - POST without `overnight`
+   - GET → JSON response should not have `subEvent/0/overnight`
+
+5. **Update `overnight` via PUT /calendar**
+   - Create event without `overnight`
+   - PUT `/calendar` with `overnight: true`
+   - GET → `subEvent/0/overnight` is `true`
+
+6. **Update `overnight` via PATCH /subEvents**
+   - Create event with `overnight: true`
+   - PATCH `/subEvents` with `id: 0, overnight: false`
+   - GET → JSON response should not have `subEvent/0/overnight`
+
+7. **`overnight` is preserved when omitted from PATCH**
+   - Create event with `overnight: true`
+   - PATCH `/subEvents` with `id: 0, status: {type: Available}` (no `overnight` key)
+   - GET → `subEvent/0/overnight` still `true`
+
+8. **`overnight` is reset when term `0.57.0.0.0` is removed via PUT /type**
+   - Create event with `overnight: true`
+   - PUT `/type/{termId}` replacing with a different type (e.g. `0.50.4.0.0`)
+   - GET → JSON response should not have `subEvent/0/overnight`
+
+9. **Invalid: `overnight: "yes"` rejected by schema on PUT /calendar**
+   - PUT `/calendar` with `overnight: "yes"` on a subEvent
+   - Response 400, `schemaErrors/0/jsonPointer` = `/subEvent/0/overnight`
+
+10. **Invalid: `overnight: 1` rejected by schema on PATCH /subEvents**
+    - PATCH `/subEvents` with `overnight: 1`
+    - Response 400, `schemaErrors/0/jsonPointer` = `/0/overnight`
+
+---
+
+## PR Breakdown Summary
+
+| PR | Scope | Key changes |
+|----|-------|-------------|
+| **PR 1** | Domain model | `SubEvent`, `SubEventUpdate`, `EventTypeResolver` constant, domain validation + reset in `Event.php` and `Offer.php` |
+| **PR 2** | Write path | `event-calendar-put.json` schema, `CalendarDenormalizer`, `SubEventUpdatesDenormalizer`, new test cases in both handler tests |
+| **PR 3** | Read model + feature tests | `SubEventNormalizer`, `SubEventDenormalizer` (replay/import), unit tests, `sub-event-overnight.feature` with fixture JSON |
+
+Each PR is independently reviewable. PR 2 depends on PR 1; PR 3 depends on both.

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -443,11 +443,11 @@ final class Event extends Offer
 
     public function updateType(Category $category): void
     {
-        $wasCamp = $this->typeId === EventTypeResolver::CAMP_UUID;
+        $wasCamp = $this->typeId === EventTypeResolver::CAMP_TERM_ID;
 
         parent::updateType($category);
 
-        $isNowCamp = $category->getId()->toString() === EventTypeResolver::CAMP_UUID;
+        $isNowCamp = $category->getId()->toString() === EventTypeResolver::CAMP_TERM_ID;
 
         if ($wasCamp && !$isNowCamp && $this->calendar instanceof CalendarWithSubEvents) {
             $subEvents = $this->calendar->getSubEvents()->toArray();
@@ -484,14 +484,14 @@ final class Event extends Offer
      */
     private function assertOvernightAllowed(array $subEvents): void
     {
-        if ($this->typeId === EventTypeResolver::CAMP_UUID) {
+        if ($this->typeId === EventTypeResolver::CAMP_TERM_ID) {
             return;
         }
 
         foreach ($subEvents as $subEvent) {
             if ($subEvent->isOvernight()) {
                 throw new \InvalidArgumentException(
-                    'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID
+                    'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID
                 );
             }
         }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -444,7 +444,7 @@ final class Event extends Offer
 
     public function updateType(Category $category): void
     {
-        $wasCamp = $this->typeId === EventTypeResolver::CAMP_OR_VACATION_TERM_ID;
+        $wasCamp = EventTypeResolver::isOvernightAllowed($this->typeId);
 
         parent::updateType($category);
 
@@ -483,7 +483,7 @@ final class Event extends Offer
      */
     private function assertOvernightAllowed(array $subEvents): void
     {
-        if ($this->typeId === EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
+        if (EventTypeResolver::isOvernightAllowed($this->typeId)) {
             return;
         }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -58,7 +58,6 @@ use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
 use CultuurNet\UDB3\Event\Events\TitleUpdated;
 use CultuurNet\UDB3\Event\Events\TypeUpdated;
-use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
@@ -470,7 +469,7 @@ final class Event extends Offer
             }
 
             if ($hasOvernight) {
-                $resetSubEvents = array_map(fn(SubEvent $se) => $se->withOvernight(false), $subEvents);
+                $resetSubEvents = array_map(fn (SubEvent $se) => $se->withOvernight(false), $subEvents);
 
                 if ($this->calendar->getType()->sameAs(CalendarType::single())) {
                     $updatedCalendar = new SingleSubEventCalendar($resetSubEvents[0]);

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -449,20 +449,8 @@ final class Event extends Offer
         parent::updateType($category);
 
         if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && $this->typeId !== EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
-            $subEvents = $this->calendar->getSubEvents()->toArray();
-
-            $hasOvernight = false;
-            foreach ($subEvents as $subEvent) {
-                if ($subEvent->isOvernight()) {
-                    $hasOvernight = true;
-                    break;
-                }
-            }
-
-            if ($hasOvernight) {
-                $resetSubEvents = array_map(fn (SubEvent $se) => $se->withOvernight(false), $subEvents);
-                $this->apply(new CalendarUpdated($this->eventId, $this->rebuildCalendarFromSubEvents($resetSubEvents)));
-            }
+            $resetSubEvents = $this->calendar->getSubEvents()->withoutOvernight()->toArray();
+            $this->apply(new CalendarUpdated($this->eventId, $this->rebuildCalendarFromSubEvents($resetSubEvents)));
         }
     }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -58,6 +58,7 @@ use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TitleTranslated;
 use CultuurNet\UDB3\Event\Events\TitleUpdated;
 use CultuurNet\UDB3\Event\Events\TypeUpdated;
+use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeDeleted;
 use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Event\Events\VideoAdded;
@@ -416,8 +417,14 @@ final class Event extends Offer
                 $updatedSubEvent = $updatedSubEvent->withChildcareTimeRange($childcareToApply);
             }
 
+            // null = not mentioned (preserve existing), true/false = explicit update
+            $overnight = $subEventUpdate->getOvernight() ?? $subEvent->isOvernight();
+            $updatedSubEvent = $updatedSubEvent->withOvernight($overnight);
+
             $subEvents[$index] = $updatedSubEvent;
         }
+
+        $this->assertOvernightAllowed($subEvents);
 
         if ($this->calendar->getType()->sameAs(CalendarType::single())) {
             $updatedCalendar = new SingleSubEventCalendar($subEvents[0]);
@@ -431,6 +438,68 @@ final class Event extends Offer
             $this->apply(
                 new CalendarUpdated($this->eventId, $updatedCalendar)
             );
+        }
+    }
+
+    public function updateCalendar(Calendar $calendar): void
+    {
+        if ($calendar instanceof CalendarWithSubEvents) {
+            $this->assertOvernightAllowed($calendar->getSubEvents()->toArray());
+        }
+
+        parent::updateCalendar($calendar);
+    }
+
+    public function updateType(Category $category): void
+    {
+        $wasKampOrVakantie = $this->typeId === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID;
+
+        parent::updateType($category);
+
+        $isNowKampOrVakantie = $category->getId()->toString() === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID;
+
+        if ($wasKampOrVakantie && !$isNowKampOrVakantie && $this->calendar instanceof CalendarWithSubEvents) {
+            $subEvents = $this->calendar->getSubEvents()->toArray();
+
+            $hasOvernight = false;
+            foreach ($subEvents as $subEvent) {
+                if ($subEvent->isOvernight()) {
+                    $hasOvernight = true;
+                    break;
+                }
+            }
+
+            if ($hasOvernight) {
+                $resetSubEvents = array_map(fn(SubEvent $se) => $se->withOvernight(false), $subEvents);
+
+                if ($this->calendar->getType()->sameAs(CalendarType::single())) {
+                    $updatedCalendar = new SingleSubEventCalendar($resetSubEvents[0]);
+                } else {
+                    $updatedCalendar = new MultipleSubEventsCalendar(new SubEvents(...$resetSubEvents));
+                }
+
+                $updatedCalendar = $updatedCalendar->withBookingAvailability($this->calendar->getBookingAvailability());
+
+                $this->apply(new CalendarUpdated($this->eventId, $updatedCalendar));
+            }
+        }
+    }
+
+    /**
+     * @param SubEvent[] $subEvents
+     */
+    private function assertOvernightAllowed(array $subEvents): void
+    {
+        if ($this->typeId === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID) {
+            return;
+        }
+
+        foreach ($subEvents as $subEvent) {
+            if ($subEvent->isOvernight()) {
+                throw new \InvalidArgumentException(
+                    'overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID
+                );
+            }
         }
     }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -444,16 +444,20 @@ final class Event extends Offer
 
     public function updateType(Category $category): void
     {
-        $wasCamp = EventTypeResolver::isOvernightAllowed($this->typeId);
-
         parent::updateType($category);
 
-        if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && $this->typeId !== EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
-            $resetSubEvents = $this->calendar->getSubEvents()->withoutOvernight()->toArray();
-            $updatedCalendar = $this->rebuildCalendarFromSubEvents($resetSubEvents);
-            if (!$this->sameCalendars($this->calendar, $updatedCalendar)) {
-                $this->apply(new CalendarUpdated($this->eventId, $updatedCalendar));
-            }
+        if (!($this->calendar instanceof CalendarWithSubEvents)) {
+            return;
+        }
+
+        if (EventTypeResolver::isOvernightAllowed($this->typeId)) {
+            return;
+        }
+
+        $resetSubEvents = $this->calendar->getSubEvents()->withoutOvernight()->toArray();
+        $updatedCalendar = $this->rebuildCalendarFromSubEvents($resetSubEvents);
+        if (!$this->sameCalendars($this->calendar, $updatedCalendar)) {
+            $this->apply(new CalendarUpdated($this->eventId, $updatedCalendar));
         }
     }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -416,22 +416,14 @@ final class Event extends Offer
                 $updatedSubEvent = $updatedSubEvent->withChildcareTimeRange($childcareToApply);
             }
 
-            // null = not mentioned (preserve existing), true/false = explicit update
-            $overnight = $subEventUpdate->getOvernight() ?? $subEvent->isOvernight();
-            $updatedSubEvent = $updatedSubEvent->withOvernight($overnight);
+            $updatedSubEvent = $updatedSubEvent->withOvernight($subEventUpdate->getOvernight() ?? $subEvent->isOvernight());
 
             $subEvents[$index] = $updatedSubEvent;
         }
 
         $this->assertOvernightAllowed($subEvents);
 
-        if ($this->calendar->getType()->sameAs(CalendarType::single())) {
-            $updatedCalendar = new SingleSubEventCalendar($subEvents[0]);
-        } else {
-            $updatedCalendar = new MultipleSubEventsCalendar(new SubEvents(...$subEvents));
-        }
-
-        $updatedCalendar = $updatedCalendar->withBookingAvailability($this->calendar->getBookingAvailability());
+        $updatedCalendar = $this->rebuildCalendarFromSubEvents($subEvents);
 
         if (!$this->sameCalendars($this->calendar, $updatedCalendar)) {
             $this->apply(
@@ -451,13 +443,13 @@ final class Event extends Offer
 
     public function updateType(Category $category): void
     {
-        $wasKampOrVakantie = $this->typeId === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID;
+        $wasCamp = $this->typeId === EventTypeResolver::CAMP_UUID;
 
         parent::updateType($category);
 
-        $isNowKampOrVakantie = $category->getId()->toString() === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID;
+        $isNowCamp = $category->getId()->toString() === EventTypeResolver::CAMP_UUID;
 
-        if ($wasKampOrVakantie && !$isNowKampOrVakantie && $this->calendar instanceof CalendarWithSubEvents) {
+        if ($wasCamp && !$isNowCamp && $this->calendar instanceof CalendarWithSubEvents) {
             $subEvents = $this->calendar->getSubEvents()->toArray();
 
             $hasOvernight = false;
@@ -470,16 +462,7 @@ final class Event extends Offer
 
             if ($hasOvernight) {
                 $resetSubEvents = array_map(fn (SubEvent $se) => $se->withOvernight(false), $subEvents);
-
-                if ($this->calendar->getType()->sameAs(CalendarType::single())) {
-                    $updatedCalendar = new SingleSubEventCalendar($resetSubEvents[0]);
-                } else {
-                    $updatedCalendar = new MultipleSubEventsCalendar(new SubEvents(...$resetSubEvents));
-                }
-
-                $updatedCalendar = $updatedCalendar->withBookingAvailability($this->calendar->getBookingAvailability());
-
-                $this->apply(new CalendarUpdated($this->eventId, $updatedCalendar));
+                $this->apply(new CalendarUpdated($this->eventId, $this->rebuildCalendarFromSubEvents($resetSubEvents)));
             }
         }
     }
@@ -487,16 +470,28 @@ final class Event extends Offer
     /**
      * @param SubEvent[] $subEvents
      */
+    private function rebuildCalendarFromSubEvents(array $subEvents): Calendar
+    {
+        $calendar = $this->calendar->getType()->sameAs(CalendarType::single())
+            ? new SingleSubEventCalendar($subEvents[0])
+            : new MultipleSubEventsCalendar(new SubEvents(...$subEvents));
+
+        return $calendar->withBookingAvailability($this->calendar->getBookingAvailability());
+    }
+
+    /**
+     * @param SubEvent[] $subEvents
+     */
     private function assertOvernightAllowed(array $subEvents): void
     {
-        if ($this->typeId === EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID) {
+        if ($this->typeId === EventTypeResolver::CAMP_UUID) {
             return;
         }
 
         foreach ($subEvents as $subEvent) {
             if ($subEvent->isOvernight()) {
                 throw new \InvalidArgumentException(
-                    'overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID
+                    'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID
                 );
             }
         }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -444,11 +444,11 @@ final class Event extends Offer
 
     public function updateType(Category $category): void
     {
-        $wasCamp = $this->typeId === EventTypeResolver::CAMP_TERM_ID;
+        $wasCamp = $this->typeId === EventTypeResolver::CAMP_OR_VACATION_TERM_ID;
 
         parent::updateType($category);
 
-        if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && !($category->getId()->toString() === EventTypeResolver::CAMP_TERM_ID)) {
+        if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && $this->typeId !== EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
             $subEvents = $this->calendar->getSubEvents()->toArray();
 
             $hasOvernight = false;
@@ -483,14 +483,14 @@ final class Event extends Offer
      */
     private function assertOvernightAllowed(array $subEvents): void
     {
-        if ($this->typeId === EventTypeResolver::CAMP_TERM_ID) {
+        if ($this->typeId === EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
             return;
         }
 
         foreach ($subEvents as $subEvent) {
             if ($subEvent->isOvernight()) {
                 throw new InvalidArgumentException(
-                    'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID
+                    'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_OR_VACATION_TERM_ID
                 );
             }
         }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -105,6 +105,7 @@ use CultuurNet\UDB3\Model\ValueObject\Text\Title;
 use CultuurNet\UDB3\Model\ValueObject\TimeImmutableRange;
 use DateTimeImmutable;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 final class Event extends Offer
 {
@@ -490,7 +491,7 @@ final class Event extends Offer
 
         foreach ($subEvents as $subEvent) {
             if ($subEvent->isOvernight()) {
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     'overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID
                 );
             }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -448,9 +448,7 @@ final class Event extends Offer
 
         parent::updateType($category);
 
-        $isNowCamp = $category->getId()->toString() === EventTypeResolver::CAMP_TERM_ID;
-
-        if ($wasCamp && !$isNowCamp && $this->calendar instanceof CalendarWithSubEvents) {
+        if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && !($category->getId()->toString() === EventTypeResolver::CAMP_TERM_ID)) {
             $subEvents = $this->calendar->getSubEvents()->toArray();
 
             $hasOvernight = false;

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -450,7 +450,10 @@ final class Event extends Offer
 
         if ($this->calendar instanceof CalendarWithSubEvents && $wasCamp && $this->typeId !== EventTypeResolver::CAMP_OR_VACATION_TERM_ID) {
             $resetSubEvents = $this->calendar->getSubEvents()->withoutOvernight()->toArray();
-            $this->apply(new CalendarUpdated($this->eventId, $this->rebuildCalendarFromSubEvents($resetSubEvents)));
+            $updatedCalendar = $this->rebuildCalendarFromSubEvents($resetSubEvents);
+            if (!$this->sameCalendars($this->calendar, $updatedCalendar)) {
+                $this->apply(new CalendarUpdated($this->eventId, $updatedCalendar));
+            }
         }
     }
 

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -12,7 +12,7 @@ use Exception;
 
 final class EventTypeResolver implements TypeResolverInterface
 {
-    public const CAMP_TERM_ID = '0.57.0.0.0';
+    public const CAMP_OR_VACATION_TERM_ID = '0.57.0.0.0';
 
     public function __construct(readonly Categories $types)
     {
@@ -34,7 +34,7 @@ final class EventTypeResolver implements TypeResolverInterface
             $eventType->getId()->toString(),
             [
                 '0.3.1.0.0',
-                self::CAMP_TERM_ID,
+                self::CAMP_OR_VACATION_TERM_ID,
             ]
         );
     }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -38,4 +38,9 @@ final class EventTypeResolver implements TypeResolverInterface
             ]
         );
     }
+
+    public static function isOvernightAllowed(string $eventTermId) : bool
+    {
+        return $eventTermId === self::CAMP_OR_VACATION_TERM_ID;
+    }
 }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -12,7 +12,7 @@ use Exception;
 
 final class EventTypeResolver implements TypeResolverInterface
 {
-    public const KAMP_OF_VAKANTIE_TERM_ID = '0.57.0.0.0';
+    public const CAMP_UUID = '0.57.0.0.0';
 
     public function __construct(readonly Categories $types)
     {
@@ -34,7 +34,7 @@ final class EventTypeResolver implements TypeResolverInterface
             $eventType->getId()->toString(),
             [
                 '0.3.1.0.0',
-                self::KAMP_OF_VAKANTIE_TERM_ID,
+                self::CAMP_UUID,
             ]
         );
     }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -12,6 +12,8 @@ use Exception;
 
 final class EventTypeResolver implements TypeResolverInterface
 {
+    public const KAMP_OF_VAKANTIE_TERM_ID = '0.57.0.0.0';
+
     public function __construct(readonly Categories $types)
     {
     }
@@ -32,7 +34,7 @@ final class EventTypeResolver implements TypeResolverInterface
             $eventType->getId()->toString(),
             [
                 '0.3.1.0.0',
-                '0.57.0.0.0',
+                self::KAMP_OF_VAKANTIE_TERM_ID,
             ]
         );
     }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -39,7 +39,7 @@ final class EventTypeResolver implements TypeResolverInterface
         );
     }
 
-    public static function isOvernightAllowed(string $eventTermId) : bool
+    public static function isOvernightAllowed(string $eventTermId): bool
     {
         return $eventTermId === self::CAMP_OR_VACATION_TERM_ID;
     }

--- a/src/Event/EventTypeResolver.php
+++ b/src/Event/EventTypeResolver.php
@@ -12,7 +12,7 @@ use Exception;
 
 final class EventTypeResolver implements TypeResolverInterface
 {
-    public const CAMP_UUID = '0.57.0.0.0';
+    public const CAMP_TERM_ID = '0.57.0.0.0';
 
     public function __construct(readonly Categories $types)
     {
@@ -34,7 +34,7 @@ final class EventTypeResolver implements TypeResolverInterface
             $eventType->getId()->toString(),
             [
                 '0.3.1.0.0',
-                self::CAMP_UUID,
+                self::CAMP_TERM_ID,
             ]
         );
     }

--- a/src/Model/Serializer/ValueObject/Calendar/SubEventNormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/SubEventNormalizer.php
@@ -33,6 +33,10 @@ final class SubEventNormalizer implements NormalizerInterface
             $normalized['childcare'] = $childcare;
         }
 
+        if ($subEvent->isOvernight()) {
+            $normalized['overnight'] = true;
+        }
+
         return $normalized;
     }
 

--- a/src/Model/ValueObject/Calendar/SubEvent.php
+++ b/src/Model/ValueObject/Calendar/SubEvent.php
@@ -19,6 +19,8 @@ final class SubEvent
 
     private ?TimeImmutableRange $childcareTimeRange = null;
 
+    private bool $overnight = false;
+
     public function __construct(
         DateRange $dateRange,
         Status $status,
@@ -69,6 +71,13 @@ final class SubEvent
         return $clone;
     }
 
+    public function withOvernight(bool $overnight): self
+    {
+        $clone = clone $this;
+        $clone->overnight = $overnight;
+        return $clone;
+    }
+
     public function getDateRange(): DateRange
     {
         return $this->dateRange;
@@ -92,5 +101,10 @@ final class SubEvent
     public function getChildcareTimeRange(): ?TimeImmutableRange
     {
         return $this->childcareTimeRange;
+    }
+
+    public function isOvernight(): bool
+    {
+        return $this->overnight;
     }
 }

--- a/src/Model/ValueObject/Calendar/SubEventUpdate.php
+++ b/src/Model/ValueObject/Calendar/SubEventUpdate.php
@@ -18,6 +18,8 @@ final class SubEventUpdate
     private ?BookingInfo $bookingInfo = null;
     private ?TimeImmutableRange $childcareTimeRange = null;
 
+    private ?bool $overnight = null;
+
     public function __construct(int $subEventId)
     {
         $this->subEventId = $subEventId;
@@ -97,6 +99,18 @@ final class SubEventUpdate
     {
         $c = clone $this;
         $c->childcareTimeRange = $childcareTimeRange;
+        return $c;
+    }
+
+    public function getOvernight(): ?bool
+    {
+        return $this->overnight;
+    }
+
+    public function withOvernight(?bool $overnight): self
+    {
+        $c = clone $this;
+        $c->overnight = $overnight;
         return $c;
     }
 }

--- a/src/Model/ValueObject/Calendar/SubEvents.php
+++ b/src/Model/ValueObject/Calendar/SubEvents.php
@@ -52,4 +52,9 @@ class SubEvents extends Collection
     {
         return $this->endDate;
     }
+
+    public function withoutOvernight(): self
+    {
+        return new self(...array_map(fn (SubEvent $se) => $se->withOvernight(false), $this->toArray()));
+    }
 }

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -2454,7 +2454,7 @@ class EventTest extends AggregateRootScenarioTestCase
             new Language('nl'),
             'Zomerkamp',
             new Category(
-                new CategoryID(EventTypeResolver::CAMP_TERM_ID),
+                new CategoryID(EventTypeResolver::CAMP_OR_VACATION_TERM_ID),
                 new CategoryLabel('Kamp of vakantie'),
                 CategoryDomain::eventType()
             ),
@@ -2540,7 +2540,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_sub_events(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_OR_VACATION_TERM_ID);
 
         // Set a single-subEvent calendar first (event is created with PermanentCalendar by default)
         $dateRange = new DateRange(
@@ -2557,7 +2557,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_calendar(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_OR_VACATION_TERM_ID);
 
         $this->event->updateCalendar(
             new SingleSubEventCalendar(
@@ -2569,6 +2569,26 @@ class EventTest extends AggregateRootScenarioTestCase
                 )->withOvernight(true)
             )
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_overnight_on_update_calendar_when_event_has_kamp_of_vakantie_term(): void
+    {
+        $subEventWithOvernight = SubEvent::createAvailable(
+            new DateRange(
+                new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+            )
+        )->withOvernight(true);
+
+        $calendar = new SingleSubEventCalendar($subEventWithOvernight);
+
+        $this->scenario
+            ->given([$this->getKampOrVakantieCreationEvent()])
+            ->when(fn (Event $event) => $event->updateCalendar($calendar))
+            ->then([new CalendarUpdated(self::EVENT_ID, $calendar)]);
     }
 
     /**

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -39,7 +39,6 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
-use CultuurNet\UDB3\Event\EventTypeResolver;
 use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
@@ -2497,7 +2496,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new CalendarUpdated(self::EVENT_ID, new SingleSubEventCalendar($subEventWithOvernight)),
             ])
             ->when(
-                fn(Event $event) => $event->updateSubEvents(
+                fn (Event $event) => $event->updateSubEvents(
                     (new SubEventUpdate(0))->withStatus($unavailable)
                 )
             )
@@ -2569,7 +2568,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 $this->getKampOrVakantieCreationEvent(),
                 new CalendarUpdated(self::EVENT_ID, new SingleSubEventCalendar($subEventWithOvernight)),
             ])
-            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->when(fn (Event $event) => $event->updateType($concertType))
             ->then([
                 new TypeUpdated(self::EVENT_ID, $concertType),
                 new CalendarUpdated(
@@ -2592,7 +2591,7 @@ class EventTest extends AggregateRootScenarioTestCase
 
         $this->scenario
             ->given([$this->getKampOrVakantieCreationEvent()])
-            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->when(fn (Event $event) => $event->updateType($concertType))
             ->then([new TypeUpdated(self::EVENT_ID, $concertType)]);
     }
 
@@ -2627,7 +2626,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new MultipleSubEventsCalendar(new SubEvents($subEvent1, $subEvent2))
                 ),
             ])
-            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->when(fn (Event $event) => $event->updateType($concertType))
             ->then([
                 new TypeUpdated(self::EVENT_ID, $concertType),
                 new CalendarUpdated(

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -39,7 +39,14 @@ use CultuurNet\UDB3\Media\Properties\MIMEType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
+use CultuurNet\UDB3\Event\EventTypeResolver;
+use CultuurNet\UDB3\Event\Events\TypeUpdated;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEventUpdate;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\ClosedDay;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\ClosedDays;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
@@ -2436,6 +2443,201 @@ class EventTest extends AggregateRootScenarioTestCase
             ])
             ->when(fn (Event $event) => $event->updateDeparturePlaces($departurePlaces))
             ->then([new DeparturePlacesUpdated($eventId, $departurePlaces)]);
+    }
+
+    // -------------------------------------------------------------------------
+    // overnight
+    // -------------------------------------------------------------------------
+
+    private const EVENT_ID = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+    private const LOCATION_ID = '322d67b6-e84d-4649-9384-12ecad74eab3';
+
+    private function getKampOrVakantieCreationEvent(): EventCreated
+    {
+        return new EventCreated(
+            self::EVENT_ID,
+            new Language('nl'),
+            'Zomerkamp',
+            new Category(
+                new CategoryID(EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID),
+                new CategoryLabel('Kamp of vakantie'),
+                CategoryDomain::eventType()
+            ),
+            new LocationId(self::LOCATION_ID),
+            new SingleSubEventCalendar(
+                SubEvent::createAvailable(
+                    new DateRange(
+                        new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                        new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_preserves_overnight_on_unrelated_sub_event_updates(): void
+    {
+        $unavailable = new \CultuurNet\UDB3\Model\ValueObject\Calendar\Status(
+            \CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType::Unavailable()
+        );
+
+        $subEventWithOvernight = SubEvent::createAvailable(
+            new DateRange(
+                new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+            )
+        )->withOvernight(true);
+
+        $this->scenario
+            ->given([
+                $this->getKampOrVakantieCreationEvent(),
+                new CalendarUpdated(self::EVENT_ID, new SingleSubEventCalendar($subEventWithOvernight)),
+            ])
+            ->when(
+                fn(Event $event) => $event->updateSubEvents(
+                    (new SubEventUpdate(0))->withStatus($unavailable)
+                )
+            )
+            ->then([
+                new CalendarUpdated(
+                    self::EVENT_ID,
+                    new SingleSubEventCalendar($subEventWithOvernight->withStatus($unavailable))
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_sub_events(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID);
+
+        // Set a single-subEvent calendar first (event is created with PermanentCalendar by default)
+        $dateRange = new DateRange(
+            new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+            new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+        );
+        $this->event->updateCalendar(new SingleSubEventCalendar(SubEvent::createAvailable($dateRange)));
+        $this->event->updateSubEvents((new SubEventUpdate(0))->withOvernight(true));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_calendar(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID);
+
+        $this->event->updateCalendar(
+            new SingleSubEventCalendar(
+                SubEvent::createAvailable(
+                    new DateRange(
+                        new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                        new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+                    )
+                )->withOvernight(true)
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_resets_overnight_on_all_sub_events_when_type_changes_away_from_kamp_of_vakantie(): void
+    {
+        $subEventWithOvernight = SubEvent::createAvailable(
+            new DateRange(
+                new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+            )
+        )->withOvernight(true);
+
+        $concertType = new Category(
+            new CategoryID('0.50.4.0.0'),
+            new CategoryLabel('Concert'),
+            CategoryDomain::eventType()
+        );
+
+        $this->scenario
+            ->given([
+                $this->getKampOrVakantieCreationEvent(),
+                new CalendarUpdated(self::EVENT_ID, new SingleSubEventCalendar($subEventWithOvernight)),
+            ])
+            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->then([
+                new TypeUpdated(self::EVENT_ID, $concertType),
+                new CalendarUpdated(
+                    self::EVENT_ID,
+                    new SingleSubEventCalendar($subEventWithOvernight->withOvernight(false))
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_emit_calendar_updated_when_type_changes_away_from_kamp_of_vakantie_but_no_overnight_is_set(): void
+    {
+        $concertType = new Category(
+            new CategoryID('0.50.4.0.0'),
+            new CategoryLabel('Concert'),
+            CategoryDomain::eventType()
+        );
+
+        $this->scenario
+            ->given([$this->getKampOrVakantieCreationEvent()])
+            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->then([new TypeUpdated(self::EVENT_ID, $concertType)]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_resets_overnight_on_multiple_sub_events_when_type_changes(): void
+    {
+        $dateRange1 = new DateRange(
+            new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+            new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+        );
+        $dateRange2 = new DateRange(
+            new \DateTimeImmutable('2026-08-01T09:00:00+02:00'),
+            new \DateTimeImmutable('2026-08-05T17:00:00+02:00')
+        );
+
+        $subEvent1 = SubEvent::createAvailable($dateRange1)->withOvernight(true);
+        $subEvent2 = SubEvent::createAvailable($dateRange2)->withOvernight(true);
+
+        $concertType = new Category(
+            new CategoryID('0.50.4.0.0'),
+            new CategoryLabel('Concert'),
+            CategoryDomain::eventType()
+        );
+
+        $this->scenario
+            ->given([
+                $this->getKampOrVakantieCreationEvent(),
+                new CalendarUpdated(
+                    self::EVENT_ID,
+                    new MultipleSubEventsCalendar(new SubEvents($subEvent1, $subEvent2))
+                ),
+            ])
+            ->when(fn(Event $event) => $event->updateType($concertType))
+            ->then([
+                new TypeUpdated(self::EVENT_ID, $concertType),
+                new CalendarUpdated(
+                    self::EVENT_ID,
+                    new MultipleSubEventsCalendar(new SubEvents(
+                        $subEvent1->withOvernight(false),
+                        $subEvent2->withOvernight(false)
+                    ))
+                ),
+            ]);
     }
 
     protected function getSample(string $file): string

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -2458,7 +2458,7 @@ class EventTest extends AggregateRootScenarioTestCase
             new Language('nl'),
             'Zomerkamp',
             new Category(
-                new CategoryID(EventTypeResolver::CAMP_UUID),
+                new CategoryID(EventTypeResolver::CAMP_TERM_ID),
                 new CategoryLabel('Kamp of vakantie'),
                 CategoryDomain::eventType()
             ),
@@ -2514,7 +2514,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_sub_events(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID);
 
         // Set a single-subEvent calendar first (event is created with PermanentCalendar by default)
         $dateRange = new DateRange(
@@ -2531,7 +2531,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_calendar(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_TERM_ID);
 
         $this->event->updateCalendar(
             new SingleSubEventCalendar(

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -133,7 +133,7 @@ class EventTest extends AggregateRootScenarioTestCase
     private function getCreationEventWithTheme(): EventCreated
     {
         return new EventCreated(
-            'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
+            self::EVENT_ID,
             new Language('en'),
             'some representative title',
             new Category(new CategoryID('0.50.4.0.0'), new CategoryLabel('Concert'), CategoryDomain::eventType()),
@@ -2447,10 +2447,6 @@ class EventTest extends AggregateRootScenarioTestCase
             ->then([new DeparturePlacesUpdated($eventId, $departurePlaces)]);
     }
 
-    // -------------------------------------------------------------------------
-    // overnight
-    // -------------------------------------------------------------------------
-
     private function getKampOrVakantieCreationEvent(): EventCreated
     {
         return new EventCreated(
@@ -2504,6 +2500,36 @@ class EventTest extends AggregateRootScenarioTestCase
                 new CalendarUpdated(
                     self::EVENT_ID,
                     new SingleSubEventCalendar($subEventWithOvernight->withStatus($unavailable))
+                ),
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_explicitly_set_overnight_to_false_via_update_sub_events(): void
+    {
+        $subEventWithOvernight = SubEvent::createAvailable(
+            new DateRange(
+                new \DateTimeImmutable('2026-07-01T09:00:00+02:00'),
+                new \DateTimeImmutable('2026-07-05T17:00:00+02:00')
+            )
+        )->withOvernight(true);
+
+        $this->scenario
+            ->given([
+                $this->getKampOrVakantieCreationEvent(),
+                new CalendarUpdated(self::EVENT_ID, new SingleSubEventCalendar($subEventWithOvernight)),
+            ])
+            ->when(
+                fn (Event $event) => $event->updateSubEvents(
+                    (new SubEventUpdate(0))->withOvernight(false)
+                )
+            )
+            ->then([
+                new CalendarUpdated(
+                    self::EVENT_ID,
+                    new SingleSubEventCalendar($subEventWithOvernight->withOvernight(false))
                 ),
             ]);
     }

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -94,6 +94,9 @@ class EventTest extends AggregateRootScenarioTestCase
     public const NS_CDBXML_3_2 = 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.2/FINAL';
     public const NS_CDBXML_3_3 = 'http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.3/FINAL';
 
+    private const EVENT_ID = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+    private const LOCATION_ID = '322d67b6-e84d-4649-9384-12ecad74eab3';
+
     protected function getAggregateRootClass(): string
     {
         return Event::class;
@@ -118,11 +121,11 @@ class EventTest extends AggregateRootScenarioTestCase
     private function getCreationEvent(): EventCreated
     {
         return new EventCreated(
-            'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
+            self::EVENT_ID,
             new Language('en'),
             'some representative title',
             new Category(new CategoryID('0.50.4.0.0'), new CategoryLabel('Concert'), CategoryDomain::eventType()),
-            new LocationId('322d67b6-e84d-4649-9384-12ecad74eab3'),
+            new LocationId(self::LOCATION_ID),
             new PermanentCalendar(new OpeningHours())
         );
     }
@@ -2448,9 +2451,6 @@ class EventTest extends AggregateRootScenarioTestCase
     // overnight
     // -------------------------------------------------------------------------
 
-    private const EVENT_ID = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
-    private const LOCATION_ID = '322d67b6-e84d-4649-9384-12ecad74eab3';
-
     private function getKampOrVakantieCreationEvent(): EventCreated
     {
         return new EventCreated(
@@ -2458,7 +2458,7 @@ class EventTest extends AggregateRootScenarioTestCase
             new Language('nl'),
             'Zomerkamp',
             new Category(
-                new CategoryID(EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID),
+                new CategoryID(EventTypeResolver::CAMP_UUID),
                 new CategoryLabel('Kamp of vakantie'),
                 CategoryDomain::eventType()
             ),
@@ -2514,7 +2514,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_sub_events(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID);
 
         // Set a single-subEvent calendar first (event is created with PermanentCalendar by default)
         $dateRange = new DateRange(
@@ -2531,7 +2531,7 @@ class EventTest extends AggregateRootScenarioTestCase
     public function it_throws_when_overnight_is_set_without_kamp_of_vakantie_term_on_update_calendar(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::KAMP_OF_VAKANTIE_TERM_ID);
+        $this->expectExceptionMessage('overnight is only allowed when the event has term ' . EventTypeResolver::CAMP_UUID);
 
         $this->event->updateCalendar(
             new SingleSubEventCalendar(

--- a/tests/Model/ValueObject/Calendar/SubEventTest.php
+++ b/tests/Model/ValueObject/Calendar/SubEventTest.php
@@ -67,4 +67,44 @@ final class SubEventTest extends TestCase
         $this->assertNotSame($this->subEvent, $updated);
         $this->assertNull($this->subEvent->getChildcareTimeRange());
     }
+
+    /**
+     * @test
+     */
+    public function it_is_not_overnight_by_default(): void
+    {
+        $this->assertFalse($this->subEvent->isOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_set_to_overnight(): void
+    {
+        $updated = $this->subEvent->withOvernight(true);
+
+        $this->assertTrue($updated->isOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_clear_overnight(): void
+    {
+        $withOvernight = $this->subEvent->withOvernight(true);
+        $cleared = $withOvernight->withOvernight(false);
+
+        $this->assertFalse($cleared->isOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_new_instance_when_setting_overnight(): void
+    {
+        $updated = $this->subEvent->withOvernight(true);
+
+        $this->assertNotSame($this->subEvent, $updated);
+        $this->assertFalse($this->subEvent->isOvernight());
+    }
 }

--- a/tests/Model/ValueObject/Calendar/SubEventUpdateTest.php
+++ b/tests/Model/ValueObject/Calendar/SubEventUpdateTest.php
@@ -52,4 +52,54 @@ final class SubEventUpdateTest extends TestCase
         $this->assertNotSame($original, $updated);
         $this->assertNull($original->getChildcareTimeRange());
     }
+
+    /**
+     * @test
+     */
+    public function it_has_no_overnight_value_by_default(): void
+    {
+        $this->assertNull((new SubEventUpdate(0))->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_set_overnight_to_true(): void
+    {
+        $update = (new SubEventUpdate(0))->withOvernight(true);
+
+        $this->assertTrue($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_set_overnight_to_false(): void
+    {
+        $update = (new SubEventUpdate(0))->withOvernight(false);
+
+        $this->assertFalse($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_set_overnight_to_null_to_leave_it_unchanged(): void
+    {
+        $update = (new SubEventUpdate(0))->withOvernight(true)->withOvernight(null);
+
+        $this->assertNull($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_new_instance_when_setting_overnight(): void
+    {
+        $original = new SubEventUpdate(0);
+        $updated = $original->withOvernight(true);
+
+        $this->assertNotSame($original, $updated);
+        $this->assertNull($original->getOvernight());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `KAMP_OF_VAKANTIE_TERM_ID = '0.57.0.0.0'` constant to `EventTypeResolver` as the single source of truth for this term id
- Adds `overnight` boolean property to `SubEvent` (`isOvernight()` / `withOvernight(bool)`) and `SubEventUpdate` (`getOvernight(): ?bool` / `withOvernight(?bool)`)
- Enforces domain invariants in `Event`:
  - `updateSubEvents()` preserves the existing overnight value when not explicitly provided in the patch; throws `InvalidArgumentException` if any sub-event ends up with `overnight=true` while the event type is not `KAMP_OF_VAKANTIE_TERM_ID`
  - `updateCalendar()` override performs the same term check before delegating to `parent::updateCalendar()`
  - `updateType()` override resets overnight to `false` on all sub-events and emits `CalendarUpdated` when the type changes away from `KAMP_OF_VAKANTIE_TERM_ID` and at least one sub-event has `overnight=true`

## Test plan

- [ ] `SubEventTest` — default false, withOvernight(true), clear to false, immutability
- [ ] `SubEventUpdateTest` — default null, withOvernight(true/false/null), immutability
- [ ] `EventTest` — overnight preserved on unrelated PATCH, throws without term on updateSubEvents, throws without term on updateCalendar, reset on type change (single + multiple calendars), no CalendarUpdated when no overnight to reset

## Related PRs

- PR 2/3: Write path — deserialization, JSON schema, HTTP validation
- PR 3/3: Read model — normalizer, denormalizer, feature tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ticket https://jira.publiq.be/browse/III-7108