### PR TITLE
III-7160 Revert plural URLs for event and place ID

### DIFF
--- a/app/Event/EventServiceProvider.php
+++ b/app/Event/EventServiceProvider.php
@@ -34,7 +34,7 @@ final class EventServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'event_iri_generator',
             fn () => new CallableIriGenerator(
-                fn ($cdbid) => $container->get('config')['url'] . '/events/' . $cdbid
+                fn ($cdbid) => $container->get('config')['url'] . '/event/' . $cdbid
             )
         );
 

--- a/app/Place/PlaceServiceProvider.php
+++ b/app/Place/PlaceServiceProvider.php
@@ -43,7 +43,7 @@ final class PlaceServiceProvider extends AbstractServiceProvider
         $container->addShared(
             'place_iri_generator',
             fn () => new CallableIriGenerator(
-                fn ($cdbid) => $container->get('config')['url'] . '/places/' . $cdbid
+                fn ($cdbid) => $container->get('config')['url'] . '/place/' . $cdbid
             )
         );
 

--- a/features/Steps/ResponseSteps.php
+++ b/features/Steps/ResponseSteps.php
@@ -288,7 +288,7 @@ trait ResponseSteps
     public function theJsonResponseAtIsAnOnlineLocation(string $jsonPath): void
     {
         assertEquals(
-            $this->requestState->getBaseUrl() . '/places/' . Uuid::NIL,
+            $this->requestState->getBaseUrl() . '/place/' . Uuid::NIL,
             $this->responseState->getValueOnPath($jsonPath)
         );
     }

--- a/features/event/update.feature
+++ b/features/event/update.feature
@@ -74,7 +74,7 @@ Feature: Test the UDB3 events API
     And the JSON response at "name/nl" should be "Updated title"
     And the JSON response at "calendarType" should be "permanent"
     And the JSON response at "terms/0/id" should be "0.17.0.0.0"
-    And the JSON response at "location/@id" should be "%{baseUrl}/places/%{placeId}"
+    And the JSON response at "location/@id" should be "%{baseUrl}/place/%{placeId}"
 
   Scenario: update booking availability single calendar type
     Given I set the JSON request payload from "places/place.json"

--- a/features/ownership/permission.feature
+++ b/features/ownership/permission.feature
@@ -103,7 +103,7 @@ Feature: Test permissions based on ownership
     And I keep the value of the JSON response at "url" as "organizerUrl"
     And I wait for the organizer with url "/organizers/%{organizerId}" to be indexed
     And I create a place from "places/place-with-organizer.json" and save the "id" as "placeId"
-    And I wait for the place with url "/places/%{placeId}" to be indexed
+    And I wait for the place with url "/place/%{placeId}" to be indexed
     And I am authorized as JWT provider user "invoerder_ownerships"
     And I set the JSON request payload to:
     """

--- a/features/place/duplicate.feature
+++ b/features/place/duplicate.feature
@@ -26,7 +26,7 @@ Feature: Test creating places
       "title": "Duplicate place",
       "status": 409,
       "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-      "duplicatePlaceUri": "%{baseUrl}/places/%{originalPlaceId}"
+      "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
     }
     """
 
@@ -42,6 +42,6 @@ Feature: Test creating places
       "title": "Duplicate place",
       "status": 409,
       "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
-      "duplicatePlaceUri": "%{baseUrl}/places/%{originalPlaceId}"
+      "duplicatePlaceUri": "%{baseUrl}/place/%{originalPlaceId}"
     }
     """

--- a/features/search/boosting.feature
+++ b/features/search/boosting.feature
@@ -48,11 +48,11 @@ Feature: Test the Search API v3 boosting
     """
     [
       {
-        "@id": "http://io.uitdatabank.local:80/places/%{boostedPlace}",
+        "@id": "http://io.uitdatabank.local:80/place/%{boostedPlace}",
         "@type": "Place"
       },
       {
-        "@id": "http://io.uitdatabank.local:80/places/%{placeId}",
+        "@id": "http://io.uitdatabank.local:80/place/%{placeId}",
         "@type": "Place"
 
       }
@@ -66,11 +66,11 @@ Feature: Test the Search API v3 boosting
     """
     [
       {
-        "@id": "http://io.uitdatabank.local:80/events/%{boostedEvent}",
+        "@id": "http://io.uitdatabank.local:80/event/%{boostedEvent}",
         "@type": "Event"
       },
       {
-        "@id": "http://io.uitdatabank.local:80/events/%{nonBoostedevent}",
+        "@id": "http://io.uitdatabank.local:80/event/%{nonBoostedevent}",
         "@type": "Event"
 
       }
@@ -108,12 +108,12 @@ Feature: Test the Search API v3 boosting
     """
     [
       {
-        "@id": "http://io.uitdatabank.local:80/places/%{placeId}",
+        "@id": "http://io.uitdatabank.local:80/place/%{placeId}",
         "@type": "Place"
 
       },
       {
-        "@id": "http://io.uitdatabank.local:80/places/%{boostedPlace}",
+        "@id": "http://io.uitdatabank.local:80/place/%{boostedPlace}",
         "@type": "Place"
       }
     ]
@@ -126,12 +126,12 @@ Feature: Test the Search API v3 boosting
     """
     [
       {
-        "@id": "http://io.uitdatabank.local:80/events/%{nonBoostedevent}",
+        "@id": "http://io.uitdatabank.local:80/event/%{nonBoostedevent}",
         "@type": "Event"
 
       },
       {
-        "@id": "http://io.uitdatabank.local:80/events/%{boostedEvent}",
+        "@id": "http://io.uitdatabank.local:80/event/%{boostedEvent}",
         "@type": "Event"
       }
     ]

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -42,7 +42,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         $document = $this->removeMainImageWhenMediaObjectIsEmpty($document);
         $document = $this->removeActorType($document);
         $document = $this->removeBookingInfoWhenEmpty($document);
-        $document = $this->fixSingularId($document);
+        $document = $this->fixPluralId($document);
         return $this->fixDuplicateLabelVisibility($document);
     }
 
@@ -366,16 +366,16 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         );
     }
 
-    private function fixSingularId(JsonDocument $jsonDocument): JsonDocument
+    private function fixPluralId(JsonDocument $jsonDocument): JsonDocument
     {
         return $jsonDocument->applyAssoc(
             function (array $json) {
                 if (isset($json['@id']) && is_string($json['@id'])) {
-                    $json['@id'] = $this->pluralizeUrl($json['@id']);
+                    $json['@id'] = $this->singularizeUrl($json['@id']);
                 }
 
                 if (isset($json['location']['@id']) && is_string($json['location']['@id'])) {
-                    $json['location']['@id'] = $this->pluralizeUrl($json['location']['@id']);
+                    $json['location']['@id'] = $this->singularizeUrl($json['location']['@id']);
                 }
 
                 return $json;
@@ -383,8 +383,8 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         );
     }
 
-    private function pluralizeUrl(string $url): string
+    private function singularizeUrl(string $url): string
     {
-        return str_replace(['/event/', '/place/'], ['/events/', '/places/'], $url);
+        return str_replace(['/events/', '/places/'], ['/event/', '/place/'], $url);
     }
 }

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -612,7 +612,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                         ],
                     ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'mainLanguage' => 'nl',
                 'name' => [
                     'nl' => 'Kopieertest',
@@ -634,7 +634,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 ],
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'mainLanguage' => 'nl',
                 'name' => [
                     'fr' => 'Kopieertest',
@@ -656,7 +656,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
                 ],
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/events/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
+                '@id' => 'https://io.uitdatabank.dev/event/5ece8d77-48dd-402d-9c5e-e64936fb87f5',
                 'name' => [
                     'fr' => 'Test de copie',
                 ],
@@ -814,34 +814,34 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_fixes_singular_event_id_to_plural(): void
+    public function it_fixes_plural_event_id_to_singular(): void
     {
         $this
             ->given([
-                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
             ]);
     }
 
     /**
      * @test
      */
-    public function it_fixes_singular_location_id_to_plural(): void
+    public function it_fixes_plural_location_id_to_singular(): void
     {
         $placeId = '1a2b3c4d-5e6f-7890-abcd-ef1234567890';
         $this
             ->given([
-                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
                 'location' => [
-                    '@id' => 'https://io.uitdatabank.dev/place/' . $placeId,
+                    '@id' => 'https://io.uitdatabank.dev/places/' . $placeId,
                     '@type' => 'Place',
                 ],
             ])
             ->assertReturnedDocumentContains([
                 'location' => [
-                    '@id' => 'https://io.uitdatabank.dev/places/' . $placeId,
+                    '@id' => 'https://io.uitdatabank.dev/place/' . $placeId,
                     '@type' => 'Place',
                     'status' => [
                         'type' => 'Available',
@@ -856,7 +856,7 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_fixes_singular_place_id_to_plural(): void
+    public function it_fixes_plural_place_id_to_singular(): void
     {
         $this->repository = new PropertyPolyfillOfferRepository(
             new InMemoryDocumentRepository(),
@@ -866,24 +866,24 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
 
         $this
             ->given([
-                '@id' => 'https://io.uitdatabank.dev/place/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/places/' . self::DOCUMENT_ID,
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/places/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/place/' . self::DOCUMENT_ID,
             ]);
     }
 
     /**
      * @test
      */
-    public function it_does_not_change_already_plural_id(): void
+    public function it_does_not_change_already_singular_id(): void
     {
         $this
             ->given([
-                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
             ])
             ->assertReturnedDocumentContains([
-                '@id' => 'https://io.uitdatabank.dev/events/' . self::DOCUMENT_ID,
+                '@id' => 'https://io.uitdatabank.dev/event/' . self::DOCUMENT_ID,
             ]);
     }
 


### PR DESCRIPTION
### Changed
- Reverted event and place IRI generators to always return singular
- Changed polyfill from `fixSingularId` to `fixPluralId`

---

Ticket: https://jira.uitdatabank.be/browse/III-7160
