### PR TITLE
III-7156 Fix terms caching

### DIFF
--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -16,33 +16,13 @@ use Psr\Log\LoggerInterface;
 
 final class JsonTaxonomyApiClient implements TaxonomyApiClient
 {
-    private array $terms;
+    private ?array $terms = null;
 
     public function __construct(
         private readonly ClientInterface $client,
         private readonly string $termsEndpoint,
         private readonly LoggerInterface $logger
     ) {
-        $request = new Request(
-            'GET',
-            $this->termsEndpoint,
-        );
-
-        $response = $this->client->sendRequest($request);
-        if ($response->getStatusCode() !== 200) {
-            $this->logger->error('Taxonomy Api returned non-200 status code', [
-                'status_code' => $response->getStatusCode(),
-                'body' => $response->getBody()->getContents(),
-            ]);
-            throw new TaxonomyApiProblem('Taxonomy Api returned non-200 status code.');
-        }
-        $contents = $response->getBody()->getContents();
-        if (empty($contents)) {
-            $this->logger->error('Taxonomy Api returned no terms');
-            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
-        }
-        $contentsAsJson = Json::decodeAssociatively($contents);
-        $this->terms = $contentsAsJson['terms'];
     }
 
     public function getPlaceTypes(): Categories
@@ -72,13 +52,36 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
 
     public function getNativeTerms(): array
     {
-        return $this->terms;
+        return $this->fetchTerms();
+    }
+
+    private function fetchTerms(): array
+    {
+        if ($this->terms !== null) {
+            return $this->terms;
+        }
+
+        $response = $this->client->sendRequest(new Request('GET', $this->termsEndpoint));
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->error('Taxonomy Api returned non-200 status code', [
+                'status_code' => $response->getStatusCode(),
+                'body' => $response->getBody()->getContents(),
+            ]);
+            throw new TaxonomyApiProblem('Taxonomy Api returned non-200 status code.');
+        }
+        $contents = $response->getBody()->getContents();
+        if (empty($contents)) {
+            $this->logger->error('Taxonomy Api returned no terms');
+            throw new TaxonomyApiProblem('Taxonomy Api returned no terms.');
+        }
+        $contentsAsJson = Json::decodeAssociatively($contents);
+        return $this->terms = $contentsAsJson['terms'];
     }
 
     private function getTermsByDomainAndScope(CategoryDomain $domain, string $scope): Categories
     {
         $termsByDomainAndScope  = [];
-        foreach ($this->terms as $term) {
+        foreach ($this->fetchTerms() as $term) {
             if ($term['domain'] === $domain->toString() && in_array($scope, $term['scope'])) {
                 $termsByDomainAndScope[] = new Category(new CategoryID($term['id']), new CategoryLabel($term['name']['nl']), $domain);
             }

--- a/src/Taxonomy/JsonTaxonomyApiClient.php
+++ b/src/Taxonomy/JsonTaxonomyApiClient.php
@@ -52,11 +52,6 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
 
     public function getNativeTerms(): array
     {
-        return $this->fetchTerms();
-    }
-
-    private function fetchTerms(): array
-    {
         if ($this->terms !== null) {
             return $this->terms;
         }
@@ -81,7 +76,7 @@ final class JsonTaxonomyApiClient implements TaxonomyApiClient
     private function getTermsByDomainAndScope(CategoryDomain $domain, string $scope): Categories
     {
         $termsByDomainAndScope  = [];
-        foreach ($this->fetchTerms() as $term) {
+        foreach ($this->getNativeTerms() as $term) {
             if ($term['domain'] === $domain->toString() && in_array($scope, $term['scope'])) {
                 $termsByDomainAndScope[] = new Category(new CategoryID($term['id']), new CategoryLabel($term['name']['nl']), $domain);
             }

--- a/tests/Taxonomy/CachedTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/CachedTaxonomyApiClientTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Taxonomy;
 
+use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Categories;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\Category;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryDomain;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryID;
 use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryLabel;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 final class CachedTaxonomyApiClientTest extends TestCase
@@ -235,5 +239,30 @@ final class CachedTaxonomyApiClientTest extends TestCase
             new JsonTaxonomyApiClient($httpClient, 'https://taxonomy.example.com/terms', new NullLogger()),
             new ArrayAdapter()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_calls_the_taxonomy_api_only_once_across_many_getter_calls(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn(
+                new Response(200, [], Json::encode(['terms' => [
+                    ['id' => '0.50.4.0.0', 'domain' => 'eventtype', 'name' => ['nl' => 'Concert'], 'scope' => ['events']],
+                ]]))
+            );
+
+        $client = new CachedTaxonomyApiClient(
+            new JsonTaxonomyApiClient($httpClient, 'https://taxonomy.example.com/terms', new NullLogger()),
+            new ArrayAdapter()
+        );
+
+        $client->getEventTypes();
+        $client->getEventThemes();
+        $client->getPlaceTypes();
+        $client->getNativeTerms();
     }
 }

--- a/tests/Taxonomy/CachedTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/CachedTaxonomyApiClientTest.php
@@ -217,4 +217,23 @@ final class CachedTaxonomyApiClientTest extends TestCase
         $this->assertEquals($placeTypes, $placeTypesResult2);
         $this->assertEquals($eventTypes, $eventTypesResult2);
     }
+
+    /**
+     * @test
+     *
+     * @bugfix https://jira.publiq.be/browse/III-7156
+     * Previously JsonTaxonomyApiClient performed the HTTP fetch in its constructor,
+     * so wrapping it in CachedTaxonomyApiClient never short-circuited the call.
+     * This test wires both real classes together and asserts no HTTP call happens until a getter is actually invoked.
+     */
+    public function it_does_not_call_the_taxonomy_api_when_no_getter_is_invoked(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->never())->method('sendRequest');
+
+        new CachedTaxonomyApiClient(
+            new JsonTaxonomyApiClient($httpClient, 'https://taxonomy.example.com/terms', new NullLogger()),
+            new ArrayAdapter()
+        );
+    }
 }

--- a/tests/Taxonomy/JsonTaxonomyApiClientTest.php
+++ b/tests/Taxonomy/JsonTaxonomyApiClientTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 final class JsonTaxonomyApiClientTest extends TestCase
@@ -37,29 +38,46 @@ final class JsonTaxonomyApiClientTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_api_returns_non_200_status(): void
+    public function it_throws_and_logs_when_api_returns_non_200_status(): void
     {
         $this->httpClient->expects($this->once())
                    ->method('sendRequest')
-                   ->willReturn(new Response(503));
+                   ->willReturn(new Response(503, [], 'upstream unavailable'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'Taxonomy Api returned non-200 status code',
+                ['status_code' => 503, 'body' => 'upstream unavailable']
+            );
+
+        $client = new JsonTaxonomyApiClient($this->httpClient, 'https://taxonomy.example.com/terms', $logger);
 
         $this->expectException(TaxonomyApiProblem::class);
 
-        new JsonTaxonomyApiClient($this->httpClient, 'https://taxonomy.example.com/terms', new NullLogger());
+        $client->getNativeTerms();
     }
 
     /**
      * @test
      */
-    public function it_throws_when_api_returns_empty_body(): void
+    public function it_throws_and_logs_when_api_returns_empty_body(): void
     {
         $this->httpClient->expects($this->once())
                    ->method('sendRequest')
                    ->willReturn(new Response(200, [], ''));
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('Taxonomy Api returned no terms');
+
+        $client = new JsonTaxonomyApiClient($this->httpClient, 'https://taxonomy.example.com/terms', $logger);
+
         $this->expectException(TaxonomyApiProblem::class);
 
-        new JsonTaxonomyApiClient($this->httpClient, 'https://taxonomy.example.com/terms', new NullLogger());
+        $client->getNativeTerms();
     }
 
     /**


### PR DESCRIPTION
### Added
- Added regression test `it_does_not_call_the_taxonomy_api_when_no_getter_is_invoked`

### Changed
- Refactor the actual terms HTTP call out of the constructor into `fetchTerms`
- Improved existing tests

---

Ticket: https://jira.uitdatabank.be/browse/III-7156
