### PR TITLE
Remove abandoned twig/extensions package

### DIFF
--- a/app/Export/ExportServiceProvider.php
+++ b/app/Export/ExportServiceProvider.php
@@ -28,7 +28,6 @@ use CultuurNet\UDB3\Search\ResultsGenerator;
 use CultuurNet\UDB3\Search\EventsSapi3SearchService;
 use Psr\Log\LoggerAwareInterface;
 use Twig_Environment;
-use Twig_Extensions_Extension_Text;
 
 final class ExportServiceProvider extends AbstractServiceProvider
 {
@@ -58,7 +57,6 @@ final class ExportServiceProvider extends AbstractServiceProvider
                 $twig = new Twig_Environment($loader);
 
                 $twig->addExtension(new GoogleMapUrlGenerator($container->get('config')['google_maps_api_key']));
-                $twig->addExtension(new Twig_Extensions_Extension_Text());
 
                 return $twig;
             }

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,6 @@
     "symfony/mailer": "^5.4",
     "symfony/process": "4.4.30",
     "symfony/serializer": "^v3.1.10",
-    "twig/extensions": "^1.5",
     "twig/twig": "~1.0",
     "webmozart/assert": "^1.2",
     "willdurand/geocoder": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "219a22f7f36c6ca118ff6ebbfda618c3",
+    "content-hash": "c63507a26e0648aea5c983f5729f6434",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8658,66 +8658,6 @@
                 }
             ],
             "time": "2026-04-14T12:12:40+00:00"
-        },
-        {
-            "name": "twig/extensions",
-            "version": "v1.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/Twig-extensions.git",
-                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/57873c8b0c1be51caa47df2cdb824490beb16202",
-                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202",
-                "shasum": ""
-            },
-            "require": {
-                "twig/twig": "^1.27|^2.0"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^3.4",
-                "symfony/translation": "^2.7|^3.4"
-            },
-            "suggest": {
-                "symfony/translation": "Allow the time_diff output to be translated"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Twig_Extensions_": "lib/"
-                },
-                "psr-4": {
-                    "Twig\\Extensions\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Common additional features for Twig that do not directly belong in core",
-            "keywords": [
-                "i18n",
-                "text"
-            ],
-            "support": {
-                "issues": "https://github.com/twigphp/Twig-extensions/issues",
-                "source": "https://github.com/twigphp/Twig-extensions/tree/master"
-            },
-            "abandoned": true,
-            "time": "2018-12-05T18:34:18+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/EventExport/Format/HTML/templates/export.map.activities.html.twig
+++ b/src/EventExport/Format/HTML/templates/export.map.activities.html.twig
@@ -53,7 +53,7 @@
             <p class="activity__type">{{ event.type }}</p>
             <p class="activity__title">{{ number }}. {{ event.title }}</p>
             <div class="activity__description">
-                <p>{{ event.description|truncate(75) }}</p>
+                <p>{{ event.description|length > 75 ? event.description|slice(0, 75) ~ '...' : event.description }}</p>
             </div>
             <div class="activity__info">
                 <table class="activity__info__table">

--- a/tests/EventExport/Format/HTML/templates/MapActivitiesTemplateTest.php
+++ b/tests/EventExport/Format/HTML/templates/MapActivitiesTemplateTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\EventExport\Format\HTML\templates;
+
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFunction;
+use Twig_Environment;
+use Twig_Loader_Filesystem;
+
+final class MapActivitiesTemplateTest extends TestCase
+{
+    private const TEMPLATE = 'export.map.activities.html.twig';
+
+    private Twig_Environment $twig;
+
+    protected function setUp(): void
+    {
+        $this->twig = new Twig_Environment(
+            new Twig_Loader_Filesystem(__DIR__ . '/../../../../../src/EventExport/Format/HTML/templates')
+        );
+
+        $this->twig->addFunction(
+            new TwigFunction('googleMapUrl', static fn (): string => 'http://maps.example.test')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_truncate_a_description_shorter_than_75_characters(): void
+    {
+        $description = 'A short description.';
+
+        $html = $this->renderWithDescription($description);
+
+        $this->assertStringContainsString('<p>' . $description . '</p>', $html);
+        $this->assertStringNotContainsString('...', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_truncate_a_description_of_exactly_75_characters(): void
+    {
+        $description = str_repeat('a', 75);
+
+        $html = $this->renderWithDescription($description);
+
+        $this->assertStringContainsString('<p>' . $description . '</p>', $html);
+        $this->assertStringNotContainsString('...', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function it_truncates_a_description_longer_than_75_characters_and_appends_an_ellipsis(): void
+    {
+        $description = str_repeat('a', 75) . 'this-part-should-be-cut';
+
+        $html = $this->renderWithDescription($description);
+
+        $this->assertStringContainsString('<p>' . str_repeat('a', 75) . '...</p>', $html);
+        $this->assertStringNotContainsString('this-part-should-be-cut', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function it_preserves_multibyte_characters_in_the_first_75_characters(): void
+    {
+        $description = str_repeat('é', 75) . 'tail';
+
+        $html = $this->renderWithDescription($description);
+
+        $this->assertStringContainsString('<p>' . str_repeat('é', 75) . '...</p>', $html);
+        $this->assertStringNotContainsString('tail', $html);
+    }
+
+    private function renderWithDescription(string $description): string
+    {
+        return $this->twig->render(self::TEMPLATE, [
+            'events' => [
+                [
+                    'type' => 'Cursus of workshop',
+                    'title' => 'Test event',
+                    'description' => $description,
+                    'address' => [
+                        'name' => 'Cultuurcentrum De Kruisboog',
+                        'street' => 'Sint-Jorisplein 20',
+                        'postcode' => '3300',
+                        'municipality' => 'Tienen',
+                    ],
+                    'price' => 'Gratis',
+                    'dates' => 'ma 02/03/15',
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- `twig/extensions` is abandoned and was used in a single place: the `truncate(75)` filter on `event.description` in `export.map.activities.html.twig`.
- Replaced that one call with twig's built-in `length` + `slice` filters, then removed the extension registration in `ExportServiceProvider` and dropped the package from `composer.json`/`composer.lock`.

## Test
https://jenkins.publiq.be/job/uitdatabank-acceptance-tests/701/