### PR TITLE
III-7133 Search departure places feature tests

### DIFF
--- a/features/State/RequestState.php
+++ b/features/State/RequestState.php
@@ -18,6 +18,9 @@ final class RequestState
     private string $json = '';
     private array $form = [];
 
+    private string $lastGetUrl = '';
+    private array $lastGetParams = [];
+
     public function getBaseUrl(): string
     {
         return $this->baseUrl;
@@ -115,5 +118,25 @@ final class RequestState
     public function setForm(array $form): void
     {
         $this->form = $form;
+    }
+
+    public function getLastGetUrl(): string
+    {
+        return $this->lastGetUrl;
+    }
+
+    public function setLastGetUrl(string $url): void
+    {
+        $this->lastGetUrl = $url;
+    }
+
+    public function getLastGetParams(): array
+    {
+        return $this->lastGetParams;
+    }
+
+    public function setLastGetParams(array $params): void
+    {
+        $this->lastGetParams = $params;
     }
 }

--- a/features/Steps/RequestSteps.php
+++ b/features/Steps/RequestSteps.php
@@ -7,6 +7,7 @@ namespace CultuurNet\UDB3\Steps;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use CultuurNet\UDB3\State\VariableState;
+use function PHPUnit\Framework\assertEquals;
 
 trait RequestSteps
 {
@@ -113,8 +114,33 @@ trait RequestSteps
     public function iSendAGetRequestToWithParameters(string $url, TableNode $parameters): void
     {
         $params = $this->addScenarioLabelToSearchParameters($url, $parameters->getRows());
+        $this->requestState->setLastGetUrl($url);
+        $this->requestState->setLastGetParams($params);
         $response = $this->getHttpClient()->getWithParameters($url, $params, $this->variableState);
         $this->responseState->setResponse($response);
+    }
+
+    /**
+     * @Then I wait for the JSON response at :jsonPath to have :nrOfEntries entries
+     */
+    public function iWaitForTheJsonResponseAtToHaveEntries(string $jsonPath, int $nrOfEntries): void
+    {
+        $elapsedTime = 0;
+        do {
+            $response = $this->getHttpClient()->getWithParameters(
+                $this->requestState->getLastGetUrl(),
+                $this->requestState->getLastGetParams(),
+                $this->variableState
+            );
+            $this->responseState->setResponse($response);
+            $actual = count((array) $this->responseState->getValueOnPath($jsonPath));
+            if ($actual !== $nrOfEntries) {
+                sleep(1);
+                $elapsedTime++;
+            }
+        } while ($actual !== $nrOfEntries && $elapsedTime < 5);
+
+        assertEquals($nrOfEntries, count((array) $this->responseState->getValueOnPath($jsonPath)));
     }
 
     private function addScenarioLabelToSearchParameters(string $url, array $parameters): array

--- a/features/Steps/RequestSteps.php
+++ b/features/Steps/RequestSteps.php
@@ -255,6 +255,29 @@ trait RequestSteps
         $this->waitForItemWithUrlToBeIndex($url);
     }
 
+    /**
+     * @Then I wait for the JSON response at :jsonPath to be :expectedValue
+     */
+    public function iWaitForTheJsonResponseAtToBe(string $jsonPath, string $expectedValue): void
+    {
+        $elapsedTime = 0;
+        do {
+            $response = $this->getHttpClient()->getWithParameters(
+                $this->requestState->getLastGetUrl(),
+                $this->requestState->getLastGetParams(),
+                $this->variableState
+            );
+            $this->responseState->setResponse($response);
+            $actual = $this->responseState->getValueOnPath($jsonPath);
+            if ((string) $actual !== $expectedValue) {
+                sleep(1);
+                $elapsedTime++;
+            }
+        } while ((string) $actual !== $expectedValue && $elapsedTime < 5);
+
+        assertEquals($expectedValue, (string) $this->responseState->getValueOnPath($jsonPath));
+    }
+
     private function waitForItemWithUrlToBeIndex(string $url): void
     {
         $url = $this->variableState->replaceVariables($url);

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -39,18 +39,20 @@ Feature: Test departure places in search results
     And I keep the value of the JSON response at "id" as "departurePlaceId2"
     And I create a minimal place and save the "url" as "departurePlaceUrl3"
     And I keep the value of the JSON response at "id" as "departurePlaceId3"
+    And I create a minimal place and save the "url" as "departurePlaceUrl4"
+    And I keep the value of the JSON response at "id" as "departurePlaceId4"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId1"
     And I publish the event at "/events/%{eventId1}"
     And I set the JSON request payload to:
     """
-    ["%{departurePlaceUrl1}", "%{departurePlaceUrl3}"]
+    ["%{departurePlaceUrl1}", "%{departurePlaceUrl3}", "%{departurePlaceUrl4}"]
     """
     And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
     And I publish the event at "/events/%{eventId2}"
     And I set the JSON request payload to:
     """
-    ["%{departurePlaceUrl2}"]
+    ["%{departurePlaceUrl2}", "%{departurePlaceUrl4}"]
     """
     And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
     And I am using the Search API v3 base URL
@@ -81,6 +83,11 @@ Feature: Test departure places in search results
     """
     %{eventId2}
     """
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                                                         |
+      | q                     | departurePlaces:%{departurePlaceId4} AND departurePlaces:%{departurePlaceId1} |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId1}"
 
   @testIsolation
   Scenario: Events can be filtered by departure place using the departurePlaces url parameter

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -13,7 +13,6 @@ Feature: Test departure places in search results
     When I create a minimal place and save the "url" as "departurePlaceUrl1"
     And I create a minimal place and save the "url" as "departurePlaceUrl2"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId"
-    And I send a GET request to "/events/%{eventId}"
     And I publish the event at "/events/%{eventId}"
     And I set the JSON request payload to:
     """
@@ -31,3 +30,54 @@ Feature: Test departure places in search results
     And I wait for the JSON response at "member/0/departurePlaces" to have 2 entries
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl1}"
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl2}"
+
+  @testIsolation
+  Scenario: Events can be searched by departure place UUID in q parameter
+    When I create a minimal place and save the "url" as "departurePlaceUrl1"
+    And I keep the value of the JSON response at "id" as "departurePlaceId1"
+    And I create a minimal place and save the "url" as "departurePlaceUrl2"
+    And I keep the value of the JSON response at "id" as "departurePlaceId2"
+    And I create a minimal place and save the "url" as "departurePlaceUrl3"
+    And I keep the value of the JSON response at "id" as "departurePlaceId3"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId1"
+    And I publish the event at "/events/%{eventId1}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl1}", "%{departurePlaceUrl3}"]
+    """
+    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
+    And I publish the event at "/events/%{eventId2}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl2}"]
+    """
+    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I am using the Search API v3 base URL
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                 |
+      | q                     | departurePlaces:%{departurePlaceId1} |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId1}"
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                 |
+      | q                     | departurePlaces:%{departurePlaceId3} |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId1}"
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                 |
+      | q                     | departurePlaces:%{departurePlaceId2} |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId2}"
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                                                        |
+      | q                     | departurePlaces:%{departurePlaceId1} OR departurePlaces:%{departurePlaceId2} |
+    Then I wait for the JSON response at "totalItems" to be 2
+    And the JSON response should include:
+    """
+    %{eventId1}
+    """
+    And the JSON response should include:
+    """
+    %{eventId2}
+    """

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -9,7 +9,7 @@ Feature: Test departure places in search results
     And I create a minimal place and save the "url" as "placeUrl"
 
   @testIsolation
-  Scenario: Departure places are returned in search results
+  Scenario: Departure places are embedded in search results
     When I create a minimal place and save the "url" as "departurePlaceUrl1"
     And I create a minimal place and save the "url" as "departurePlaceUrl2"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId"

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -81,3 +81,62 @@ Feature: Test departure places in search results
     """
     %{eventId2}
     """
+
+  @testIsolation
+  Scenario: Events can be filtered by departure place using the departurePlaces url parameter
+    When I create a minimal place and save the "url" as "departurePlaceUrl1"
+    And I keep the value of the JSON response at "id" as "departurePlaceId1"
+    And I create a minimal place and save the "url" as "departurePlaceUrl2"
+    And I keep the value of the JSON response at "id" as "departurePlaceId2"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId1"
+    And I publish the event at "/events/%{eventId1}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl1}"]
+    """
+    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
+    And I publish the event at "/events/%{eventId2}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl2}"]
+    """
+    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I am using the Search API v3 base URL
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                  |
+      | departurePlaces[]     | %{departurePlaceId1}  |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId1}"
+
+  @testIsolation
+  Scenario: Multiple departure place url parameters use AND logic
+    When I create a minimal place and save the "url" as "departurePlaceUrl1"
+    And I keep the value of the JSON response at "id" as "departurePlaceId1"
+    And I create a minimal place and save the "url" as "departurePlaceUrl2"
+    And I keep the value of the JSON response at "id" as "departurePlaceId2"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId1"
+    And I publish the event at "/events/%{eventId1}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl1}", "%{departurePlaceUrl2}"]
+    """
+    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
+    And I publish the event at "/events/%{eventId2}"
+    And I set the JSON request payload to:
+    """
+    ["%{departurePlaceUrl1}"]
+    """
+    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I am using the Search API v3 base URL
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                  |
+      | departurePlaces[]     | %{departurePlaceId1}  |
+    Then I wait for the JSON response at "totalItems" to be 2
+    And I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                  |
+      | departurePlaces[]     | %{departurePlaceId1}  |
+      | departurePlaces[]     | %{departurePlaceId2}  |
+    Then I wait for the JSON response at "totalItems" to be 1
+    And the JSON response at "member/0/@id" should include "%{eventId1}"

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -23,12 +23,11 @@ Feature: Test departure places in search results
     ]
     """
     And I send a PUT request to "/events/%{eventId}/departurePlaces/"
-    And I wait for the event with url "/events/%{eventId}" to be indexed
     And I am using the Search API v3 base URL
     And I send a GET request to "/events" with parameters:
       | embed                 | true          |
       | disableDefaultFilters | true          |
-    Then the JSON response at "totalItems" should be 1
+    Then I wait for the JSON response at "totalItems" to be 1
     And I wait for the JSON response at "member/0/departurePlaces" to have 2 entries
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl1}"
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl2}"

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -29,6 +29,6 @@ Feature: Test departure places in search results
       | embed                 | true          |
       | disableDefaultFilters | true          |
     Then the JSON response at "totalItems" should be 1
-    And the JSON response at "member/0/departurePlaces" should have 2 entries
+    And I wait for the JSON response at "member/0/departurePlaces" to have 2 entries
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl1}"
     And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl2}"

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -1,0 +1,34 @@
+@sapi3
+Feature: Test departure places in search results
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+    And I create a minimal place and save the "url" as "placeUrl"
+
+  @testIsolation
+  Scenario: Departure places are returned in search results
+    When I create a minimal place and save the "url" as "departurePlaceUrl1"
+    And I create a minimal place and save the "url" as "departurePlaceUrl2"
+    And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId"
+    And I send a GET request to "/events/%{eventId}"
+    And I publish the event at "/events/%{eventId}"
+    And I set the JSON request payload to:
+    """
+    [
+      "%{departurePlaceUrl1}",
+      "%{departurePlaceUrl2}"
+    ]
+    """
+    And I send a PUT request to "/events/%{eventId}/departurePlaces/"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    And I send a GET request to "/events" with parameters:
+      | embed                 | true          |
+      | disableDefaultFilters | true          |
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response at "member/0/departurePlaces" should have 2 entries
+    And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl1}"
+    And the JSON response at "member/0/departurePlaces" should include "%{departurePlaceUrl2}"


### PR DESCRIPTION
### Added
- Add `features/search/departure-places.feature` with four Behat scenarios verifying that departure places are correctly indexed and searchable in SAPI: departure places returned in embedded search results, filtering by departure place UUID via the `q` parameter (including OR queries and events with multiple departure places), filtering via the `departurePlaces[]` URL parameter, and AND logic when multiple `departurePlaces[]` values are provided
- Add `I wait for the JSON response at :jsonPath to have :nrOfEntries entries` Behat step that replays the last GET request in a polling loop (up to 5 seconds) until the array at the given JSON path reaches the expected length, avoiding flaky fixed-duration waits for async SAPI indexing
- Add `I wait for the JSON response at :jsonPath to be :value` Behat step that replays the last GET request in a polling loop (up to 5 seconds) until a scalar value at the given JSON path matches the expected value, used to reliably wait for `totalItems` to reflect the correct count before asserting search results
- Add `lastGetUrl` and `lastGetParams` to `RequestState` so the two new polling steps can replay the most recent parameterised GET request without re-applying the `@testIsolation` scenario label filter a second time

---
Ticket: https://jira.uitdatabank.be/browse/III-7133