### PR TITLE
III-7188: Fix childcare time validation failing for UTC-offset event dates

### DIFF
--- a/features/data/events/sub-event-childcare/event-multiple-with-childcare.json
+++ b/features/data/events/sub-event-childcare/event-multiple-with-childcare.json
@@ -1,11 +1,9 @@
 {
   "mainLanguage": "nl",
-  "name": {"nl": "Event met kinderopvang"},
+  "name": {"nl": "Multiple event met kinderopvang"},
   "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
   "location": {"@id": "%{placeUrl}"},
-  "calendarType": "single",
-  "startDate": "%{startDate}",
-  "endDate": "%{endDate}",
+  "calendarType": "multiple",
   "subEvent": [
     {
       "startDate": "%{startDate}",
@@ -14,6 +12,10 @@
         "start": "%{childcareStart}",
         "end": "%{childcareEnd}"
       }
+    },
+    {
+      "startDate": "%{startDate2}",
+      "endDate": "%{endDate2}"
     }
   ]
 }

--- a/features/data/events/sub-event-childcare/event-single-with-childcare-end-only.json
+++ b/features/data/events/sub-event-childcare/event-single-with-childcare-end-only.json
@@ -1,6 +1,6 @@
 {
   "mainLanguage": "nl",
-  "name": {"nl": "Event met kinderopvang"},
+  "name": {"nl": "Event met gedeeltelijke kinderopvang"},
   "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
   "location": {"@id": "%{placeUrl}"},
   "calendarType": "single",
@@ -10,10 +10,7 @@
     {
       "startDate": "%{startDate}",
       "endDate": "%{endDate}",
-      "childcare": {
-        "start": "%{childcareStart}",
-        "end": "%{childcareEnd}"
-      }
+      "childcare": {"end": "%{childcareEnd}"}
     }
   ]
 }

--- a/features/data/events/sub-event-childcare/event-single-with-childcare-start-only.json
+++ b/features/data/events/sub-event-childcare/event-single-with-childcare-start-only.json
@@ -1,6 +1,6 @@
 {
   "mainLanguage": "nl",
-  "name": {"nl": "Event met kinderopvang"},
+  "name": {"nl": "Event met gedeeltelijke kinderopvang"},
   "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
   "location": {"@id": "%{placeUrl}"},
   "calendarType": "single",
@@ -10,10 +10,7 @@
     {
       "startDate": "%{startDate}",
       "endDate": "%{endDate}",
-      "childcare": {
-        "start": "%{childcareStart}",
-        "end": "%{childcareEnd}"
-      }
+      "childcare": {"start": "%{childcareStart}"}
     }
   ]
 }

--- a/features/data/events/sub-event-childcare/event-single-with-childcare.json
+++ b/features/data/events/sub-event-childcare/event-single-with-childcare.json
@@ -4,12 +4,12 @@
   "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
   "location": {"@id": "%{placeUrl}"},
   "calendarType": "single",
-  "startDate": "2021-05-17T16:00:00+00:00",
-  "endDate": "2021-05-17T22:00:00+00:00",
+  "startDate": "2021-05-17T16:00:00+02:00",
+  "endDate": "2021-05-17T22:00:00+02:00",
   "subEvent": [
     {
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
+      "startDate": "2021-05-17T16:00:00+02:00",
+      "endDate": "2021-05-17T22:00:00+02:00",
       "childcare": {
         "start": "%{childcareStart}",
         "end": "%{childcareEnd}"

--- a/features/data/events/sub-event-childcare/event-single.json
+++ b/features/data/events/sub-event-childcare/event-single.json
@@ -1,6 +1,6 @@
 {
   "mainLanguage": "nl",
-  "name": {"nl": "Event met kinderopvang"},
+  "name": {"nl": "Event"},
   "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
   "location": {"@id": "%{placeUrl}"},
   "calendarType": "single",
@@ -9,11 +9,7 @@
   "subEvent": [
     {
       "startDate": "%{startDate}",
-      "endDate": "%{endDate}",
-      "childcare": {
-        "start": "%{childcareStart}",
-        "end": "%{childcareEnd}"
-      }
+      "endDate": "%{endDate}"
     }
   ]
 }

--- a/features/event/sub-event-childcare-time.feature
+++ b/features/event/sub-event-childcare-time.feature
@@ -7,106 +7,112 @@ Feature: Test SubEvent childcare times
     And I send and accept "application/json"
     And I create a place from "places/place.json" and save the "url" as "placeUrl"
 
-  Scenario: Create an event with childcare times on a single calendar subEvent
-    When I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event met kinderopvang"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
-      "subEvent": [
-        {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T22:00:00+00:00",
-          "childcare": {
-            "start": "15:00",
-            "end": "23:00"
-          }
-        }
-      ]
-    }
-    """
+  Scenario: Create a single-calendar event with childcare times in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
     Then the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "15:00"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
 
-  Scenario: Create an event with childcare times on a multiple calendar subEvent
-    When I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Multiple event met kinderopvang"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "multiple",
-      "subEvent": [
-        {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T22:00:00+00:00",
-          "childcare": {
-            "start": "15:00",
-            "end": "23:00"
-          }
-        },
-        {
-          "startDate": "2021-05-18T16:00:00+00:00",
-          "endDate": "2021-05-18T22:00:00+00:00"
-        }
-      ]
-    }
-    """
+  Scenario: Create a single-calendar event with childcare times in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "childcareStart" to "15:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
     Then the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "15:00"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
-    And the JSON response at "subEvent/1/startDate" should be "2021-05-18T16:00:00+00:00"
-    And the JSON response at "subEvent/1/endDate" should be "2021-05-18T22:00:00+00:00"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
 
-  Scenario: Update childcare times on a subEvent via PATCH
-    Given I set the JSON request payload to:
+  Scenario: Create a multiple-calendar event with childcare times in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "startDate2" to "2021-05-18T16:00:00+02:00"
+    And I set the variable "endDate2" to "2021-05-18T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-multiple-with-childcare.json"
+    And I send a POST request to "/events/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "subEvent/0/childcare" should be:
     """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00"
-    }
+    {"start": "15:00", "end": "23:00"}
     """
+
+  Scenario: Create a multiple-calendar event with childcare times in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "startDate2" to "2021-05-18T14:00:00+00:00"
+    And I set the variable "endDate2" to "2021-05-18T20:00:00+00:00"
+    And I set the variable "childcareStart" to "15:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-multiple-with-childcare.json"
+    And I send a POST request to "/events/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
+
+  Scenario: Add childcare times to a subEvent via PATCH in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the JSON request payload from "events/sub-event-childcare/event-single.json"
     And I send a POST request to "/events/"
     And the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "childcare": {
-          "start": "15:00",
-          "end": "23:00"
-        }
-      }
-    ]
+    [{"id": 0, "childcare": {"start": "15:00", "end": "23:00"}}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "15:00"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
+
+  Scenario: Add childcare times to a subEvent via PATCH in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the JSON request payload from "events/sub-event-childcare/event-single.json"
+    And I send a POST request to "/events/"
+    And the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    [{"id": 0, "childcare": {"start": "15:00", "end": "23:00"}}]
+    """
+    And I send a PATCH request to "%{eventUrl}/subEvents"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
 
   Scenario: Childcare times are preserved when omitted from PATCH
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -114,21 +120,20 @@ Feature: Test SubEvent childcare times
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "status": {"type": "Available"}
-      }
-    ]
+    [{"id": 0, "status": {"type": "Available"}}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "15:00"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00", "end": "23:00"}
+    """
 
   Scenario: Childcare times are cleared when explicitly set to empty in PATCH
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -136,12 +141,7 @@ Feature: Test SubEvent childcare times
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "childcare": {}
-      }
-    ]
+    [{"id": 0, "childcare": {}}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "204"
@@ -152,7 +152,9 @@ Feature: Test SubEvent childcare times
     """
 
   Scenario: Childcare times are cleared when omitted from a PUT calendar update
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -162,12 +164,12 @@ Feature: Test SubEvent childcare times
     """
     {
       "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
+      "startDate": "2021-05-17T16:00:00+02:00",
+      "endDate": "2021-05-17T22:00:00+02:00",
       "subEvent": [
         {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T22:00:00+00:00"
+          "startDate": "2021-05-17T16:00:00+02:00",
+          "endDate": "2021-05-17T22:00:00+02:00"
         }
       ]
     }
@@ -180,92 +182,66 @@ Feature: Test SubEvent childcare times
     "childcare"
     """
 
-  Scenario: Create an event with only childcare.start on a subEvent
-    When I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event met gedeeltelijke kinderopvang"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
-      "subEvent": [
-        {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T22:00:00+00:00",
-          "childcare": {"start": "15:00"}
-        }
-      ]
-    }
-    """
+  Scenario: Create a single-calendar event with only childcare.start in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-start-only.json"
     And I send a POST request to "/events/"
     Then the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "15:00"
-    And the JSON response should not have "subEvent/0/childcare/end"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00"}
+    """
 
-  Scenario: Create an event with only childcare.end on a subEvent
-    When I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event met gedeeltelijke kinderopvang"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
-      "subEvent": [
-        {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T22:00:00+00:00",
-          "childcare": {"end": "23:00"}
-        }
-      ]
-    }
-    """
+  Scenario: Create a single-calendar event with only childcare.start in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "childcareStart" to "15:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-start-only.json"
     And I send a POST request to "/events/"
     Then the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
-    And the JSON response should not have "subEvent/0/childcare/start"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"start": "15:00"}
+    """
 
-  Scenario: Create an event where childcare times are valid in CET but startDate and endDate are sent as UTC
-    When I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event met kinderopvang (UTC datums)"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T20:00:00+00:00",
-      "subEvent": [
-        {
-          "startDate": "2021-05-17T16:00:00+00:00",
-          "endDate": "2021-05-17T20:00:00+00:00",
-          "childcare": {
-            "start": "17:00",
-            "end": "23:00"
-          }
-        }
-      ]
-    }
-    """
+  Scenario: Create a single-calendar event with only childcare.end in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-end-only.json"
     And I send a POST request to "/events/"
     Then the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     And I get the event at "%{eventUrl}"
-    And the JSON response at "subEvent/0/childcare/start" should be "17:00"
-    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"end": "23:00"}
+    """
 
-  Scenario: Cannot create an event when childcare.start equals the startDate time
-    Given I set the variable "childcareStart" to "16:00"
+  Scenario: Create a single-calendar event with only childcare.end in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-end-only.json"
+    And I send a POST request to "/events/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And I get the event at "%{eventUrl}"
+    Then the JSON response at "subEvent/0/childcare" should be:
+    """
+    {"end": "23:00"}
+    """
+
+  Scenario: Cannot create an event when childcare.start equals the startDate time in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "16:00"
     And I set the variable "childcareEnd" to "23:00"
     When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -273,8 +249,10 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/start"
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
-  Scenario: Cannot create an event when childcare.start is after the startDate time
-    Given I set the variable "childcareStart" to "17:00"
+  Scenario: Cannot create an event when childcare.start equals the startDate time in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "childcareStart" to "16:00"
     And I set the variable "childcareEnd" to "23:00"
     When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -282,8 +260,21 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/start"
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
-  Scenario: Cannot create an event when childcare.end equals the endDate time
-    Given I set the variable "childcareStart" to "15:00"
+  Scenario: Cannot create an event when childcare.start is after the startDate time in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "17:00"
+    And I set the variable "childcareEnd" to "23:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
+    And I send a POST request to "/events/"
+    Then the response status should be "400"
+    And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/start"
+    And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
+
+  Scenario: Cannot create an event when childcare.end equals the endDate time in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "22:00"
     When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -291,8 +282,21 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/end"
     And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
 
-  Scenario: Cannot create an event when childcare.end is before the endDate time
-    Given I set the variable "childcareStart" to "15:00"
+  Scenario: Cannot create an event when childcare.end equals the endDate time in UTC
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
+    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
+    And I set the variable "childcareStart" to "15:00"
+    And I set the variable "childcareEnd" to "22:00"
+    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
+    And I send a POST request to "/events/"
+    Then the response status should be "400"
+    And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/end"
+    And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
+
+  Scenario: Cannot create an event when childcare.end is before the endDate time in CET
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "21:00"
     When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -301,7 +305,9 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
 
   Scenario: Cannot PATCH a subEvent when the new startDate makes the existing childcare.start invalid
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -313,10 +319,7 @@ Feature: Test SubEvent childcare times
       {
         "id": 0,
         "startDate": "2021-05-17T14:00:00+02:00",
-        "childcare": {
-          "start": "15:00",
-          "end": "23:00"
-        }
+        "childcare": {"start": "15:00", "end": "23:00"}
       }
     ]
     """
@@ -326,7 +329,9 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
   Scenario: Cannot PATCH a subEvent when the new endDate makes the existing childcare.end invalid
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -338,10 +343,7 @@ Feature: Test SubEvent childcare times
       {
         "id": 0,
         "endDate": "2021-05-17T23:30:00+02:00",
-        "childcare": {
-          "start": "15:00",
-          "end": "23:00"
-        }
+        "childcare": {"start": "15:00", "end": "23:00"}
       }
     ]
     """
@@ -351,32 +353,15 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
 
   Scenario: Cannot PATCH a subEvent with childcare.start not before the stored startDate time
-    Given I set the JSON request payload to:
-    """
-    {
-      "mainLanguage": "nl",
-      "name": {"nl": "Event"},
-      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
-      "location": {"@id": "%{placeUrl}"},
-      "calendarType": "single",
-      "startDate": "2021-05-17T14:00:00+02:00",
-      "endDate": "2021-05-17T22:00:00+02:00"
-    }
-    """
+    Given I set the variable "startDate" to "2021-05-17T14:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the JSON request payload from "events/sub-event-childcare/event-single.json"
     And I send a POST request to "/events/"
     And the response status should be "201"
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "childcare": {
-          "start": "16:00",
-          "end": "23:00"
-        }
-      }
-    ]
+    [{"id": 0, "childcare": {"start": "16:00", "end": "23:00"}}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "400"
@@ -384,7 +369,9 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
   Scenario: Cannot PATCH a subEvent with a new startDate that makes the preserved childcare.start invalid
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -392,12 +379,7 @@ Feature: Test SubEvent childcare times
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "startDate": "2021-05-17T15:00:00+02:00"
-      }
-    ]
+    [{"id": 0, "startDate": "2021-05-17T15:00:00+02:00"}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "400"
@@ -405,7 +387,9 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
   Scenario: Cannot PATCH a subEvent with a new endDate that makes the preserved childcare.end invalid
-    Given I set the variable "childcareStart" to "15:00"
+    Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
+    And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
+    And I set the variable "childcareStart" to "15:00"
     And I set the variable "childcareEnd" to "23:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
     And I send a POST request to "/events/"
@@ -413,12 +397,7 @@ Feature: Test SubEvent childcare times
     And I keep the value of the JSON response at "url" as "eventUrl"
     When I set the JSON request payload to:
     """
-    [
-      {
-        "id": 0,
-        "endDate": "2021-05-17T23:00:00+02:00"
-      }
-    ]
+    [{"id": 0, "endDate": "2021-05-17T23:00:00+02:00"}]
     """
     And I send a PATCH request to "%{eventUrl}/subEvents"
     Then the response status should be "400"

--- a/features/event/sub-event-childcare-time.feature
+++ b/features/event/sub-event-childcare-time.feature
@@ -234,6 +234,36 @@ Feature: Test SubEvent childcare times
     And the JSON response at "subEvent/0/childcare/end" should be "23:00"
     And the JSON response should not have "subEvent/0/childcare/start"
 
+  Scenario: Create an event where childcare times are valid in CET but startDate and endDate are sent as UTC
+    When I set the JSON request payload to:
+    """
+    {
+      "mainLanguage": "nl",
+      "name": {"nl": "Event met kinderopvang (UTC datums)"},
+      "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
+      "location": {"@id": "%{placeUrl}"},
+      "calendarType": "single",
+      "startDate": "2021-05-17T16:00:00+00:00",
+      "endDate": "2021-05-17T20:00:00+00:00",
+      "subEvent": [
+        {
+          "startDate": "2021-05-17T16:00:00+00:00",
+          "endDate": "2021-05-17T20:00:00+00:00",
+          "childcare": {
+            "start": "17:00",
+            "end": "23:00"
+          }
+        }
+      ]
+    }
+    """
+    And I send a POST request to "/events/"
+    Then the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "subEvent/0/childcare/start" should be "17:00"
+    And the JSON response at "subEvent/0/childcare/end" should be "23:00"
+
   Scenario: Cannot create an event when childcare.start equals the startDate time
     Given I set the variable "childcareStart" to "16:00"
     And I set the variable "childcareEnd" to "23:00"
@@ -282,7 +312,7 @@ Feature: Test SubEvent childcare times
     [
       {
         "id": 0,
-        "startDate": "2021-05-17T14:00:00+00:00",
+        "startDate": "2021-05-17T14:00:00+02:00",
         "childcare": {
           "start": "15:00",
           "end": "23:00"
@@ -307,7 +337,7 @@ Feature: Test SubEvent childcare times
     [
       {
         "id": 0,
-        "endDate": "2021-05-17T23:30:00+00:00",
+        "endDate": "2021-05-17T23:30:00+02:00",
         "childcare": {
           "start": "15:00",
           "end": "23:00"
@@ -329,8 +359,8 @@ Feature: Test SubEvent childcare times
       "terms": [{"id": "0.50.4.0.0", "label": "Concert", "domain": "eventtype"}],
       "location": {"@id": "%{placeUrl}"},
       "calendarType": "single",
-      "startDate": "2021-05-17T16:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00"
+      "startDate": "2021-05-17T14:00:00+02:00",
+      "endDate": "2021-05-17T22:00:00+02:00"
     }
     """
     And I send a POST request to "/events/"
@@ -365,7 +395,7 @@ Feature: Test SubEvent childcare times
     [
       {
         "id": 0,
-        "startDate": "2021-05-17T14:00:00+00:00"
+        "startDate": "2021-05-17T15:00:00+02:00"
       }
     ]
     """
@@ -386,7 +416,7 @@ Feature: Test SubEvent childcare times
     [
       {
         "id": 0,
-        "endDate": "2021-05-17T23:30:00+00:00"
+        "endDate": "2021-05-17T23:00:00+02:00"
       }
     ]
     """

--- a/features/event/sub-event-childcare-time.feature
+++ b/features/event/sub-event-childcare-time.feature
@@ -37,7 +37,7 @@ Feature: Test SubEvent childcare times
     {"start": "15:00", "end": "23:00"}
     """
 
-  Scenario: Create a multiple-calendar event with childcare times in CET
+  Scenario: Create a multiple-calendar event with childcare times
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
     And I set the variable "startDate2" to "2021-05-18T16:00:00+02:00"
@@ -54,45 +54,9 @@ Feature: Test SubEvent childcare times
     {"start": "15:00", "end": "23:00"}
     """
 
-  Scenario: Create a multiple-calendar event with childcare times in UTC
-    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
-    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
-    And I set the variable "startDate2" to "2021-05-18T14:00:00+00:00"
-    And I set the variable "endDate2" to "2021-05-18T20:00:00+00:00"
-    And I set the variable "childcareStart" to "15:00"
-    And I set the variable "childcareEnd" to "23:00"
-    When I set the JSON request payload from "events/sub-event-childcare/event-multiple-with-childcare.json"
-    And I send a POST request to "/events/"
-    Then the response status should be "201"
-    And I keep the value of the JSON response at "url" as "eventUrl"
-    And I get the event at "%{eventUrl}"
-    Then the JSON response at "subEvent/0/childcare" should be:
-    """
-    {"start": "15:00", "end": "23:00"}
-    """
-
-  Scenario: Add childcare times to a subEvent via PATCH in CET
+  Scenario: Add childcare times to a subEvent via PATCH
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
-    And I set the JSON request payload from "events/sub-event-childcare/event-single.json"
-    And I send a POST request to "/events/"
-    And the response status should be "201"
-    And I keep the value of the JSON response at "url" as "eventUrl"
-    When I set the JSON request payload to:
-    """
-    [{"id": 0, "childcare": {"start": "15:00", "end": "23:00"}}]
-    """
-    And I send a PATCH request to "%{eventUrl}/subEvents"
-    Then the response status should be "204"
-    And I get the event at "%{eventUrl}"
-    Then the JSON response at "subEvent/0/childcare" should be:
-    """
-    {"start": "15:00", "end": "23:00"}
-    """
-
-  Scenario: Add childcare times to a subEvent via PATCH in UTC
-    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
-    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
     And I set the JSON request payload from "events/sub-event-childcare/event-single.json"
     And I send a POST request to "/events/"
     And the response status should be "201"
@@ -182,7 +146,7 @@ Feature: Test SubEvent childcare times
     "childcare"
     """
 
-  Scenario: Create a single-calendar event with only childcare.start in CET
+  Scenario: Create a single-calendar event with only childcare.start
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
     And I set the variable "childcareStart" to "15:00"
@@ -196,37 +160,9 @@ Feature: Test SubEvent childcare times
     {"start": "15:00"}
     """
 
-  Scenario: Create a single-calendar event with only childcare.start in UTC
-    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
-    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
-    And I set the variable "childcareStart" to "15:00"
-    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-start-only.json"
-    And I send a POST request to "/events/"
-    Then the response status should be "201"
-    And I keep the value of the JSON response at "url" as "eventUrl"
-    And I get the event at "%{eventUrl}"
-    Then the JSON response at "subEvent/0/childcare" should be:
-    """
-    {"start": "15:00"}
-    """
-
-  Scenario: Create a single-calendar event with only childcare.end in CET
+  Scenario: Create a single-calendar event with only childcare.end
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
-    And I set the variable "childcareEnd" to "23:00"
-    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-end-only.json"
-    And I send a POST request to "/events/"
-    Then the response status should be "201"
-    And I keep the value of the JSON response at "url" as "eventUrl"
-    And I get the event at "%{eventUrl}"
-    Then the JSON response at "subEvent/0/childcare" should be:
-    """
-    {"end": "23:00"}
-    """
-
-  Scenario: Create a single-calendar event with only childcare.end in UTC
-    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
-    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
     And I set the variable "childcareEnd" to "23:00"
     When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare-end-only.json"
     And I send a POST request to "/events/"
@@ -260,7 +196,7 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/start"
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
-  Scenario: Cannot create an event when childcare.start is after the startDate time in CET
+  Scenario: Cannot create an event when childcare.start is after the startDate time
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
     And I set the variable "childcareStart" to "17:00"
@@ -271,7 +207,7 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/start"
     And the JSON response at "schemaErrors/0/error" should be "childcare.start must be before the time portion of startDate"
 
-  Scenario: Cannot create an event when childcare.end equals the endDate time in CET
+  Scenario: Cannot create an event when childcare.end equals the endDate time
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
     And I set the variable "childcareStart" to "15:00"
@@ -282,18 +218,7 @@ Feature: Test SubEvent childcare times
     And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/end"
     And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
 
-  Scenario: Cannot create an event when childcare.end equals the endDate time in UTC
-    Given I set the variable "startDate" to "2021-05-17T14:00:00+00:00"
-    And I set the variable "endDate" to "2021-05-17T20:00:00+00:00"
-    And I set the variable "childcareStart" to "15:00"
-    And I set the variable "childcareEnd" to "22:00"
-    When I set the JSON request payload from "events/sub-event-childcare/event-single-with-childcare.json"
-    And I send a POST request to "/events/"
-    Then the response status should be "400"
-    And the JSON response at "schemaErrors/0/jsonPointer" should be "/subEvent/0/childcare/end"
-    And the JSON response at "schemaErrors/0/error" should be "childcare.end must be after the time portion of endDate"
-
-  Scenario: Cannot create an event when childcare.end is before the endDate time in CET
+  Scenario: Cannot create an event when childcare.end is before the endDate time
     Given I set the variable "startDate" to "2021-05-17T16:00:00+02:00"
     And I set the variable "endDate" to "2021-05-17T22:00:00+02:00"
     And I set the variable "childcareStart" to "15:00"

--- a/src/Model/ValueObject/TimeImmutableRange.php
+++ b/src/Model/ValueObject/TimeImmutableRange.php
@@ -70,6 +70,7 @@ final class TimeImmutableRange
 
     private function dateTimeToMinutes(DateTimeImmutable $dateTime): int
     {
-        return (int) $dateTime->format('H') * 60 + (int) $dateTime->format('i');
+        $local = $dateTime->setTimezone(new \DateTimeZone('Europe/Brussels'));
+        return (int) $local->format('H') * 60 + (int) $local->format('i');
     }
 }

--- a/src/Model/ValueObject/TimeImmutableRange.php
+++ b/src/Model/ValueObject/TimeImmutableRange.php
@@ -71,7 +71,7 @@ final class TimeImmutableRange
 
     private function dateTimeToMinutes(DateTimeImmutable $dateTime): int
     {
-        // Childcare applies exclusively to Flanders; HH:mm times are always entered in Brussels local time.
+        // We always handle HH:mm time information as Brussels local time. To compare it to a datetime, the datetime should also be converted to Europe/Brussels
         $local = $dateTime->setTimezone(new DateTimeZone('Europe/Brussels'));
         return (int) $local->format('H') * 60 + (int) $local->format('i');
     }

--- a/src/Model/ValueObject/TimeImmutableRange.php
+++ b/src/Model/ValueObject/TimeImmutableRange.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\ValueObject;
 
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use DateTimeImmutable;
+use DateTimeZone;
 use InvalidArgumentException;
 
 final class TimeImmutableRange
@@ -70,7 +71,8 @@ final class TimeImmutableRange
 
     private function dateTimeToMinutes(DateTimeImmutable $dateTime): int
     {
-        $local = $dateTime->setTimezone(new \DateTimeZone('Europe/Brussels'));
+        // Childcare applies exclusively to Flanders; HH:mm times are always entered in Brussels local time.
+        $local = $dateTime->setTimezone(new DateTimeZone('Europe/Brussels'));
         return (int) $local->format('H') * 60 + (int) $local->format('i');
     }
 }

--- a/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
@@ -85,8 +85,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new LocationId('d0cd4e9d-3cf1-4324-9835-2bfba63ac015'),
             new PeriodicCalendar(
                 new DateRange(
-                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                    new DateTimeImmutable('2020-01-01 12:00:00')
+                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                 ),
                 new OpeningHours()
             )
@@ -115,8 +115,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new SingleSubEventCalendar(
                 SubEvent::createAvailable(
                     new DateRange(
-                        new DateTimeImmutable('2020-01-01 10:00:00'),
-                        new DateTimeImmutable('2020-01-01 12:00:00')
+                        new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                        new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                     )
                 )
             )
@@ -159,14 +159,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -174,7 +174,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                 ),
                 new UpdateSubEvents(
                     '1',
-                    (new SubEventUpdate(1))->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00'))
+                    (new SubEventUpdate(1))->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00+01:00'))
                 ),
                 new CalendarUpdated(
                     '1',
@@ -182,14 +182,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-29 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2019-12-29 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -207,14 +207,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -223,8 +223,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                 new UpdateSubEvents(
                     '1',
                     (new SubEventUpdate(1))
-                        ->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00'))
-                        ->withEndDate(new DateTimeImmutable('2019-12-29 12:00:00'))
+                        ->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00+01:00'))
+                        ->withEndDate(new DateTimeImmutable('2019-12-29 12:00:00+01:00'))
                 ),
                 new CalendarUpdated(
                     '1',
@@ -232,14 +232,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-29 10:00:00'),
-                                    new DateTimeImmutable('2019-12-29 12:00:00')
+                                    new DateTimeImmutable('2019-12-29 10:00:00+01:00'),
+                                    new DateTimeImmutable('2019-12-29 12:00:00+01:00')
                                 )
                             )
                         )
@@ -257,14 +257,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -272,8 +272,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                 ),
                 new UpdateSubEvents(
                     '1',
-                    (new SubEventUpdate(0))->withStartDate(new DateTimeImmutable('2019-12-31 10:00:00')),
-                    (new SubEventUpdate(1))->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00'))
+                    (new SubEventUpdate(0))->withStartDate(new DateTimeImmutable('2019-12-31 10:00:00+01:00')),
+                    (new SubEventUpdate(1))->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00+01:00'))
                 ),
                 new CalendarUpdated(
                     '1',
@@ -281,14 +281,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-31 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2019-12-31 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-29 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2019-12-29 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -306,14 +306,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -322,11 +322,11 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                 new UpdateSubEvents(
                     '1',
                     (new SubEventUpdate(0))
-                        ->withStartDate(new DateTimeImmutable('2019-12-31 10:00:00'))
-                        ->withEndDate(new DateTimeImmutable('2019-12-31 12:00:00')),
+                        ->withStartDate(new DateTimeImmutable('2019-12-31 10:00:00+01:00'))
+                        ->withEndDate(new DateTimeImmutable('2019-12-31 12:00:00+01:00')),
                     (new SubEventUpdate(1))
-                        ->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00'))
-                        ->withEndDate(new DateTimeImmutable('2019-12-29 12:00:00'))
+                        ->withStartDate(new DateTimeImmutable('2019-12-29 10:00:00+01:00'))
+                        ->withEndDate(new DateTimeImmutable('2019-12-29 12:00:00+01:00'))
                 ),
                 new CalendarUpdated(
                     '1',
@@ -334,14 +334,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-31 10:00:00'),
-                                    new DateTimeImmutable('2019-12-31 12:00:00')
+                                    new DateTimeImmutable('2019-12-31 10:00:00+01:00'),
+                                    new DateTimeImmutable('2019-12-31 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2019-12-29 10:00:00'),
-                                    new DateTimeImmutable('2019-12-29 12:00:00')
+                                    new DateTimeImmutable('2019-12-29 10:00:00+01:00'),
+                                    new DateTimeImmutable('2019-12-29 12:00:00+01:00')
                                 )
                             )
                         )
@@ -359,14 +359,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                        new SubEvents(
                            SubEvent::createAvailable(
                                new DateRange(
-                                   new DateTimeImmutable('2020-01-01 10:00:00'),
-                                   new DateTimeImmutable('2020-01-01 12:00:00')
+                                   new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                   new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                )
                            ),
                            SubEvent::createAvailable(
                                new DateRange(
-                                   new DateTimeImmutable('2020-01-03 10:00:00'),
-                                   new DateTimeImmutable('2020-01-03 12:00:00')
+                                   new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                   new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                )
                            )
                        )
@@ -390,14 +390,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -423,14 +423,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -463,8 +463,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -477,8 +477,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -504,14 +504,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -531,14 +531,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withBookingAvailability(BookingAvailability::Unavailable()),
                         )
@@ -556,14 +556,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -588,14 +588,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ))->withBookingAvailability(BookingAvailability::Unavailable()),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withBookingAvailability(BookingAvailability::Unavailable()),
                         )
@@ -613,14 +613,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -650,14 +650,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -683,14 +683,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -710,14 +710,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withBookingInfo(
                                 (new BookingInfo())
@@ -739,14 +739,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -762,14 +762,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withBookingAvailability(BookingAvailability::Unavailable()),
                         )
@@ -786,8 +786,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                     (new SingleSubEventCalendar(
                         SubEvent::createAvailable(
                             new DateRange(
-                                new DateTimeImmutable('2020-01-01 10:00:00'),
-                                new DateTimeImmutable('2020-01-01 12:00:00')
+                                new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                             )
                         )
                     ))->withBookingAvailability(BookingAvailability::Available()->withCapacity(100))
@@ -801,8 +801,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                     (new SingleSubEventCalendar(
                         (SubEvent::createAvailable(
                             new DateRange(
-                                new DateTimeImmutable('2020-01-01 10:00:00'),
-                                new DateTimeImmutable('2020-01-01 12:00:00')
+                                new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                             )
                         ))->withBookingAvailability(BookingAvailability::Unavailable())
                     ))->withBookingAvailability(BookingAvailability::Available()->withCapacity(100))
@@ -819,14 +819,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withBookingInfo(
                                 (new BookingInfo())
@@ -846,14 +846,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ),
                         )
@@ -871,14 +871,14 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             )
                         )
@@ -923,8 +923,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -937,8 +937,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             )->withBookingAvailability(BookingAvailability::Unavailable()),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 12:00:00')
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-03 12:00:00+01:00')
                                 )
                             ))->withStatus(
                                 new Status(
@@ -964,13 +964,13 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
                                     new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             )
@@ -987,13 +987,13 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
                                     new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00'))),
@@ -1012,13 +1012,13 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
                                     new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00')))
@@ -1035,13 +1035,13 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                         new SubEvents(
                             SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-01 10:00:00'),
-                                    new DateTimeImmutable('2020-01-01 12:00:00')
+                                    new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                                    new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                                 )
                             ),
                             (SubEvent::createAvailable(
                                 new DateRange(
-                                    new DateTimeImmutable('2020-01-03 10:00:00'),
+                                    new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
                                     new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(null, null)),
@@ -1067,13 +1067,13 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                 new SubEvents(
                     SubEvent::createAvailable(
                         new DateRange(
-                            new DateTimeImmutable('2020-01-01 10:00:00'),
-                            new DateTimeImmutable('2020-01-01 12:00:00')
+                            new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                            new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                         )
                     ),
                     (SubEvent::createAvailable(
                         new DateRange(
-                            new DateTimeImmutable('2020-01-03 10:00:00'),
+                            new DateTimeImmutable('2020-01-03 10:00:00+01:00'),
                             new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                         )
                     ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00')))
@@ -1133,8 +1133,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new SingleSubEventCalendar(
                 SubEvent::createAvailable(
                     new DateRange(
-                        new DateTimeImmutable('2020-01-01 10:00:00'),
-                        new DateTimeImmutable('2020-01-01 12:00:00')
+                        new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                        new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                     )
                 )
             )
@@ -1164,8 +1164,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new SingleSubEventCalendar(
                 (SubEvent::createAvailable(
                     new DateRange(
-                        new DateTimeImmutable('2020-01-01 16:00:00'),
-                        new DateTimeImmutable('2020-01-01 22:00:00')
+                        new DateTimeImmutable('2020-01-01 16:00:00+01:00'),
+                        new DateTimeImmutable('2020-01-01 22:00:00+01:00')
                     )
                 ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('15:00'), Time::fromString('23:00')))
             )
@@ -1178,7 +1178,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
         $this->scenario
             ->withAggregateId('1')
             ->given([$eventCreated])
-            ->when(new UpdateSubEvents('1', (new SubEventUpdate(0))->withStartDate(new DateTimeImmutable('2020-01-01 14:00:00'))))
+            ->when(new UpdateSubEvents('1', (new SubEventUpdate(0))->withStartDate(new DateTimeImmutable('2020-01-01 14:00:00+01:00'))))
             ->then([]);
     }
 
@@ -1196,8 +1196,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new SingleSubEventCalendar(
                 (SubEvent::createAvailable(
                     new DateRange(
-                        new DateTimeImmutable('2020-01-01 16:00:00'),
-                        new DateTimeImmutable('2020-01-01 22:00:00')
+                        new DateTimeImmutable('2020-01-01 16:00:00+01:00'),
+                        new DateTimeImmutable('2020-01-01 22:00:00+01:00')
                     )
                 ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('15:00'), Time::fromString('23:00')))
             )

--- a/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
@@ -1001,6 +1001,40 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                     )
                 ),
             ],
+            'Update childcare times that are valid in CET against UTC-stored sub-event dates' => [
+                // Stored dates are UTC. 14:00 UTC = 15:00 CET; 20:00 UTC = 21:00 CET.
+                // childcare.start 14:30 is before 15:00 CET (valid) but after 14:00 UTC (was a false error).
+                new EventCreated(
+                    '1',
+                    new Language('nl'),
+                    'Single Event',
+                    new Category(new CategoryID('0.50.4.0.0'), new CategoryLabel('Concert'), CategoryDomain::eventType()),
+                    new LocationId('d0cd4e9d-3cf1-4324-9835-2bfba63ac015'),
+                    new SingleSubEventCalendar(
+                        SubEvent::createAvailable(
+                            new DateRange(
+                                new DateTimeImmutable('2020-01-03 14:00:00+00:00'),
+                                new DateTimeImmutable('2020-01-03 20:00:00+00:00')
+                            )
+                        )
+                    )
+                ),
+                new UpdateSubEvents(
+                    '1',
+                    (new SubEventUpdate(0))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('14:30'), Time::fromString('22:00')))
+                ),
+                new CalendarUpdated(
+                    '1',
+                    new SingleSubEventCalendar(
+                        (SubEvent::createAvailable(
+                            new DateRange(
+                                new DateTimeImmutable('2020-01-03 14:00:00+00:00'),
+                                new DateTimeImmutable('2020-01-03 20:00:00+00:00')
+                            )
+                        ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('14:30'), Time::fromString('22:00')))
+                    )
+                ),
+            ],
             'Clear childcare times when explicitly set to empty' => [
                 new EventCreated(
                     '1',

--- a/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
+++ b/tests/Event/CommandHandlers/UpdateSubEventsHandlerTest.php
@@ -971,7 +971,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             SubEvent::createAvailable(
                                 new DateRange(
                                     new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 13:00:00')
+                                    new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             )
                         )
@@ -994,7 +994,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             (SubEvent::createAvailable(
                                 new DateRange(
                                     new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 13:00:00')
+                                    new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00'))),
                         )
@@ -1019,7 +1019,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             (SubEvent::createAvailable(
                                 new DateRange(
                                     new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 13:00:00')
+                                    new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00')))
                         )
@@ -1042,7 +1042,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                             (SubEvent::createAvailable(
                                 new DateRange(
                                     new DateTimeImmutable('2020-01-03 10:00:00'),
-                                    new DateTimeImmutable('2020-01-03 13:00:00')
+                                    new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                                 )
                             ))->withChildcareTimeRange(new TimeImmutableRange(null, null)),
                         )
@@ -1074,7 +1074,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
                     (SubEvent::createAvailable(
                         new DateRange(
                             new DateTimeImmutable('2020-01-03 10:00:00'),
-                            new DateTimeImmutable('2020-01-03 13:00:00')
+                            new DateTimeImmutable('2020-01-03 13:00:00+01:00')
                         )
                     ))->withChildcareTimeRange(new TimeImmutableRange(Time::fromString('9:00'), Time::fromString('14:00')))
                 )
@@ -1102,8 +1102,8 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
             new SingleSubEventCalendar(
                 SubEvent::createAvailable(
                     new DateRange(
-                        new DateTimeImmutable('2020-01-01 10:00:00'),
-                        new DateTimeImmutable('2020-01-01 12:00:00')
+                        new DateTimeImmutable('2020-01-01 10:00:00+01:00'),
+                        new DateTimeImmutable('2020-01-01 12:00:00+01:00')
                     )
                 )
             )
@@ -1210,7 +1210,7 @@ final class UpdateSubEventsHandlerTest extends CommandHandlerScenarioTestCase
         $this->scenario
             ->withAggregateId('1')
             ->given([$eventCreated])
-            ->when(new UpdateSubEvents('1', (new SubEventUpdate(0))->withEndDate(new DateTimeImmutable('2020-01-01 23:30:00'))))
+            ->when(new UpdateSubEvents('1', (new SubEventUpdate(0))->withEndDate(new DateTimeImmutable('2020-01-01 23:00:00+01:00'))))
             ->then([]);
     }
 }

--- a/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
+++ b/tests/Http/Event/UpdateSubEventsRequestHandlerTest.php
@@ -605,8 +605,8 @@ final class UpdateSubEventsRequestHandlerTest extends TestCase
                 'data' => [
                     (object)[
                         'id' => 0,
-                        'startDate' => '2020-01-01T10:00:00+00:00',
-                        'endDate' => '2020-01-01T12:00:00+00:00',
+                        'startDate' => '2020-01-01T10:00:00+01:00',
+                        'endDate' => '2020-01-01T12:00:00+01:00',
                         'childcare' => (object)['start' => '10:00', 'end' => '23:00'],
                     ],
                 ],

--- a/tests/Http/Offer/ChildcareTimeValidatorTest.php
+++ b/tests/Http/Offer/ChildcareTimeValidatorTest.php
@@ -64,8 +64,8 @@ final class ChildcareTimeValidatorTest extends TestCase
         string $childcareStart
     ): void {
         $errors = $this->validator->validate((object) [
-            'startDate' => '2021-05-17T16:00:00+00:00',
-            'endDate' => '2021-05-17T22:00:00+00:00',
+            'startDate' => '2021-05-17T16:00:00+02:00',
+            'endDate' => '2021-05-17T22:00:00+02:00',
             'childcare' => (object)['start' => $childcareStart, 'end' => '23:00'],
         ]);
 
@@ -90,8 +90,8 @@ final class ChildcareTimeValidatorTest extends TestCase
         string $childcareEnd
     ): void {
         $errors = $this->validator->validate((object) [
-            'startDate' => '2021-05-17T16:00:00+00:00',
-            'endDate' => '2021-05-17T22:00:00+00:00',
+            'startDate' => '2021-05-17T16:00:00+02:00',
+            'endDate' => '2021-05-17T22:00:00+02:00',
             'childcare' => (object)['start' => '15:00', 'end' => $childcareEnd],
         ]);
 
@@ -114,12 +114,29 @@ final class ChildcareTimeValidatorTest extends TestCase
     public function it_returns_both_errors_when_both_childcare_times_are_invalid(): void
     {
         $errors = $this->validator->validate((object) [
-            'startDate' => '2021-05-17T16:00:00+00:00',
-            'endDate' => '2021-05-17T22:00:00+00:00',
+            'startDate' => '2021-05-17T16:00:00+02:00',
+            'endDate' => '2021-05-17T22:00:00+02:00',
             'childcare' => (object)['start' => '17:00', 'end' => '21:00'],
         ]);
 
         $this->assertCount(2, $errors);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_errors_when_childcare_times_are_valid_in_cet_but_dates_are_sent_as_utc(): void
+    {
+        // startDate 16:00 UTC = 18:00 CEST; endDate 20:00 UTC = 22:00 CEST.
+        // childcare.start 17:00 and childcare.end 23:00 are valid in CEST but were previously
+        // rejected because the comparison happened against raw UTC hours.
+        $errors = $this->validator->validate((object) [
+            'startDate' => '2021-05-17T16:00:00+00:00',
+            'endDate' => '2021-05-17T20:00:00+00:00',
+            'childcare' => (object)['start' => '17:00', 'end' => '23:00'],
+        ]);
+
+        $this->assertEmpty($errors);
     }
 
     /**
@@ -155,8 +172,8 @@ final class ChildcareTimeValidatorTest extends TestCase
     {
         $errors = $this->validator->validate(
             (object) [
-                'startDate' => '2021-05-17T16:00:00+00:00',
-                'endDate' => '2021-05-17T22:00:00+00:00',
+                'startDate' => '2021-05-17T16:00:00+02:00',
+                'endDate' => '2021-05-17T22:00:00+02:00',
                 'childcare' => (object)['start' => '17:00', 'end' => '23:00'],
             ],
             '/subEvent/0'

--- a/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
+++ b/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
@@ -220,32 +220,40 @@ final class TimeImmutableRangeTest extends TestCase
         Time::fromString('15:00:00');
     }
 
-    /** @test */
-    public function start_is_before_time_of_compares_in_europe_brussels(): void
+    /**
+     * @test
+     */
+    public function it_returns_true_from_start_is_before_time_of_when_start_is_before_in_europe_brussels(): void
     {
         $range = new TimeImmutableRange(Time::fromString('17:00'));
         // 16:00 UTC == 18:00 CEST → 17:00 is before 18:00.
         $this->assertTrue($range->startIsBeforeTimeOf(new DateTimeImmutable('2021-05-17T16:00:00+00:00')));
     }
 
-    /** @test */
-    public function start_is_before_time_of_returns_false_when_start_is_not_before_in_europe_brussels(): void
+    /**
+     * @test
+     */
+    public function it_returns_false_from_start_is_before_time_of_when_start_is_not_before_in_europe_brussels(): void
     {
         $range = new TimeImmutableRange(Time::fromString('17:00'));
         // 15:00 UTC == 17:00 CEST → 17:00 is NOT before 17:00.
         $this->assertFalse($range->startIsBeforeTimeOf(new DateTimeImmutable('2021-05-17T15:00:00+00:00')));
     }
 
-    /** @test */
-    public function end_is_after_time_of_compares_in_europe_brussels(): void
+    /**
+     * @test
+     */
+    public function it_returns_true_from_end_is_after_time_of_when_end_is_after_in_europe_brussels(): void
     {
         $range = new TimeImmutableRange(null, Time::fromString('23:00'));
         // 20:00 UTC == 22:00 CEST → 23:00 is after 22:00.
         $this->assertTrue($range->endIsAfterTimeOf(new DateTimeImmutable('2021-05-17T20:00:00+00:00')));
     }
 
-    /** @test */
-    public function end_is_after_time_of_returns_false_when_end_is_not_after_in_europe_brussels(): void
+    /**
+     * @test
+     */
+    public function it_returns_false_from_end_is_after_time_of_when_end_is_not_after_in_europe_brussels(): void
     {
         $range = new TimeImmutableRange(null, Time::fromString('22:00'));
         // 21:00 UTC == 23:00 CEST → 22:00 is NOT after 23:00.

--- a/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
+++ b/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
@@ -224,6 +224,31 @@ final class TimeImmutableRangeTest extends TestCase
     public function start_is_before_time_of_compares_in_europe_brussels(): void
     {
         $range = new TimeImmutableRange(Time::fromString('17:00'));
+        // 16:00 UTC == 18:00 CEST → 17:00 is before 18:00.
         $this->assertTrue($range->startIsBeforeTimeOf(new DateTimeImmutable('2021-05-17T16:00:00+00:00')));
+    }
+
+    /** @test */
+    public function start_is_before_time_of_returns_false_when_start_is_not_before_in_europe_brussels(): void
+    {
+        $range = new TimeImmutableRange(Time::fromString('17:00'));
+        // 15:00 UTC == 17:00 CEST → 17:00 is NOT before 17:00.
+        $this->assertFalse($range->startIsBeforeTimeOf(new DateTimeImmutable('2021-05-17T15:00:00+00:00')));
+    }
+
+    /** @test */
+    public function end_is_after_time_of_compares_in_europe_brussels(): void
+    {
+        $range = new TimeImmutableRange(null, Time::fromString('23:00'));
+        // 20:00 UTC == 22:00 CEST → 23:00 is after 22:00.
+        $this->assertTrue($range->endIsAfterTimeOf(new DateTimeImmutable('2021-05-17T20:00:00+00:00')));
+    }
+
+    /** @test */
+    public function end_is_after_time_of_returns_false_when_end_is_not_after_in_europe_brussels(): void
+    {
+        $range = new TimeImmutableRange(null, Time::fromString('22:00'));
+        // 21:00 UTC == 23:00 CEST → 22:00 is NOT after 23:00.
+        $this->assertFalse($range->endIsAfterTimeOf(new DateTimeImmutable('2021-05-17T21:00:00+00:00')));
     }
 }

--- a/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
+++ b/tests/Model/ValueObject/Calendar/TimeImmutableRangeTest.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use CultuurNet\UDB3\Model\ValueObject\TimeImmutableRange;
+use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -217,5 +218,12 @@ final class TimeImmutableRangeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         Time::fromString('15:00:00');
+    }
+
+    /** @test */
+    public function start_is_before_time_of_compares_in_europe_brussels(): void
+    {
+        $range = new TimeImmutableRange(Time::fromString('17:00'));
+        $this->assertTrue($range->startIsBeforeTimeOf(new DateTimeImmutable('2021-05-17T16:00:00+00:00')));
     }
 }


### PR DESCRIPTION
## Summary

- When frontends (and integrators) send `startDate`/`endDate` as UTC timestamps, the `childcare.start`/`childcare.end` validation was comparing against raw UTC hours instead of local CET/CEST clock time, causing false validation errors.
- Fix: in `TimeImmutableRange::dateTimeToMinutes()`, normalise the incoming `DateTimeImmutable` to `Europe/Brussels` before extracting hours and minutes.
- Updated the fixture and all affected unit/feature tests to use explicit timezone offsets so the test intent stays clear and correct under the new behaviour. Added a new feature scenario and unit test that directly reproduce the reported bug.

### Ticket
Ticket: https://jira.uitdatabank.be/browse/III-7188