### PR TITLE
Fix Acceptance tests departure places

### DIFF
--- a/features/data/organizers/rdf/organizer-with-address.ttl
+++ b/features/data/organizers/rdf/organizer-with-address.ttl
@@ -19,7 +19,7 @@
   cpr:naam "%{name}"@nl ;
   foaf:homepage "https://www.%{name}.be" ;
   locn:address <http://data.uitdatabank.local:80/organizers/%{organizerId}#address-8b181138> ;
-  locn:geometry <http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-dbec4cfd> .
+  locn:geometry <http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-d23b87da> .
 
 <http://data.uitdatabank.local:80/organizers/%{organizerId}#identifier-%{identifier}>
   a adms:Identifier ;
@@ -40,6 +40,6 @@
   locn:postCode "1080" ;
   locn:locatorDesignator "41" .
 
-<http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-dbec4cfd>
+<http://data.uitdatabank.local:80/organizers/%{organizerId}#geometry-d23b87da>
   a locn:Geometry ;
-  geosparql:asGML "<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'><gml:coordinates>4.3380041, 50.8509352</gml:coordinates></gml:Point>"^^geosparql:gmlLiteral .
+  geosparql:asGML "<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'><gml:coordinates>4.3379987, 50.8509332</gml:coordinates></gml:Point>"^^geosparql:gmlLiteral .

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -3,8 +3,7 @@ Feature: Test departure places in search results
 
   Background:
     Given I am using the UDB3 base URL
-    And I am using an UiTID v1 API key of consumer "uitdatabank"
-    And I am authorized as JWT provider user "centraal_beheerder"
+    And I am authorized with an OAuth client access token for "boa_client"
     And I send and accept "application/json"
     And I create a minimal place and save the "url" as "placeUrl"
 
@@ -23,6 +22,7 @@ Feature: Test departure places in search results
     """
     And I send a PUT request to "/events/%{eventId}/departurePlaces/"
     And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
       | embed                 | true          |
       | disableDefaultFilters | true          |
@@ -56,6 +56,7 @@ Feature: Test departure places in search results
     """
     And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
     And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true                                 |
       | q                     | departurePlaces:%{departurePlaceId1} |
@@ -110,6 +111,7 @@ Feature: Test departure places in search results
     """
     And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
     And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true                  |
       | departurePlaces[]     | %{departurePlaceId1}  |
@@ -137,6 +139,7 @@ Feature: Test departure places in search results
     """
     And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
     And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true                  |
       | departurePlaces[]     | %{departurePlaceId1}  |


### PR DESCRIPTION
### Changed

- `search/departure-places.feature`:  Use `boa_client` in tests for searching departure places.
- `organizer-with-address.ttl`: Updated coordinates in data test file.

### Related PR

- https://github.com/cultuurnet/appconfig/pull/1381

---