### PR TITLE
ChildcareTimeInvalid implements ConvertsToApiProblem

### DIFF
--- a/src/Event/ChildcareTimeInvalid.php
+++ b/src/Event/ChildcareTimeInvalid.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event;
 
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\ConvertsToApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use InvalidArgumentException;
 
-class ChildcareTimeInvalid extends InvalidArgumentException
+class ChildcareTimeInvalid extends InvalidArgumentException implements ConvertsToApiProblem
 {
     private int $subEventIndex;
     private string $reason;
@@ -36,5 +39,12 @@ class ChildcareTimeInvalid extends InvalidArgumentException
     public function getReason(): string
     {
         return $this->reason;
+    }
+
+    public function toApiProblem(): ApiProblem
+    {
+        $field = str_contains($this->reason, 'start') ? 'start' : 'end';
+        $pointer = '/' . $this->subEventIndex . '/childcare/' . $field;
+        return ApiProblem::bodyInvalidData(new SchemaError($pointer, $this->getMessage()));
     }
 }

--- a/src/Http/Event/UpdateSubEventsRequestHandler.php
+++ b/src/Http/Event/UpdateSubEventsRequestHandler.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace CultuurNet\UDB3\Http\Event;
 
 use Broadway\CommandHandling\CommandBus;
-use CultuurNet\UDB3\Event\ChildcareTimeInvalid;
 use CultuurNet\UDB3\Event\Commands\UpdateSubEvents;
-use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
-use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
 use CultuurNet\UDB3\Http\Request\Body\DenormalizingRequestBodyParser;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaLocator;
 use CultuurNet\UDB3\Http\Request\Body\JsonSchemaValidatingRequestBodyParser;
@@ -18,7 +15,6 @@ use CultuurNet\UDB3\Http\Request\RouteParameters;
 use CultuurNet\UDB3\Http\Response\NoContentResponse;
 use CultuurNet\UDB3\Model\Serializer\ValueObject\Calendar\SubEventUpdatesDenormalizer;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEventUpdates;
-use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -49,16 +45,7 @@ class UpdateSubEventsRequestHandler implements RequestHandlerInterface
         /** @var SubEventUpdates $updates */
         $updates = $this->updateSubEventsParser->parse($request)->getParsedBody();
 
-        try {
-            $this->commandBus->dispatch(new UpdateSubEvents($eventId, ...$updates));
-        } catch (ChildcareTimeInvalid $exception) {
-            // Map domain exception to HTTP error format
-            $field = str_contains($exception->getReason(), 'start') ? 'start' : 'end';
-            $pointer = '/' . $exception->getSubEventIndex() . '/childcare/' . $field;
-            throw ApiProblem::bodyInvalidData(new SchemaError($pointer, $exception->getMessage()));
-        } catch (InvalidArgumentException $exception) {
-            throw ApiProblem::bodyInvalidDataWithDetail($exception->getMessage());
-        }
+        $this->commandBus->dispatch(new UpdateSubEvents($eventId, ...$updates));
 
         return new NoContentResponse();
     }


### PR DESCRIPTION
## Summary

- `ChildcareTimeInvalid` now implements `ConvertsToApiProblem`, moving the JSON pointer logic (`/index/childcare/start|end`) into `toApiProblem()` on the exception itself
- Removed the manual `catch (ChildcareTimeInvalid)` and the broad `catch (InvalidArgumentException)` from `UpdateSubEventsRequestHandler` — `ApiProblemFactory` handles both automatically
- The exception holds all the context it needs (`subEventIndex`, `reason`), making the request handler free of domain-exception catch blocks, consistent with the pattern established for `OvernightNotAllowed` and `AttendanceModeNotSupported`

## Test plan

- [ ] Patch a sub-event with an invalid childcare start time → expect 400 with pointer `/index/childcare/start`
- [ ] Patch a sub-event with an invalid childcare end time → expect 400 with pointer `/index/childcare/end`
- [ ] Run `make ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)