### PR TITLE
III-7137 Throw error when remainingCapacity sent on top level

### DIFF
--- a/src/Http/Offer/OfferValidatingRequestBodyParser.php
+++ b/src/Http/Offer/OfferValidatingRequestBodyParser.php
@@ -22,6 +22,7 @@ final class OfferValidatingRequestBodyParser implements RequestBodyParser
             new CalendarValidatingRequestBodyParser(),
             new DuplicateLabelValidatingRequestBodyParser(),
             new PriceInfoDuplicateNameValidatingRequestBodyParser(),
+            new RemainingCapacityValidatingRequestBodyParser(),
             $offerType->sameAs(OfferType::event()) ?
                 MainLanguageValidatingRequestBodyParser::createForEvent() :
                 MainLanguageValidatingRequestBodyParser::createForPlace()

--- a/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
+++ b/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
@@ -23,7 +23,7 @@ final class RemainingCapacityValidatingRequestBodyParser implements RequestBodyP
             throw ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
                 )
             );
         }

--- a/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
+++ b/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
@@ -23,7 +23,7 @@ final class RemainingCapacityValidatingRequestBodyParser implements RequestBodyP
             throw ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
+                    'remainingCapacity is not valid on the top-level bookingAvailability.'
                 )
             );
         }

--- a/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
+++ b/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
@@ -23,7 +23,7 @@ final class RemainingCapacityValidatingRequestBodyParser implements RequestBodyP
             throw ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity is not valid on the top-level bookingAvailability.'
+                    'remainingCapacity is not supported on the top-level bookingAvailability..'
                 )
             );
         }

--- a/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
+++ b/src/Http/Offer/RemainingCapacityValidatingRequestBodyParser.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Body\RequestBodyParser;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RemainingCapacityValidatingRequestBodyParser implements RequestBodyParser
+{
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        $data = $request->getParsedBody();
+
+        if (!is_object($data) || !isset($data->bookingAvailability) || !is_object($data->bookingAvailability)) {
+            return $request;
+        }
+
+        if (property_exists($data->bookingAvailability, 'remainingCapacity')) {
+            throw ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/bookingAvailability/remainingCapacity',
+                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                )
+            );
+        }
+
+        return $request;
+    }
+}

--- a/src/Http/Offer/UpdateCalendarRequestHandler.php
+++ b/src/Http/Offer/UpdateCalendarRequestHandler.php
@@ -38,6 +38,7 @@ final class UpdateCalendarRequestHandler implements RequestHandlerInterface
         $parser = RequestBodyParserFactory::createBaseParser(
             new LegacyUpdateCalendarRequestBodyParser(),
             new UpdateCalendarValidatingRequestBodyParser($jsonSchema),
+            new RemainingCapacityValidatingRequestBodyParser(),
             new DenormalizingRequestBodyParser(new CalendarDenormalizer(), Calendar::class)
         );
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4186,7 +4186,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
+                'remainingCapacity is not valid on the top-level bookingAvailability.'
             ),
         ];
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4186,7 +4186,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
             ),
         ];
 

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4102,6 +4102,65 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_accepts_remainingCapacity_inside_subEvent_bookingAvailability(): void
+    {
+        $eventId = 'f2850154-553a-4553-8d37-b32dd14546e4';
+
+        $this->uuidGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturn($eventId);
+
+        $given = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannenkoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'single',
+            'startDate' => '2026-05-17T22:00:00+00:00',
+            'endDate' => '2026-05-17T22:00:00+00:00',
+            'subEvent' => [
+                [
+                    'id' => 0,
+                    'startDate' => '2026-05-17T22:00:00+00:00',
+                    'endDate' => '2026-05-17T22:00:00+00:00',
+                    'status' => [
+                        'type' => 'Available',
+                    ],
+                    'bookingAvailability' => [
+                        'type' => 'Available',
+                        'remainingCapacity' => 5,
+                    ],
+                ],
+            ],
+        ];
+
+        $request = (new Psr7RequestBuilder())
+            ->withJsonBodyFromArray($given)
+            ->build('POST');
+
+        $this->imageCollectionFactory->expects($this->once())
+            ->method('fromImages')
+            ->willReturn(new ImageCollection());
+
+        $this->aggregateRepository->expects($this->once())
+            ->method('save');
+
+        $response = $this->importEventRequestHandler->handle($request);
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_if_bookingAvailability_has_top_level_remainingCapacity(): void
     {
         $event = [

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4102,6 +4102,41 @@ final class ImportEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_if_bookingAvailability_has_top_level_remainingCapacity(): void
+    {
+        $event = [
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Pannenkoeken voor het goede doel',
+            ],
+            'terms' => [
+                [
+                    'id' => '1.50.0.0.0',
+                ],
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.dev/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84',
+            ],
+            'calendarType' => 'permanent',
+            'bookingAvailability' => [
+                'type' => 'Available',
+                'remainingCapacity' => 10,
+            ],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/bookingAvailability/remainingCapacity',
+                'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+            ),
+        ];
+
+        $this->assertValidationErrors($event, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_if_organizer_id_is_invalid(): void
     {
         $event = [

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -4186,7 +4186,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity is not valid on the top-level bookingAvailability.'
+                'remainingCapacity is not supported on the top-level bookingAvailability..'
             ),
         ];
 

--- a/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
@@ -118,7 +118,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
                 )
             ),
             fn () => $this->parser->parse($request)
@@ -145,7 +145,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
                 )
             ),
             fn () => $this->parser->parse($request)

--- a/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Http\Offer;
+
+use CultuurNet\UDB3\Http\ApiProblem\ApiProblem;
+use CultuurNet\UDB3\Http\ApiProblem\AssertApiProblemTrait;
+use CultuurNet\UDB3\Http\ApiProblem\SchemaError;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
+{
+    use AssertApiProblemTrait;
+
+    private RemainingCapacityValidatingRequestBodyParser $parser;
+
+    private Psr7RequestBuilder $requestBuilder;
+
+    protected function setUp(): void
+    {
+        $this->parser = new RemainingCapacityValidatingRequestBodyParser();
+        $this->requestBuilder = new Psr7RequestBuilder();
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_request_unchanged_when_body_is_not_an_object(): void
+    {
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody(['bookingAvailability' => ['remainingCapacity' => 10]]);
+
+        $this->assertSame($request, $this->parser->parse($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_request_unchanged_when_bookingAvailability_is_missing(): void
+    {
+        $body = (object) [
+            'mainLanguage' => 'nl',
+            'name' => (object) ['nl' => 'Some event'],
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($body);
+
+        $this->assertSame($request, $this->parser->parse($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_request_unchanged_when_bookingAvailability_is_a_scalar(): void
+    {
+        $body = (object) [
+            'bookingAvailability' => 'Available',
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($body);
+
+        $this->assertSame($request, $this->parser->parse($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_request_unchanged_when_only_subEvent_carries_remainingCapacity(): void
+    {
+        $body = (object) [
+            'calendarType' => 'single',
+            'bookingAvailability' => (object) [
+                'type' => 'Available',
+            ],
+            'subEvent' => [
+                (object) [
+                    'startDate' => '2026-01-01T00:00:00+00:00',
+                    'endDate' => '2026-01-01T23:59:59+00:00',
+                    'bookingAvailability' => (object) [
+                        'type' => 'Available',
+                        'remainingCapacity' => 5,
+                    ],
+                ],
+            ],
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($body);
+
+        $this->assertSame($request, $this->parser->parse($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_top_level_bookingAvailability_has_remainingCapacity(): void
+    {
+        $body = (object) [
+            'bookingAvailability' => (object) [
+                'type' => 'Available',
+                'remainingCapacity' => 10,
+            ],
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($body);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/bookingAvailability/remainingCapacity',
+                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                )
+            ),
+            fn () => $this->parser->parse($request)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_top_level_remainingCapacity_is_null(): void
+    {
+        $body = (object) [
+            'bookingAvailability' => (object) [
+                'type' => 'Available',
+                'remainingCapacity' => null,
+            ],
+        ];
+
+        $request = $this->requestBuilder
+            ->build('POST')
+            ->withParsedBody($body);
+
+        $this->assertCallableThrowsApiProblem(
+            ApiProblem::bodyInvalidData(
+                new SchemaError(
+                    '/bookingAvailability/remainingCapacity',
+                    'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                )
+            ),
+            fn () => $this->parser->parse($request)
+        );
+    }
+}

--- a/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
@@ -118,7 +118,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity is not valid on the top-level bookingAvailability.'
+                    'remainingCapacity is not supported on the top-level bookingAvailability..'
                 )
             ),
             fn () => $this->parser->parse($request)
@@ -145,7 +145,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity is not valid on the top-level bookingAvailability.'
+                    'remainingCapacity is not supported on the top-level bookingAvailability..'
                 )
             ),
             fn () => $this->parser->parse($request)

--- a/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
+++ b/tests/Http/Offer/RemainingCapacityValidatingRequestBodyParserTest.php
@@ -118,7 +118,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
+                    'remainingCapacity is not valid on the top-level bookingAvailability.'
                 )
             ),
             fn () => $this->parser->parse($request)
@@ -145,7 +145,7 @@ final class RemainingCapacityValidatingRequestBodyParserTest extends TestCase
             ApiProblem::bodyInvalidData(
                 new SchemaError(
                     '/bookingAvailability/remainingCapacity',
-                    'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
+                    'remainingCapacity is not valid on the top-level bookingAvailability.'
                 )
             ),
             fn () => $this->parser->parse($request)

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -1915,6 +1915,22 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                     new SchemaError('/subEvent/0/overnight', 'The data (integer) must match the type: boolean'),
                 ],
             ],
+            'top_level_bookingAvailability_remainingCapacity' => [
+                'data' => (object)[
+                    'calendarType' => 'permanent',
+                    'openingHours' => [],
+                    'bookingAvailability' => (object)[
+                        'type' => 'Available',
+                        'remainingCapacity' => 10,
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError(
+                        '/bookingAvailability/remainingCapacity',
+                        'remainingCapacity is not valid on the top-level bookingAvailability.'
+                    ),
+                ],
+            ],
         ];
     }
 
@@ -2295,6 +2311,22 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                 ],
                 'expectedSchemaErrors' => [
                     new SchemaError('/openingHours/0/closes', 'closes should not be before opens'),
+                ],
+            ],
+            'top_level_bookingAvailability_remainingCapacity' => [
+                'data' => (object)[
+                    'calendarType' => 'permanent',
+                    'openingHours' => [],
+                    'bookingAvailability' => (object)[
+                        'type' => 'Available',
+                        'remainingCapacity' => 10,
+                    ],
+                ],
+                'expectedSchemaErrors' => [
+                    new SchemaError(
+                        '/bookingAvailability/remainingCapacity',
+                        'remainingCapacity is not valid on the top-level bookingAvailability.'
+                    ),
                 ],
             ],
         ];

--- a/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
+++ b/tests/Http/Offer/UpdateCalendarRequestHandlerTest.php
@@ -1927,7 +1927,7 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                 'expectedSchemaErrors' => [
                     new SchemaError(
                         '/bookingAvailability/remainingCapacity',
-                        'remainingCapacity is not valid on the top-level bookingAvailability.'
+                        'remainingCapacity is not supported on the top-level bookingAvailability..'
                     ),
                 ],
             ],
@@ -2325,7 +2325,7 @@ final class UpdateCalendarRequestHandlerTest extends TestCase
                 'expectedSchemaErrors' => [
                     new SchemaError(
                         '/bookingAvailability/remainingCapacity',
-                        'remainingCapacity is not valid on the top-level bookingAvailability.'
+                        'remainingCapacity is not supported on the top-level bookingAvailability..'
                     ),
                 ],
             ],

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -3332,7 +3332,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity is not valid on the top-level bookingAvailability.'
+                'remainingCapacity is not supported on the top-level bookingAvailability..'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -3332,7 +3332,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
+                'remainingCapacity is not valid on the top-level bookingAvailability.'
             ),
         ];
 

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -3299,6 +3299,49 @@ final class ImportPlaceRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_throw_if_booking_availability_has_top_level_remainingCapacity(): void
+    {
+        $place = [
+            '@id' => 'http://io.uitdatabank.be/place/b19d4090-db47-4520-ac1a-880684357ec9',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Test place',
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => 'Yf4aZBfsUEu2NsQqsprngw',
+                    'domain' => 'eventtype',
+                    'label' => 'Cultuur- of ontmoetingscentrum',
+                ],
+            ],
+            'address' => [
+                'nl' => [
+                    'streetAddress' => 'Henegouwenkaai 41-43',
+                    'postalCode' => '1080',
+                    'addressLocality' => 'Brussel',
+                    'addressCountry' => 'BE',
+                ],
+            ],
+            'bookingAvailability' => [
+                'type' => 'Available',
+                'remainingCapacity' => 10,
+            ],
+        ];
+
+        $expectedErrors = [
+            new SchemaError(
+                '/bookingAvailability/remainingCapacity',
+                'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+            ),
+        ];
+
+        $this->assertValidationErrors($place, $expectedErrors);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_an_exception_if_typicalAgeRange_is_not_a_string(): void
     {
         $place = [

--- a/tests/Http/Place/ImportPlaceRequestHandlerTest.php
+++ b/tests/Http/Place/ImportPlaceRequestHandlerTest.php
@@ -3332,7 +3332,7 @@ final class ImportPlaceRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/bookingAvailability/remainingCapacity',
-                'remainingCapacity can only be set on a subEvent, not on the top-level bookingAvailability.'
+                'remainingCapacity can only be set on a sub-event entry, not on the top-level bookingAvailability. Set it under /subEvent/{index}/bookingAvailability instead.'
             ),
         ];
 


### PR DESCRIPTION
## Summary
- `remainingCapacity` is only valid inside `subEvent.bookingAvailability` (see `event-subEvent-bookingAvailability.json` in `publiq/udb3-json-schemas`). At the top-level `bookingAvailability` of an Event or Place, it has no effect — but until now it was silently accepted.
- New `RemainingCapacityValidatingRequestBodyParser` (wired into `OfferValidatingRequestBodyParser`, so it applies to both Event and Place) throws a `bodyInvalidData` ApiProblem with a SchemaError at `/bookingAvailability/remainingCapacity` and a user-friendly message.
- Added unit tests in `ImportEventRequestHandlerTest` and `ImportPlaceRequestHandlerTest` covering the new rejection.

## Ticket

https://jira.publiq.be/browse/III-7137