### PR TITLE
III-7108 Overnight serializers (PR 2/3)

### DIFF
--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -228,9 +228,7 @@ final class CalendarDenormalizer implements DenormalizerInterface
             );
         }
 
-        if (isset($subEventData['overnight']) && $subEventData['overnight'] === true) {
-            $subEvent = $subEvent->withOvernight(true);
-        }
+        $subEvent = $subEvent->withOvernight($subEventData['overnight'] ?? false);
 
         return $subEvent;
     }

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -228,6 +228,10 @@ final class CalendarDenormalizer implements DenormalizerInterface
             );
         }
 
+        if (isset($subEventData['overnight']) && $subEventData['overnight'] === true) {
+            $subEvent = $subEvent->withOvernight(true);
+        }
+
         return $subEvent;
     }
 

--- a/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -228,7 +228,9 @@ final class CalendarDenormalizer implements DenormalizerInterface
             );
         }
 
-        $subEvent = $subEvent->withOvernight($subEventData['overnight'] ?? false);
+        if (isset($subEventData['overnight'])) {
+            $subEvent = $subEvent->withOvernight($subEventData['overnight']);
+        }
 
         return $subEvent;
     }

--- a/src/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizer.php
@@ -68,7 +68,7 @@ final class SubEventUpdateDenormalizer implements DenormalizerInterface
             );
         }
 
-        if (array_key_exists('overnight', $data)) {
+        if (isset($data['overnight'])) {
             $subEventUpdate = $subEventUpdate->withOvernight($data['overnight']);
         }
 

--- a/src/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizer.php
+++ b/src/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizer.php
@@ -68,6 +68,10 @@ final class SubEventUpdateDenormalizer implements DenormalizerInterface
             );
         }
 
+        if (array_key_exists('overnight', $data)) {
+            $subEventUpdate = $subEventUpdate->withOvernight($data['overnight']);
+        }
+
         return $subEventUpdate;
     }
 

--- a/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
@@ -337,6 +337,30 @@ final class UpdateSubEventsRequestHandlerTest extends TestCase
                         ),
                 ),
             ],
+            'one_subEvent_with_overnight_true' => [
+                'data' => [
+                    (object)[
+                        'id' => 0,
+                        'overnight' => true,
+                    ],
+                ],
+                'expected_command' => new UpdateSubEvents(
+                    self::EVENT_ID,
+                    (new SubEventUpdate(0))->withOvernight(true)
+                ),
+            ],
+            'one_subEvent_with_overnight_false' => [
+                'data' => [
+                    (object)[
+                        'id' => 0,
+                        'overnight' => false,
+                    ],
+                ],
+                'expected_command' => new UpdateSubEvents(
+                    self::EVENT_ID,
+                    (new SubEventUpdate(0))->withOvernight(false)
+                ),
+            ],
         ];
     }
 
@@ -670,6 +694,28 @@ final class UpdateSubEventsRequestHandlerTest extends TestCase
                 ],
                 'expectedSchemaErrors' => [
                     new SchemaError('/0/childcare/start', 'The data (integer) must match the type: string'),
+                ],
+            ],
+            'one_subEvent_with_overnight_wrong_type_string' => [
+                'data' => [
+                    (object)[
+                        'id' => 0,
+                        'overnight' => 'yes',
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/0/overnight', 'The data (string) must match the type: boolean'),
+                ],
+            ],
+            'one_subEvent_with_overnight_wrong_type_integer' => [
+                'data' => [
+                    (object)[
+                        'id' => 0,
+                        'overnight' => 1,
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/0/overnight', 'The data (integer) must match the type: boolean'),
                 ],
             ],
         ];

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -955,6 +955,29 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                     )
                 ),
             ],
+            'single_with_overnight_false' => [
+                'data' => (object)[
+                    'calendarType' => 'single',
+                    'subEvent' => [
+                        (object)[
+                            'startDate' => '2026-07-01T09:00:00+02:00',
+                            'endDate' => '2026-07-05T17:00:00+02:00',
+                            'overnight' => false,
+                        ],
+                    ],
+                ],
+                'expected_command' => new UpdateCalendar(
+                    self::EVENT_ID,
+                    new SingleSubEventCalendar(
+                        SubEvent::createAvailable(
+                            new DateRange(
+                                DateTimeFactory::fromAtom('2026-07-01T09:00:00+02:00'),
+                                DateTimeFactory::fromAtom('2026-07-05T17:00:00+02:00')
+                            )
+                        )
+                    )
+                ),
+            ],
             'single_with_overnight_true' => [
                 'data' => (object)[
                     'calendarType' => 'single',

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -955,6 +955,64 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                     )
                 ),
             ],
+            'single_with_overnight_true' => [
+                'data' => (object)[
+                    'calendarType' => 'single',
+                    'subEvent' => [
+                        (object)[
+                            'startDate' => '2026-07-01T09:00:00+02:00',
+                            'endDate' => '2026-07-05T17:00:00+02:00',
+                            'overnight' => true,
+                        ],
+                    ],
+                ],
+                'expected_command' => new UpdateCalendar(
+                    self::EVENT_ID,
+                    new SingleSubEventCalendar(
+                        SubEvent::createAvailable(
+                            new DateRange(
+                                DateTimeFactory::fromAtom('2026-07-01T09:00:00+02:00'),
+                                DateTimeFactory::fromAtom('2026-07-05T17:00:00+02:00')
+                            )
+                        )->withOvernight(true)
+                    )
+                ),
+            ],
+            'multiple_with_overnight_on_first_sub_event' => [
+                'data' => (object)[
+                    'calendarType' => 'multiple',
+                    'subEvent' => [
+                        (object)[
+                            'startDate' => '2026-07-01T09:00:00+02:00',
+                            'endDate' => '2026-07-05T17:00:00+02:00',
+                            'overnight' => true,
+                        ],
+                        (object)[
+                            'startDate' => '2026-07-10T09:00:00+02:00',
+                            'endDate' => '2026-07-14T17:00:00+02:00',
+                        ],
+                    ],
+                ],
+                'expected_command' => new UpdateCalendar(
+                    self::EVENT_ID,
+                    new MultipleSubEventsCalendar(
+                        new SubEvents(
+                            SubEvent::createAvailable(
+                                new DateRange(
+                                    DateTimeFactory::fromAtom('2026-07-01T09:00:00+02:00'),
+                                    DateTimeFactory::fromAtom('2026-07-05T17:00:00+02:00')
+                                )
+                            )->withOvernight(true),
+                            SubEvent::createAvailable(
+                                new DateRange(
+                                    DateTimeFactory::fromAtom('2026-07-10T09:00:00+02:00'),
+                                    DateTimeFactory::fromAtom('2026-07-14T17:00:00+02:00')
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
         ];
     }
 
@@ -1800,6 +1858,36 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                 ],
                 'expectedSchemaErrors' => [
                     new SchemaError('/openingHoursAdjustedDays/1/startDate', 'adjusted opening hours entries must not overlap'),
+                ],
+            ],
+            'single_overnight_wrong_type_string' => [
+                'data' => (object)[
+                    'calendarType' => 'single',
+                    'subEvent' => [
+                        (object)[
+                            'startDate' => '2026-07-01T09:00:00+02:00',
+                            'endDate' => '2026-07-05T17:00:00+02:00',
+                            'overnight' => 'yes',
+                        ],
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/subEvent/0/overnight', 'The data (string) must match the type: boolean'),
+                ],
+            ],
+            'single_overnight_wrong_type_integer' => [
+                'data' => (object)[
+                    'calendarType' => 'single',
+                    'subEvent' => [
+                        (object)[
+                            'startDate' => '2026-07-01T09:00:00+02:00',
+                            'endDate' => '2026-07-05T17:00:00+02:00',
+                            'overnight' => 1,
+                        ],
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError('/subEvent/0/overnight', 'The data (integer) must match the type: boolean'),
                 ],
             ],
         ];

--- a/tests/Model/Serializer/ValueObject/Calendar/CalendarDenormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Calendar/CalendarDenormalizerTest.php
@@ -873,4 +873,75 @@ final class CalendarDenormalizerTest extends TestCase
         $this->assertEquals('2024-12-25', $adjustedDays[0]->getStartDate()->format('Y-m-d'));
         $this->assertEquals('2024-12-31', $adjustedDays[1]->getStartDate()->format('Y-m-d'));
     }
+
+    /**
+     * @test
+     */
+    public function it_denormalizes_a_single_calendar_with_overnight_true(): void
+    {
+        $data = [
+            'calendarType' => 'single',
+            'subEvent' => [
+                [
+                    'startDate' => '2026-07-01T09:00:00+02:00',
+                    'endDate' => '2026-07-05T17:00:00+02:00',
+                    'overnight' => true,
+                ],
+            ],
+        ];
+
+        $result = $this->denormalizer->denormalize($data, Calendar::class);
+
+        $this->assertInstanceOf(SingleSubEventCalendar::class, $result);
+        $this->assertTrue($result->getSubEvents()->toArray()[0]->isOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_set_overnight_when_key_is_absent(): void
+    {
+        $data = [
+            'calendarType' => 'single',
+            'subEvent' => [
+                [
+                    'startDate' => '2026-07-01T09:00:00+02:00',
+                    'endDate' => '2026-07-05T17:00:00+02:00',
+                ],
+            ],
+        ];
+
+        $result = $this->denormalizer->denormalize($data, Calendar::class);
+
+        $this->assertInstanceOf(SingleSubEventCalendar::class, $result);
+        $this->assertFalse($result->getSubEvents()->toArray()[0]->isOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_denormalizes_a_multiple_calendar_with_overnight_on_one_sub_event(): void
+    {
+        $data = [
+            'calendarType' => 'multiple',
+            'subEvent' => [
+                [
+                    'startDate' => '2026-07-01T09:00:00+02:00',
+                    'endDate' => '2026-07-05T17:00:00+02:00',
+                    'overnight' => true,
+                ],
+                [
+                    'startDate' => '2026-07-10T09:00:00+02:00',
+                    'endDate' => '2026-07-14T17:00:00+02:00',
+                ],
+            ],
+        ];
+
+        $result = $this->denormalizer->denormalize($data, Calendar::class);
+
+        $this->assertInstanceOf(MultipleSubEventsCalendar::class, $result);
+        $subEvents = $result->getSubEvents()->toArray();
+        $this->assertTrue($subEvents[0]->isOvernight());
+        $this->assertFalse($subEvents[1]->isOvernight());
+    }
 }

--- a/tests/Model/Serializer/ValueObject/Calendar/CalendarDenormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Calendar/CalendarDenormalizerTest.php
@@ -944,4 +944,25 @@ final class CalendarDenormalizerTest extends TestCase
         $this->assertTrue($subEvents[0]->isOvernight());
         $this->assertFalse($subEvents[1]->isOvernight());
     }
+
+    /**
+     * @test
+     */
+    public function it_does_not_set_overnight_when_key_is_explicitly_false(): void
+    {
+        $data = [
+            'calendarType' => 'single',
+            'subEvent' => [
+                [
+                    'startDate' => '2026-07-01T09:00:00+02:00',
+                    'endDate' => '2026-07-05T17:00:00+02:00',
+                    'overnight' => false,
+                ],
+            ],
+        ];
+
+        $result = $this->denormalizer->denormalize($data, Calendar::class);
+
+        $this->assertFalse($result->getSubEvents()->toArray()[0]->isOvernight());
+    }
 }

--- a/tests/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Calendar/SubEventUpdateDenormalizerTest.php
@@ -101,6 +101,36 @@ final class SubEventUpdateDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_set_overnight_when_key_is_absent(): void
+    {
+        $update = $this->denormalizer->denormalize(['id' => 0], SubEventUpdate::class);
+
+        $this->assertNull($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_overnight_to_true(): void
+    {
+        $update = $this->denormalizer->denormalize(['id' => 0, 'overnight' => true], SubEventUpdate::class);
+
+        $this->assertTrue($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_overnight_to_false(): void
+    {
+        $update = $this->denormalizer->denormalize(['id' => 0, 'overnight' => false], SubEventUpdate::class);
+
+        $this->assertFalse($update->getOvernight());
+    }
+
+    /**
+     * @test
+     */
     public function it_supports_denormalization_of_sub_event_update(): void
     {
         $this->assertTrue($this->denormalizer->supportsDenormalization([], SubEventUpdate::class));


### PR DESCRIPTION
## Summary

- Deserialize `overnight` from `PUT /events/{id}/calendar` (via `CalendarDenormalizer`) and `PATCH /events/{id}/subEvents` (via `SubEventUpdateDenormalizer`)

# Ticket 
https://jira.publiq.be/browse/III-7108


🤖 Generated with [Claude Code](https://claude.com/claude-code)