### PR TITLE
III-7203 Use kebab-case for endpoints

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -524,9 +524,9 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
             $routeGroup->put('{eventId}/audience/', UpdateAudienceRequestHandler::class);
             $routeGroup->post('{eventId}/copies/', CopyEventRequestHandler::class);
             $routeGroup->put('{eventId}/faqs/', UpdateFaqsRequestHandler::class);
-            $routeGroup->put('{eventId}/departurePlaces/', UpdateDeparturePlacesRequestHandler::class);
-            $routeGroup->put('{eventId}/birthdateRange/', UpdateBirthdateRangeRequestHandler::class);
-            $routeGroup->delete('{eventId}/birthdateRange/', DeleteBirthdateRangeRequestHandler::class);
+            $routeGroup->put('{eventId}/departure-places/', UpdateDeparturePlacesRequestHandler::class);
+            $routeGroup->put('{eventId}/birthdate-range/', UpdateBirthdateRangeRequestHandler::class);
+            $routeGroup->delete('{eventId}/birthdate-range/', DeleteBirthdateRangeRequestHandler::class);
 
             /**
              * Legacy routes that we need to keep for backward compatibility.

--- a/features/event/birthdate-range.feature
+++ b/features/event/birthdate-range.feature
@@ -19,7 +19,7 @@ Feature: Test birthdateRange on events
         """
         { "from": "2014-01-01", "to": "2020-12-31" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response at "birthdateRange/from" should be "2014-01-01"
@@ -31,12 +31,12 @@ Feature: Test birthdateRange on events
         """
         { "from": "2014-01-01", "to": "2020-12-31" }
         """
-    And I send a PUT request to "%{eventUrl}/birthdateRange"
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
     And I set the JSON request payload to:
         """
         { "from": "2015-01-01", "to": "2021-12-31" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response at "birthdateRange/from" should be "2015-01-01"
@@ -48,8 +48,8 @@ Feature: Test birthdateRange on events
         """
         { "from": "2014-01-01", "to": "2020-12-31" }
         """
-    And I send a PUT request to "%{eventUrl}/birthdateRange"
-    When I send a DELETE request to "%{eventUrl}/birthdateRange"
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
+    When I send a DELETE request to "%{eventUrl}/birthdate-range"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response should not have "birthdateRange"
@@ -60,7 +60,7 @@ Feature: Test birthdateRange on events
         """
         { "from": "2020-12-31", "to": "2014-01-01" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "400"
     And the JSON response at "schemaErrors" should be:
     """
@@ -78,7 +78,7 @@ Feature: Test birthdateRange on events
         """
         { "from": 1609372800, "to": "1 January 2024" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "400"
     And the JSON response at "schemaErrors" should be:
     """
@@ -100,7 +100,7 @@ Feature: Test birthdateRange on events
         """
         { "from": "2020-12-31" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "400"
     And the JSON response at "schemaErrors" should be:
     """
@@ -118,7 +118,7 @@ Feature: Test birthdateRange on events
         """
         { "to": "2024-12-31" }
         """
-    When I send a PUT request to "%{eventUrl}/birthdateRange"
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
     Then the response status should be "400"
     And the JSON response at "schemaErrors" should be:
     """

--- a/features/event/departure-places.feature
+++ b/features/event/departure-places.feature
@@ -19,7 +19,7 @@ Feature: Test event departure places
       "%{departurePlaceUrl2}"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response at "departurePlaces/0" should be "%{departurePlaceUrl1}"
@@ -33,7 +33,7 @@ Feature: Test event departure places
       "%{baseUrl}/place/%{departurePlaceId}"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response at "departurePlaces/0" should be "%{baseUrl}/place/%{departurePlaceId}"
@@ -46,13 +46,13 @@ Feature: Test event departure places
       "%{departurePlaceUrl1}"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "204"
     And I set the JSON request payload to:
     """
     []
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     Then the JSON response should not have "departurePlaces"
@@ -65,7 +65,7 @@ Feature: Test event departure places
       "%{departurePlaceUrl1}"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "400"
 
   Scenario: Reject departure places with non-existing place
@@ -77,7 +77,7 @@ Feature: Test event departure places
       "%{baseUrl}/places/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "400"
 
   Scenario: Reject departure places exceeding the limit via PUT departurePlaces
@@ -108,7 +108,7 @@ Feature: Test event departure places
       "%{baseUrl}/places/00000000-0000-0000-0000-000000000021"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "400"
     And the JSON response at "schemaErrors/0/error" should be "Array should have at most 20 items, 21 found"
 
@@ -126,7 +126,7 @@ Feature: Test event departure places
       "%{departurePlaceUrl1}"
     ]
     """
-    And I send a PUT request to "%{eventUrl}/departurePlaces/"
+    And I send a PUT request to "%{eventUrl}/departure-places/"
     Then the response status should be "204"
     And I set the JSON request payload to:
     """

--- a/features/search/departure-places.feature
+++ b/features/search/departure-places.feature
@@ -20,7 +20,7 @@ Feature: Test departure places in search results
       "%{departurePlaceUrl2}"
     ]
     """
-    And I send a PUT request to "/events/%{eventId}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId}/departure-places/"
     And I am using the Search API v3 base URL
     And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
@@ -47,14 +47,14 @@ Feature: Test departure places in search results
     """
     ["%{departurePlaceUrl1}", "%{departurePlaceUrl3}", "%{departurePlaceUrl4}"]
     """
-    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId1}/departure-places/"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
     And I publish the event at "/events/%{eventId2}"
     And I set the JSON request payload to:
     """
     ["%{departurePlaceUrl2}", "%{departurePlaceUrl4}"]
     """
-    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId2}/departure-places/"
     And I am using the Search API v3 base URL
     And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
@@ -102,14 +102,14 @@ Feature: Test departure places in search results
     """
     ["%{departurePlaceUrl1}"]
     """
-    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId1}/departure-places/"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
     And I publish the event at "/events/%{eventId2}"
     And I set the JSON request payload to:
     """
     ["%{departurePlaceUrl2}"]
     """
-    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId2}/departure-places/"
     And I am using the Search API v3 base URL
     And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:
@@ -130,14 +130,14 @@ Feature: Test departure places in search results
     """
     ["%{departurePlaceUrl1}", "%{departurePlaceUrl2}"]
     """
-    And I send a PUT request to "/events/%{eventId1}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId1}/departure-places/"
     And I create an event from "events/audience-type/event-audience-type-children-only.json" and save the "id" as "eventId2"
     And I publish the event at "/events/%{eventId2}"
     And I set the JSON request payload to:
     """
     ["%{departurePlaceUrl1}"]
     """
-    And I send a PUT request to "/events/%{eventId2}/departurePlaces/"
+    And I send a PUT request to "/events/%{eventId2}/departure-places/"
     And I am using the Search API v3 base URL
     And I am using a x-client-id header for client "boa_client"
     And I send a GET request to "/events" with parameters:

--- a/src/Http/LegacyPathRewriter.php
+++ b/src/Http/LegacyPathRewriter.php
@@ -23,7 +23,7 @@ final class LegacyPathRewriter
         '/subEvents/' => 'sub-events',
         '/typicalAgeRange/' => 'typical-age-range',
         '/departurePlaces/' => 'departure-places',
-        'birthdateRange' => 'birthdate-range',
+        '/birthdateRange/' => 'birthdate-range',
 
         // Convert old "calsum" path to "calendar-summary"
         '/\/calsum/' => '/calendar-summary',

--- a/src/Http/LegacyPathRewriter.php
+++ b/src/Http/LegacyPathRewriter.php
@@ -22,6 +22,8 @@ final class LegacyPathRewriter
         '/priceInfo/' => 'price-info',
         '/subEvents/' => 'sub-events',
         '/typicalAgeRange/' => 'typical-age-range',
+        '/departurePlaces/' => 'departure-places',
+        'birthdateRange' => 'birthdate-range',
 
         // Convert old "calsum" path to "calendar-summary"
         '/\/calsum/' => '/calendar-summary',

--- a/tests/Http/LegacyPathRewriterTest.php
+++ b/tests/Http/LegacyPathRewriterTest.php
@@ -123,6 +123,14 @@ class LegacyPathRewriterTest extends TestCase
                 'original' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/typicalAgeRange',
                 'rewrite' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/typical-age-range/',
             ],
+            'event_update_departure_places_camel_case_to_kebab_case_and_trailing_slash' => [
+                'original' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/departurePlaces',
+                'rewrite' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/departure-places/',
+            ],
+            'event_update_birthdate_range_camel_case_to_kebab_case_and_trailing_slash' => [
+                'original' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/birthdateRange',
+                'rewrite' => '/events/8a5fcfae-e698-437a-87a5-32cd4ac61076/birthdate-range/',
+            ],
             'event_uitpas_card_systems_camel_case_to_kebab_case_and_trailing_slash' => [
                 'original' => '/uitpas/events/08a70475-4ffe-44b9-b0b9-256c82e7d747/cardSystems',
                 'rewrite' => '/uitpas/events/08a70475-4ffe-44b9-b0b9-256c82e7d747/card-systems/',


### PR DESCRIPTION
### Changed

- `PsrRouterServiceProvider`: Use `kebab-case` instead of `camelCase` for BOA endpoints
- `LegacyPathRewriter`: Add `departurePlaces` & `birthdateRange` as legacy paths
- `LegacyPathRewriterTest`: Update unit tests.
- `features`: Use `kebab-case` in Acceptance tests

### Related PR

- https://github.com/cultuurnet/apidocs/pull/524

---

Ticket: https://jira.publiq.be/browse/III-7203
