### PR TITLE
[Low prio] Replace abandoned mathiasverraes/money with moneyphp/money

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "league/uri": "^6.3",
     "league/uri-components": "^2.4",
     "mailjet/mailjet-apiv3-php": "^1.6",
-    "mathiasverraes/money": "^v1.3.0",
+    "moneyphp/money": "^4.0",
     "monolog/monolog": "~1.11",
     "opis/json-schema": "^2.1",
     "php-amqplib/php-amqplib": "^3.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e40e7c536212fa26f7e5e65d6e1f4d26",
+    "content-hash": "d642826c512eff585658ef9b58be4ddd",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4005,39 +4005,61 @@
             "time": "2022-12-02T22:17:43+00:00"
         },
         {
-            "name": "mathiasverraes/money",
-            "version": "v1.3.0",
+            "name": "moneyphp/money",
+            "version": "v4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moneyphp/money.git",
-                "reference": "1926c54143da8eec322ae4985014cd73a98b0792"
+                "reference": "d49ee625c6ba79b9d7a228ce153b02fc1032152b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moneyphp/money/zipball/1926c54143da8eec322ae4985014cd73a98b0792",
-                "reference": "1926c54143da8eec322ae4985014cd73a98b0792",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/d49ee625c6ba79b9d7a228ce153b02fc1032152b",
+                "reference": "d49ee625c6ba79b9d7a228ce153b02fc1032152b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "ext-bcmath": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*"
+                "cache/taggable-cache": "^1.1.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/exchanger": "^2.8.1",
+                "florianv/swap": "^4.3.0",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
+                "phpbench/phpbench": "^1.2.5",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1.9",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.9",
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "ticketswap/phpstan-error-formatter": "^1.1"
             },
             "suggest": {
-                "Sylius/SyliusMoneyBundle": "Sylius' Symfony2 integration with Money library",
-                "TheBigBrainsCompany/TbbcMoneyBundle": "Very complete Symfony2 bundle with support for Twig, Doctrine, Forms, ...",
-                "pink-tie/money-bundle": "Pink-Tie's Symfony2 integration with Money library"
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/exchanger": "Exchange rates library for PHP",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Money": "lib"
+                "psr-4": {
+                    "Money\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4047,22 +4069,30 @@
             "authors": [
                 {
                     "name": "Mathias Verraes",
-                    "email": "mathias@verraes.net"
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
                 }
             ],
             "description": "PHP implementation of Fowler's Money pattern",
-            "homepage": "http://verraes.net/2011/04/fowler-money-pattern-in-php/",
+            "homepage": "http://moneyphp.org",
             "keywords": [
-                "Generic Sub-domain",
                 "Value Object",
-                "money"
+                "money",
+                "vo"
             ],
             "support": {
                 "issues": "https://github.com/moneyphp/money/issues",
-                "source": "https://github.com/moneyphp/money/tree/v1.3.0"
+                "source": "https://github.com/moneyphp/money/tree/v4.9.0"
             },
-            "abandoned": "moneyphp/money",
-            "time": "2016-01-16T22:03:46+00:00"
+            "time": "2026-05-04T20:23:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -6150,12 +6180,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "3c4b1ec0c463250972d04c85cb64e5c669d08a7d"
+                "reference": "4df3bd56d2ef1f97f535becc9bd8c8fb8af1844d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/3c4b1ec0c463250972d04c85cb64e5c669d08a7d",
-                "reference": "3c4b1ec0c463250972d04c85cb64e5c669d08a7d",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/4df3bd56d2ef1f97f535becc9bd8c8fb8af1844d",
+                "reference": "4df3bd56d2ef1f97f535becc9bd8c8fb8af1844d",
                 "shasum": ""
             },
             "default-branch": true,
@@ -6173,9 +6203,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-7127-birthyear"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2026-05-06T06:51:06+00:00"
+            "time": "2026-05-07T13:48:14+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -12843,6 +12873,6 @@
         "ext-tidy": "*",
         "ext-xmlreader": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
+++ b/src/Event/ReadModel/RDF/EventJsonToTurtleConverter.php
@@ -559,7 +559,7 @@ final class EventJsonToTurtleConverter implements JsonToTurtleConverter
         $monetaryAmountResource = $this->rdfResourceFactory->create($resource, self::TYPE_MONETARY_AMOUNT, (new MoneyNormalizer())->normalize($tariff->getPrice()));
         $monetaryAmountResource->set(
             self::PROPERTY_CURRENCY,
-            new Literal($tariff->getPrice()->getCurrency()->getName(), null)
+            new Literal($tariff->getPrice()->getCurrency()->getCode(), null)
         );
         $monetaryAmountResource->set(
             self::PROPERTY_VALUE,

--- a/src/Kinepolis/ValueObject/ParsedPriceForATheater.php
+++ b/src/Kinepolis/ValueObject/ParsedPriceForATheater.php
@@ -47,7 +47,7 @@ final class ParsedPriceForATheater
                 new Language('nl'),
                 new TariffName('Basistarief')
             ),
-            new Money($basePrice, new Currency('EUR'))
+            new Money((string)$basePrice, new Currency('EUR'))
         );
     }
 
@@ -65,14 +65,14 @@ final class ParsedPriceForATheater
                     new Language('nl'),
                     new TariffName('Kinepolis Student Card')
                 ),
-                new Money($studentPrice, new Currency('EUR'))
+                new Money((string)$studentPrice, new Currency('EUR'))
             ),
             new Tariff(
                 new TranslatedTariffName(
                     new Language('nl'),
                     new TariffName('Kortingstarief')
                 ),
-                new Money($discountPrice, new Currency('EUR'))
+                new Money((string)$discountPrice, new Currency('EUR'))
             ),
         );
     }

--- a/src/Model/Serializer/ValueObject/Price/MoneyNormalizer.php
+++ b/src/Model/Serializer/ValueObject/Price/MoneyNormalizer.php
@@ -17,8 +17,8 @@ class MoneyNormalizer implements NormalizerInterface
         }
 
         return [
-            'amount' => $object->getAmount(),
-            'currency' => $object->getCurrency()->getName(),
+            'amount' => (int) $object->getAmount(),
+            'currency' => $object->getCurrency()->getCode(),
         ];
     }
 

--- a/src/Model/ValueObject/Price/PriceInfo.php
+++ b/src/Model/ValueObject/Price/PriceInfo.php
@@ -64,8 +64,8 @@ class PriceInfo
     {
         $serialized = [
             'base' => [
-                'price' => $this->basePrice->getPrice()->getAmount(),
-                'currency' => $this->basePrice->getPrice()->getCurrency()->getName(),
+                'price' => (int) $this->basePrice->getPrice()->getAmount(),
+                'currency' => $this->basePrice->getPrice()->getCurrency()->getCode(),
                 'groupPrice' => $this->basePrice->isGroupPrice(),
             ],
             'tariffs' => [],
@@ -73,8 +73,8 @@ class PriceInfo
         ];
 
         $normalize = fn (Tariff $tariff): array => [
-            'price' => $tariff->getPrice()->getAmount(),
-            'currency' => $tariff->getPrice()->getCurrency()->getName(),
+            'price' => (int) $tariff->getPrice()->getAmount(),
+            'currency' => $tariff->getPrice()->getCurrency()->getCode(),
             'name' => (new TranslatedTariffNameNormalizer())->normalize($tariff->getName()),
             'groupPrice' => $tariff->isGroupPrice(),
         ];

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -17,7 +17,7 @@ final class MoneyFactory
         Currency $currency
     ): Money {
         self::guard($price);
-        return new Money((int) round(($price*100)), $currency);
+        return new Money((string)((int) round(($price*100))), $currency);
     }
 
     /**
@@ -28,7 +28,7 @@ final class MoneyFactory
         Currency $currency
     ): Money {
         self::guard($price);
-        return new Money((int) $price, $currency);
+        return new Money((string)((int) $price), $currency);
     }
 
     /**

--- a/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
+++ b/src/Offer/ReadModel/JSONLD/CdbXMLItemBaseImporter.php
@@ -134,7 +134,7 @@ final class CdbXMLItemBaseImporter
                 'category' => 'base',
                 'name' => $this->basePriceTranslations,
                 'price' => $priceInfo->getBasePrice()->getPrice()->getAmount() / 100,
-                'priceCurrency' => $priceInfo->getBasePrice()->getPrice()->getCurrency()->getName(),
+                'priceCurrency' => $priceInfo->getBasePrice()->getPrice()->getCurrency()->getCode(),
             ],
         ];
 
@@ -143,7 +143,7 @@ final class CdbXMLItemBaseImporter
                 'category' => 'tariff',
                 'name' => (new TranslatedTariffNameNormalizer())->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
-                'priceCurrency' => $tariff->getPrice()->getCurrency()->getName(),
+                'priceCurrency' => $tariff->getPrice()->getCurrency()->getCode(),
             ];
         }
     }

--- a/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
+++ b/src/Offer/ReadModel/JSONLD/OfferLDProjector.php
@@ -679,7 +679,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
             'category' => 'base',
             'name' => $this->basePriceTranslations,
             'price' => $basePrice->getPrice()->getAmount() / 100,
-            'priceCurrency' => $basePrice->getPrice()->getCurrency()->getName(),
+            'priceCurrency' => $basePrice->getPrice()->getCurrency()->getCode(),
         ];
 
         if ($basePrice->isGroupPrice()) {
@@ -695,7 +695,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
                 'category' => 'tariff',
                 'name' => $translatedTariffNameNormalizer->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
-                'priceCurrency' => $tariff->getPrice()->getCurrency()->getName(),
+                'priceCurrency' => $tariff->getPrice()->getCurrency()->getCode(),
             ];
 
             if ($tariff->isGroupPrice()) {
@@ -710,7 +710,7 @@ abstract class OfferLDProjector implements OrganizerServiceInterface
                 'category' => 'uitpas',
                 'name' => $translatedTariffNameNormalizer->normalize($tariff->getName()),
                 'price' => $tariff->getPrice()->getAmount() / 100,
-                'priceCurrency' => $tariff->getPrice()->getCurrency()->getName(),
+                'priceCurrency' => $tariff->getPrice()->getCurrency()->getCode(),
             ];
         }
 

--- a/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
+++ b/tests/BackwardsCompatiblePayloadSerializerFactoryTest.php
@@ -619,7 +619,7 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
 
         $expectedPriceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1500, new Currency('EUR'))
+                new Money('1500', new Currency('EUR'))
             ),
             new Tariffs(
                 new Tariff(
@@ -627,14 +627,14 @@ class BackwardsCompatiblePayloadSerializerFactoryTest extends TestCase
                         new Language('nl'),
                         new TariffName('Senioren')
                     ),
-                    new Money(1000, new Currency('EUR'))
+                    new Money('1000', new Currency('EUR'))
                 ),
                 new Tariff(
                     new TranslatedTariffName(
                         new Language('nl'),
                         new TariffName('Studenten')
                     ),
-                    new Money(750, new Currency('EUR'))
+                    new Money('750', new Currency('EUR'))
                 )
             )
         );

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -678,7 +678,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -688,7 +688,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -698,7 +698,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -711,7 +711,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                90,
+                                '90',
                                 new Currency('EUR')
                             )
                         ),
@@ -723,7 +723,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(90, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('90', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -733,7 +733,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -756,7 +756,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -766,7 +766,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -776,7 +776,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -789,7 +789,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     (new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                90,
+                                '90',
                                 new Currency('EUR')
                             )
                         ),
@@ -802,7 +802,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    80,
+                                    '80',
                                     new Currency('EUR')
                                 )
                             )
@@ -814,7 +814,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(90, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('90', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -824,7 +824,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -847,7 +847,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -857,7 +857,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -867,7 +867,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -880,7 +880,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -904,7 +904,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -914,7 +914,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -924,7 +924,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -937,7 +937,7 @@ class EventTest extends AggregateRootScenarioTestCase
                     (new PriceInfo(
                         Tariff::createBasePrice(
                             new Money(
-                                100,
+                                '100',
                                 new Currency('EUR')
                             )
                         ),
@@ -950,7 +950,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    80,
+                                    '80',
                                     new Currency('EUR')
                                 )
                             )
@@ -971,7 +971,7 @@ class EventTest extends AggregateRootScenarioTestCase
 
         $priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(999, new Currency('EUR'))
+                new Money('999', new Currency('EUR'))
             ),
             new Tariffs()
         );
@@ -1013,14 +1013,14 @@ class EventTest extends AggregateRootScenarioTestCase
             ->when(
                 fn (Event $event) => $event->updatePriceInfo(
                     new PriceInfo(
-                        Tariff::createBasePrice(new Money(1250, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('1250', new Currency('EUR'))),
                         new Tariffs(
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Met kinderen')
                                 ),
-                                new Money(2000, new Currency('EUR'))
+                                new Money('2000', new Currency('EUR'))
                             ),
                         )
                     )
@@ -1029,14 +1029,14 @@ class EventTest extends AggregateRootScenarioTestCase
             ->when(
                 fn (Event $event) => $event->updatePriceInfo(
                     new PriceInfo(
-                        Tariff::createBasePrice(new Money(1250, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('1250', new Currency('EUR'))),
                         new Tariffs(
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Met kinderen')
                                 ),
-                                new Money(1499, new Currency('EUR'))
+                                new Money('1499', new Currency('EUR'))
                             ),
                         )
                     )
@@ -1046,14 +1046,14 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     $eventId,
                     new PriceInfo(
-                        Tariff::createBasePrice(new Money(1250, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('1250', new Currency('EUR'))),
                         new Tariffs(
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Met kinderen')
                                 ),
-                                new Money(1499, new Currency('EUR'))
+                                new Money('1499', new Currency('EUR'))
                             ),
                         )
                     )
@@ -1952,7 +1952,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -1962,7 +1962,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 2')
                                 ),
                                 new Money(
-                                    299,
+                                    '299',
                                     new Currency('EUR')
                                 )
                             )
@@ -1985,7 +1985,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -1995,7 +1995,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -2005,7 +2005,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 2')
                                 ),
                                 new Money(
-                                    299,
+                                    '299',
                                     new Currency('EUR')
                                 )
                             )
@@ -2023,7 +2023,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -2033,7 +2033,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 2')
                                 ),
                                 new Money(
-                                    299,
+                                    '299',
                                     new Currency('EUR')
                                 )
                             )
@@ -2056,7 +2056,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     )
                 ),
@@ -2071,7 +2071,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -2081,7 +2081,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 2')
                                 ),
                                 new Money(
-                                    299,
+                                    '299',
                                     new Currency('EUR')
                                 )
                             )
@@ -2093,7 +2093,7 @@ class EventTest extends AggregateRootScenarioTestCase
                 new PriceInfoUpdated(
                     'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
                     (new PriceInfo(
-                        Tariff::createBasePrice(new Money(100, new Currency('EUR'))),
+                        Tariff::createBasePrice(new Money('100', new Currency('EUR'))),
                         new Tariffs()
                     ))->withUiTPASTariffs(
                         new Tariffs(
@@ -2103,7 +2103,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 1')
                                 ),
                                 new Money(
-                                    199,
+                                    '199',
                                     new Currency('EUR')
                                 )
                             ),
@@ -2113,7 +2113,7 @@ class EventTest extends AggregateRootScenarioTestCase
                                     new TariffName('Tariff 2')
                                 ),
                                 new Money(
-                                    299,
+                                    '299',
                                     new Currency('EUR')
                                 )
                             )

--- a/tests/Event/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Event/ReadModel/History/HistoryProjectorTest.php
@@ -1461,7 +1461,7 @@ class HistoryProjectorTest extends TestCase
             self::EVENT_ID_1,
             new PriceInfo(
                 Tariff::createBasePrice(
-                    new Money(1000, new Currency('EUR'))
+                    new Money('1000', new Currency('EUR'))
                 ),
                 new Tariffs()
             )

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -826,7 +826,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                                 new Language('de'),
                                 new TariffName('Basisrate')
                             ),
-                            new Money(1050, new Currency('EUR'))
+                            new Money('1050', new Currency('EUR'))
                         ),
                         new Tariffs()
                     )
@@ -5152,7 +5152,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                                 new Language('de'),
                                 new TariffName('Basisrate')
                             ),
-                            new Money(1050, new Currency('EUR'))
+                            new Money('1050', new Currency('EUR'))
                         ),
                         new Tariffs()
                     )
@@ -5259,7 +5259,7 @@ final class ImportEventRequestHandlerTest extends TestCase
                                 new Language('de'),
                                 new TariffName('Basisrate')
                             ),
-                            new Money(10500, new Currency('EUR'))
+                            new Money('10500', new Currency('EUR'))
                         ))->withGroupPrice(true),
                         new Tariffs()
                     )

--- a/tests/Http/Offer/UpdatePriceInfoRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdatePriceInfoRequestHandlerTest.php
@@ -79,7 +79,7 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new TariffName('Basistarief')
                 ),
-                new Money(1000, new Currency('EUR'))
+                new Money('1000', new Currency('EUR'))
             ),
             new Tariffs(
                 new Tariff(
@@ -87,14 +87,14 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                         new Language('nl'),
                         new TariffName('Jongeren')
                     ),
-                    new Money(500, new Currency('EUR'))
+                    new Money('500', new Currency('EUR'))
                 ),
                 new Tariff(
                     new TranslatedTariffName(
                         new Language('nl'),
                         new TariffName('Senioren')
                     ),
-                    new Money(500, new Currency('EUR'))
+                    new Money('500', new Currency('EUR'))
                 )
             )
         );
@@ -147,7 +147,7 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new TariffName('Basistarief')
                 ),
-                new Money(230, new Currency('EUR'))
+                new Money('230', new Currency('EUR'))
             ),
             new Tariffs(
                 new Tariff(
@@ -155,7 +155,7 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                         new Language('nl'),
                         new TariffName('Early birds')
                     ),
-                    new Money(230, new Currency('EUR'))
+                    new Money('230', new Currency('EUR'))
                 ),
             )
         );
@@ -218,7 +218,7 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                     new Language('nl'),
                     new TariffName('Basistarief')
                 ),
-                new Money(25000, new Currency('EUR'))
+                new Money('25000', new Currency('EUR'))
             ))->withGroupPrice(true),
             new Tariffs(
                 new Tariff(
@@ -226,14 +226,14 @@ class UpdatePriceInfoRequestHandlerTest extends TestCase
                         new Language('nl'),
                         new TariffName('Individuen')
                     ),
-                    new Money(1500, new Currency('EUR'))
+                    new Money('1500', new Currency('EUR'))
                 ),
                 (new Tariff(
                     new TranslatedTariffName(
                         new Language('nl'),
                         new TariffName('Leraren')
                     ),
-                    new Money(10000, new Currency('EUR'))
+                    new Money('10000', new Currency('EUR'))
                 ))->withGroupPrice(true),
             )
         );

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -932,7 +932,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
                                 new Language('de'),
                                 new TariffName('Basisrate')
                             ),
-                            new Money(1050, new Currency('EUR'))
+                            new Money('1050', new Currency('EUR'))
                         ),
                         new Tariffs()
                     )

--- a/tests/Kinepolis/KinepolisServiceTest.php
+++ b/tests/Kinepolis/KinepolisServiceTest.php
@@ -249,7 +249,7 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Basistarief')
                                 ),
-                                new Money(1100, new Currency('EUR'))
+                                new Money('1100', new Currency('EUR'))
                             ),
                             new Tariffs(
                                 new Tariff(
@@ -257,14 +257,14 @@ final class KinepolisServiceTest extends TestCase
                                         new Language('nl'),
                                         new TariffName('Kinepolis Student Card')
                                     ),
-                                    new Money(900, new Currency('EUR'))
+                                    new Money('900', new Currency('EUR'))
                                 ),
                                 new Tariff(
                                     new TranslatedTariffName(
                                         new Language('nl'),
                                         new TariffName('Kortingstarief')
                                     ),
-                                    new Money(1000, new Currency('EUR'))
+                                    new Money('1000', new Currency('EUR'))
                                 ),
                             )
                         ),
@@ -334,7 +334,7 @@ final class KinepolisServiceTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1100, new Currency('EUR'))
+                            new Money('1100', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -342,14 +342,14 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             ),
                         )
                     )
@@ -427,7 +427,7 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Basistarief')
                                 ),
-                                new Money(1100, new Currency('EUR'))
+                                new Money('1100', new Currency('EUR'))
                             ),
                             new Tariffs(
                                 new Tariff(
@@ -435,14 +435,14 @@ final class KinepolisServiceTest extends TestCase
                                         new Language('nl'),
                                         new TariffName('Kinepolis Student Card')
                                     ),
-                                    new Money(900, new Currency('EUR'))
+                                    new Money('900', new Currency('EUR'))
                                 ),
                                 new Tariff(
                                     new TranslatedTariffName(
                                         new Language('nl'),
                                         new TariffName('Kortingstarief')
                                     ),
-                                    new Money(1000, new Currency('EUR'))
+                                    new Money('1000', new Currency('EUR'))
                                 ),
                             )
                         ),
@@ -517,7 +517,7 @@ final class KinepolisServiceTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1100, new Currency('EUR'))
+                            new Money('1100', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -525,14 +525,14 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             ),
                         )
                     )
@@ -607,7 +607,7 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Basistarief')
                                 ),
-                                new Money(1200, new Currency('EUR'))
+                                new Money('1200', new Currency('EUR'))
                             ),
                             new Tariffs(
                                 new Tariff(
@@ -615,14 +615,14 @@ final class KinepolisServiceTest extends TestCase
                                         new Language('nl'),
                                         new TariffName('Kinepolis Student Card')
                                     ),
-                                    new Money(1000, new Currency('EUR'))
+                                    new Money('1000', new Currency('EUR'))
                                 ),
                                 new Tariff(
                                     new TranslatedTariffName(
                                         new Language('nl'),
                                         new TariffName('Kortingstarief')
                                     ),
-                                    new Money(1100, new Currency('EUR'))
+                                    new Money('1100', new Currency('EUR'))
                                 ),
                             )
                         ),
@@ -700,7 +700,7 @@ final class KinepolisServiceTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1200, new Currency('EUR'))
+                            new Money('1200', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -708,14 +708,14 @@ final class KinepolisServiceTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1100, new Currency('EUR'))
+                                new Money('1100', new Currency('EUR'))
                             ),
                         )
                     )

--- a/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
+++ b/tests/Kinepolis/Parser/KinepolisMovieParserTest.php
@@ -163,7 +163,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1100, new Currency('EUR'))
+                            new Money('1100', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -171,14 +171,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             )
                         )
                     ),
@@ -212,7 +212,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1000, new Currency('EUR'))
+                            new Money('1000', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -220,14 +220,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(800, new Currency('EUR'))
+                                new Money('800', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             )
                         )
                     ),
@@ -261,7 +261,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1200, new Currency('EUR'))
+                            new Money('1200', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -269,14 +269,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1100, new Currency('EUR'))
+                                new Money('1100', new Currency('EUR'))
                             )
                         )
                     ),
@@ -340,7 +340,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1100, new Currency('EUR'))
+                            new Money('1100', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -348,14 +348,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             )
                         )
                     ),
@@ -389,7 +389,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1000, new Currency('EUR'))
+                            new Money('1000', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -397,14 +397,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(800, new Currency('EUR'))
+                                new Money('800', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(900, new Currency('EUR'))
+                                new Money('900', new Currency('EUR'))
                             )
                         )
                     ),
@@ -438,7 +438,7 @@ final class KinepolisMovieParserTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Basistarief')
                             ),
-                            new Money(1200, new Currency('EUR'))
+                            new Money('1200', new Currency('EUR'))
                         ),
                         new Tariffs(
                             new Tariff(
@@ -446,14 +446,14 @@ final class KinepolisMovieParserTest extends TestCase
                                     new Language('nl'),
                                     new TariffName('Kinepolis Student Card')
                                 ),
-                                new Money(1000, new Currency('EUR'))
+                                new Money('1000', new Currency('EUR'))
                             ),
                             new Tariff(
                                 new TranslatedTariffName(
                                     new Language('nl'),
                                     new TariffName('Kortingstarief')
                                 ),
-                                new Money(1100, new Currency('EUR'))
+                                new Money('1100', new Currency('EUR'))
                             )
                         )
                     ),

--- a/tests/Model/Offer/ImmutableOfferTest.php
+++ b/tests/Model/Offer/ImmutableOfferTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Model\Offer;
 
-use Money\UnknownCurrencyException;
 use CultuurNet\UDB3\DateTimeFactory;
 use CultuurNet\UDB3\Model\Organizer\OrganizerReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
@@ -331,13 +330,12 @@ class ImmutableOfferTest extends TestCase
 
     /**
      * @test
-     * @throws UnknownCurrencyException
      */
     public function it_should_return_a_copy_with_updated_price_info(): void
     {
         $priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1000, new Currency('EUR'))
+                new Money('1000', new Currency('EUR'))
             ),
             new Tariffs()
         );
@@ -352,13 +350,12 @@ class ImmutableOfferTest extends TestCase
 
     /**
      * @test
-     * @throws UnknownCurrencyException
      */
     public function it_should_return_a_copy_without_price_info(): void
     {
         $priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1000, new Currency('EUR'))
+                new Money('1000', new Currency('EUR'))
             ),
             new Tariffs()
         );

--- a/tests/Model/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Model/Serializer/Event/EventDenormalizerTest.php
@@ -1677,7 +1677,7 @@ class EventDenormalizerTest extends TestCase
                             new TariffName('Basistarief')
                         ))->withTranslation(new Language('en'), new TariffName('Base tariff')),
                         new Money(
-                            1500,
+                            '1500',
                             new Currency('EUR')
                         )
                     ),
@@ -1688,7 +1688,7 @@ class EventDenormalizerTest extends TestCase
                                 new TariffName('Senioren')
                             ))->withTranslation(new Language('en'), new TariffName('Seniors')),
                             new Money(
-                                1050,
+                                '1050',
                                 new Currency('EUR')
                             )
                         )

--- a/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
+++ b/tests/Model/Serializer/Place/PlaceDenormalizerTest.php
@@ -870,7 +870,7 @@ class PlaceDenormalizerTest extends TestCase
                             new TariffName('Basistarief')
                         ))->withTranslation(new Language('en'), new TariffName('Base tariff')),
                         new Money(
-                            1500,
+                            '1500',
                             new Currency('EUR')
                         )
                     ),
@@ -881,7 +881,7 @@ class PlaceDenormalizerTest extends TestCase
                                 new TariffName('Senioren')
                             ))->withTranslation(new Language('en'), new TariffName('Seniors')),
                             new Money(
-                                1050,
+                                '1050',
                                 new Currency('EUR')
                             )
                         )

--- a/tests/Model/Serializer/ValueObject/Price/MoneyNormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Price/MoneyNormalizerTest.php
@@ -18,7 +18,7 @@ class MoneyNormalizerTest extends TestCase
     protected function setUp(): void
     {
         $this->normalizer = new MoneyNormalizer();
-        $this->money = new Money(100, new Currency('EUR'));
+        $this->money = new Money('100', new Currency('EUR'));
     }
 
     /**

--- a/tests/Model/Serializer/ValueObject/Price/TariffNormalizerTest.php
+++ b/tests/Model/Serializer/ValueObject/Price/TariffNormalizerTest.php
@@ -28,7 +28,7 @@ class TariffNormalizerTest extends TestCase
                 new TariffName('Basistarief')
             ))->withTranslation(new Language('en'), new TariffName('Base tariff')),
             new Money(
-                100,
+                '100',
                 new Currency('EUR')
             )
         );

--- a/tests/Model/ValueObject/Price/PriceInfoTest.php
+++ b/tests/Model/ValueObject/Price/PriceInfoTest.php
@@ -17,7 +17,7 @@ class PriceInfoTest extends TestCase
     public function it_should_combine_a_base_price_and_optional_extra_tariffs(): void
     {
         $basePrice = Tariff::createBasePrice(
-            new Money(1000, new Currency('EUR'))
+            new Money('1000', new Currency('EUR'))
         );
         $tariffs = new Tariffs();
         $priceInfo = new PriceInfo($basePrice, $tariffs);
@@ -32,13 +32,13 @@ class PriceInfoTest extends TestCase
     public function it_should_return_a_copy_with_an_updated_base_price(): void
     {
         $basePrice = Tariff::createBasePrice(
-            new Money(1000, new Currency('EUR'))
+            new Money('1000', new Currency('EUR'))
         );
         $tariffs = new Tariffs();
         $priceInfo = new PriceInfo($basePrice, $tariffs);
 
         $updatedBasePrice = Tariff::createBasePrice(
-            new Money(2000, new Currency('EUR'))
+            new Money('2000', new Currency('EUR'))
         );
         $updatedPriceInfo = $priceInfo->withBasePrice($updatedBasePrice);
 
@@ -53,7 +53,7 @@ class PriceInfoTest extends TestCase
     public function it_should_return_a_copy_with_updated_tariffs(): void
     {
         $basePrice = Tariff::createBasePrice(
-            new Money(1000, new Currency('EUR'))
+            new Money('1000', new Currency('EUR'))
         );
         $tariffs = new Tariffs();
         $priceInfo = new PriceInfo($basePrice, $tariffs);
@@ -64,7 +64,7 @@ class PriceInfoTest extends TestCase
                     new Language('nl'),
                     new TariffName('Senioren')
                 ),
-                new Money(500, new Currency('EUR'))
+                new Money('500', new Currency('EUR'))
             )
         );
         $updatedPriceInfo = $priceInfo->withTariffs($updatedTariffs);
@@ -104,7 +104,7 @@ class PriceInfoTest extends TestCase
             'originalPriceInfo' => [
                 new PriceInfo(
                     Tariff::createBasePrice(
-                        new Money(1000, new Currency('EUR'))
+                        new Money('1000', new Currency('EUR'))
                     ),
                     new Tariffs(
                         new Tariff(
@@ -112,7 +112,7 @@ class PriceInfoTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Senioren')
                             ),
-                            new Money(500, new Currency('EUR'))
+                            new Money('500', new Currency('EUR'))
                         )
                     )
                 ),
@@ -138,7 +138,7 @@ class PriceInfoTest extends TestCase
            'priceInfoWithGroupPrice' => [
                new PriceInfo(
                    (Tariff::createBasePrice(
-                       new Money(1000, new Currency('EUR'))
+                       new Money('1000', new Currency('EUR'))
                    ))->withGroupPrice(true),
                    new Tariffs(
                        new Tariff(
@@ -146,14 +146,14 @@ class PriceInfoTest extends TestCase
                                new Language('nl'),
                                new TariffName('Senioren')
                            ),
-                           new Money(500, new Currency('EUR'))
+                           new Money('500', new Currency('EUR'))
                        ),
                        (new Tariff(
                            new TranslatedTariffName(
                                new Language('nl'),
                                new TariffName('Jongeren')
                            ),
-                           new Money(750, new Currency('EUR'))
+                           new Money('750', new Currency('EUR'))
                        ))->withGroupPrice(true)
                    )
                ),
@@ -211,7 +211,7 @@ class PriceInfoTest extends TestCase
                 ],
                 new PriceInfo(
                     (Tariff::createBasePrice(
-                        new Money(1000, new Currency('EUR'))
+                        new Money('1000', new Currency('EUR'))
                     ))->withGroupPrice(false),
                     new Tariffs(
                         (new Tariff(
@@ -219,7 +219,7 @@ class PriceInfoTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Senioren')
                             ),
-                            new Money(500, new Currency('EUR'))
+                            new Money('500', new Currency('EUR'))
                         ))->withGroupPrice(false)
                     )
                 ),
@@ -253,7 +253,7 @@ class PriceInfoTest extends TestCase
                 ],
                 new PriceInfo(
                     (Tariff::createBasePrice(
-                        new Money(1000, new Currency('EUR'))
+                        new Money('1000', new Currency('EUR'))
                     ))->withGroupPrice(true),
                     new Tariffs(
                         (new Tariff(
@@ -261,14 +261,14 @@ class PriceInfoTest extends TestCase
                                 new Language('nl'),
                                 new TariffName('Senioren')
                             ),
-                            new Money(500, new Currency('EUR'))
+                            new Money('500', new Currency('EUR'))
                         ))->withGroupPrice(false),
                         (new Tariff(
                             new TranslatedTariffName(
                                 new Language('nl'),
                                 new TariffName('Jongeren')
                             ),
-                            new Money(750, new Currency('EUR'))
+                            new Money('750', new Currency('EUR'))
                         ))->withGroupPrice(true)
                     )
                 ),

--- a/tests/Model/ValueObject/Price/TariffTest.php
+++ b/tests/Model/ValueObject/Price/TariffTest.php
@@ -21,7 +21,7 @@ class TariffTest extends TestCase
             new TariffName('Senioren')
         );
 
-        $price = new Money(1000, new Currency('EUR'));
+        $price = new Money('1000', new Currency('EUR'));
 
         $tariff = new Tariff($name, $price);
 
@@ -38,7 +38,7 @@ class TariffTest extends TestCase
             new Language('nl'),
             new TariffName('Senioren')
         );
-        $price = new Money(1000, new Currency('EUR'));
+        $price = new Money('1000', new Currency('EUR'));
         $tariff = new Tariff($name, $price);
 
         $updatedName = $name->withTranslation(
@@ -61,7 +61,7 @@ class TariffTest extends TestCase
             new Language('nl'),
             new TariffName('Senioren')
         );
-        $price = new Money(1000, new Currency('EUR'));
+        $price = new Money('1000', new Currency('EUR'));
         $tariff = new Tariff($name, $price);
 
         $updatedPrice = $price->multiply(2);
@@ -81,7 +81,7 @@ class TariffTest extends TestCase
             new Language('nl'),
             new TariffName('Leerlingen')
         );
-        $price = new Money(1000, new Currency('EUR'));
+        $price = new Money('1000', new Currency('EUR'));
         $tariff = new Tariff($name, $price);
 
         $updatedTariff = $tariff->withGroupPrice(true);

--- a/tests/MoneyFactoryTest.php
+++ b/tests/MoneyFactoryTest.php
@@ -49,19 +49,19 @@ final class MoneyFactoryTest extends TestCase
     {
         return [
             'euro in int' => [
-                'expectedMoney' => new Money(200, new Currency('EUR')),
+                'expectedMoney' => new Money('200', new Currency('EUR')),
                 'actualMoney' => MoneyFactory::create(2, new Currency('EUR')),
             ],
             'euro in float' => [
-                'expectedMoney' => new Money(230, new Currency('GBP')),
+                'expectedMoney' => new Money('230', new Currency('GBP')),
                 'actualMoney' => MoneyFactory::create(2.3, new Currency('GBP')),
             ],
             'euro in string' => [
-                'expectedMoney' => new Money(4500, new Currency('EUR')),
+                'expectedMoney' => new Money('4500', new Currency('EUR')),
                 'actualMoney' => MoneyFactory::create('45', new Currency('EUR')),
             ],
             'euro in string with decimals' => [
-                'expectedMoney' => new Money(3390, new Currency('EUR')),
+                'expectedMoney' => new Money('3390', new Currency('EUR')),
                 'actualMoney' => MoneyFactory::create('33.9', new Currency('EUR')),
             ],
         ];
@@ -71,15 +71,15 @@ final class MoneyFactoryTest extends TestCase
     {
         return [
             'cents in int' => [
-                'expectedMoney' => new Money(1999, new Currency('EUR')),
+                'expectedMoney' => new Money('1999', new Currency('EUR')),
                 'actualMoney' => MoneyFactory::createFromCents(1999, new Currency('EUR')),
             ],
             'cents in string' => [
-                'expectedMoney' => new Money(2999, new Currency('EUR')),
+                'expectedMoney' => new Money('2999', new Currency('EUR')),
                 'actualMoney' => MoneyFactory::createFromCents('2999', new Currency('EUR')),
             ],
             'cents in different currency' => [
-                'expectedMoney' => new Money(3999, new Currency('SEK')),
+                'expectedMoney' => new Money('3999', new Currency('SEK')),
                 'actualMoney' => MoneyFactory::createFromCents('3999', new Currency('SEK')),
             ],
         ];

--- a/tests/Offer/CommandHandlers/UpdatePriceInfoHandlerTest.php
+++ b/tests/Offer/CommandHandlers/UpdatePriceInfoHandlerTest.php
@@ -57,7 +57,7 @@ final class UpdatePriceInfoHandlerTest extends CommandHandlerScenarioTestCase
                         new Language('nl'),
                         new TariffName('Basisprijs')
                     ),
-                    new Money(1499, new Currency('EUR'))
+                    new Money('1499', new Currency('EUR'))
                 ),
                 new Tariffs()
             )

--- a/tests/Offer/OfferCommandHandlerTest.php
+++ b/tests/Offer/OfferCommandHandlerTest.php
@@ -59,7 +59,7 @@ final class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
 
         $this->priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1050, new Currency('EUR'))
+                new Money('1050', new Currency('EUR'))
             ),
             new Tariffs()
         );

--- a/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
+++ b/tests/Offer/ReadModel/JSONLD/OfferLDProjectorTest.php
@@ -799,7 +799,7 @@ class OfferLDProjectorTest extends TestCase
 
         $priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1050, new Currency('EUR'))
+                new Money('1050', new Currency('EUR'))
             ),
             new Tariffs(
                 new Tariff(
@@ -807,7 +807,7 @@ class OfferLDProjectorTest extends TestCase
                         new Language('nl'),
                         new TariffName('Tarief inwoners')
                     ),
-                    new Money(950, new Currency('EUR'))
+                    new Money('950', new Currency('EUR'))
                 )
             )
         );
@@ -818,7 +818,7 @@ class OfferLDProjectorTest extends TestCase
                         new Language('nl'),
                         new TariffName('UiTPAS tarief')
                     ),
-                    new Money(650, new Currency('EUR'))
+                    new Money('650', new Currency('EUR'))
                 )
             )
         );

--- a/tests/Place/PlaceTest.php
+++ b/tests/Place/PlaceTest.php
@@ -223,7 +223,7 @@ class PlaceTest extends AggregateRootScenarioTestCase
 
         $priceInfo = new PriceInfo(
             Tariff::createBasePrice(
-                new Money(1000, new Currency('EUR'))
+                new Money('1000', new Currency('EUR'))
             ),
             new Tariffs()
         );

--- a/tests/Place/ReadModel/History/HistoryProjectorTest.php
+++ b/tests/Place/ReadModel/History/HistoryProjectorTest.php
@@ -834,7 +834,7 @@ class HistoryProjectorTest extends TestCase
             'a0ee7b1c-a9c1-4da1-af7e-d15496014656',
             new PriceInfo(
                 Tariff::createBasePrice(
-                    new Money(1000, new Currency('EUR'))
+                    new Money('1000', new Currency('EUR'))
                 ),
                 new Tariffs()
             )

--- a/tests/UiTPAS/Event/Event/PricesUpdatedDeserializerTest.php
+++ b/tests/UiTPAS/Event/Event/PricesUpdatedDeserializerTest.php
@@ -52,7 +52,7 @@ final class PricesUpdatedDeserializerTest extends TestCase
                             new TariffName('Tariff 1')
                         ),
                         new Money(
-                            199,
+                            '199',
                             new Currency('EUR')
                         )
                     ),
@@ -62,7 +62,7 @@ final class PricesUpdatedDeserializerTest extends TestCase
                             new TariffName('Tariff 2')
                         ),
                         new Money(
-                            299,
+                            '299',
                             new Currency('EUR')
                         )
                     )

--- a/tests/UiTPAS/Event/EventProcessManagerTest.php
+++ b/tests/UiTPAS/Event/EventProcessManagerTest.php
@@ -450,7 +450,7 @@ final class EventProcessManagerTest extends TestCase
                     new TariffName('Tariff 1')
                 ),
                 new Money(
-                    199,
+                    '199',
                     new Currency('EUR')
                 )
             ),
@@ -460,7 +460,7 @@ final class EventProcessManagerTest extends TestCase
                     new TariffName('Tariff 2')
                 ),
                 new Money(
-                    299,
+                    '299',
                     new Currency('EUR')
                 )
             )


### PR DESCRIPTION
I wanted to experiment with Claude agents and git worktree to run multiple agents at the same time, so I just picked some low hanging maintance work.
This is a low prio PR, only pick up if you want.

## Summary

- Replaces the abandoned `mathiasverraes/money ^v1.3.0` with the maintained `moneyphp/money ^4.0` (v4.9.0 installed)
- `Currency::getName()` renamed to `Currency::getCode()` across 6 source files
- `Money` constructor now requires `string` amount under `strict_types=1` — wrapped integer expressions with `(string)((int) ...)` in `MoneyFactory` and `ParsedPriceForATheater`
- `MoneyNormalizer` and `PriceInfo::serialize()` cast `getAmount()` to `int` to preserve backward-compatible JSON and event-store output (cents are always whole numbers)
- All 139 `new Money(int, ...)` literal calls in test files updated to `new Money('int', ...)`

## Test plan

- [x] All 5416 tests pass in Docker (`make test`)
- [x] No changes to JSON-LD output, RDF URIs, or event-store serialization format

🤖 Generated with [Claude Code](https://claude.com/claude-code)