### PR TITLE
Calendar put should not be to clear bookinginfo

### DIFF
--- a/features/event/sub-event-booking-info.feature
+++ b/features/event/sub-event-booking-info.feature
@@ -187,6 +187,109 @@ Feature: Test SubEvent bookingInfo
     }
     """
 
+  Scenario: bookingInfo on subEvents is preserved when updating the calendar with new dates
+    Given I set the JSON request payload to:
+    """
+    {
+      "mainLanguage": "nl",
+      "name": {
+        "nl": "Multiple calendar event"
+      },
+      "terms": [
+        {
+          "id": "0.50.4.0.0",
+          "label": "Concert",
+          "domain": "eventtype"
+        }
+      ],
+      "location": {
+        "@id": "%{placeUrl}"
+      },
+      "calendarType": "multiple",
+      "subEvent": [
+        {
+          "startDate": "2021-05-17T08:00:00+00:00",
+          "endDate": "2021-05-17T22:00:00+00:00"
+        },
+        {
+          "startDate": "2021-05-18T08:00:00+00:00",
+          "endDate": "2021-05-18T22:00:00+00:00"
+        }
+      ]
+    }
+    """
+    And I send a POST request to "/events/"
+    And the response status should be "201"
+    And I keep the value of the JSON response at "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    [
+      {
+        "id": 0,
+        "bookingInfo": {
+          "url": "https://www.domain.be/reservations/subEvent-0",
+          "urlLabel": {"nl": "Reserveer subEvent 0"},
+          "email": "subevent0@example.com",
+          "phone": "0111111111"
+        }
+      },
+      {
+        "id": 1,
+        "bookingInfo": {
+          "url": "https://www.domain.be/reservations/subEvent-1",
+          "urlLabel": {"nl": "Reserveer subEvent 1"},
+          "email": "subevent1@example.com",
+          "phone": "0222222222"
+        }
+      }
+    ]
+    """
+    And I send a PATCH request to "%{eventUrl}/subEvents"
+    Then the response status should be "204"
+    When I set the JSON request payload to:
+    """
+    {
+      "calendarType": "multiple",
+      "subEvent": [
+        {
+          "startDate": "2021-05-20T08:00:00+00:00",
+          "endDate": "2021-05-20T22:00:00+00:00"
+        },
+        {
+          "startDate": "2021-05-21T08:00:00+00:00",
+          "endDate": "2021-05-21T22:00:00+00:00"
+        }
+      ]
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/calendar"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "subEvent/0/startDate" should be "2021-05-20T08:00:00+00:00"
+    And the JSON response at "subEvent/0/bookingInfo" should be:
+    """
+    {
+      "email": "subevent0@example.com",
+      "phone": "0111111111",
+      "url": "https://www.domain.be/reservations/subEvent-0",
+      "urlLabel": {
+        "nl": "Reserveer subEvent 0"
+      }
+    }
+    """
+    And the JSON response at "subEvent/1/startDate" should be "2021-05-21T08:00:00+00:00"
+    And the JSON response at "subEvent/1/bookingInfo" should be:
+    """
+    {
+      "email": "subevent1@example.com",
+      "phone": "0222222222",
+      "url": "https://www.domain.be/reservations/subEvent-1",
+      "urlLabel": {
+        "nl": "Reserveer subEvent 1"
+      }
+    }
+    """
+
   Scenario: Clear bookingInfo on a subEvent
     Given I create an event from "events/event-with-single-calendar.json" and save the "url" as "eventUrl"
     And I set the JSON request payload to:

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -445,9 +445,48 @@ final class Event extends Offer
     {
         if ($calendar instanceof CalendarWithSubEvents) {
             $this->assertOvernightAllowed($calendar->getSubEvents()->toArray());
+            $calendar = $this->preserveSubEventBookingInfo($calendar);
         }
 
         parent::updateCalendar($calendar);
+    }
+
+    private function preserveSubEventBookingInfo(Calendar $calendar): Calendar
+    {
+        if (!$calendar instanceof CalendarWithSubEvents || !$this->calendar instanceof CalendarWithSubEvents) {
+            return $calendar;
+        }
+
+        $existingSubEvents = $this->calendar->getSubEvents()->toArray();
+        $newSubEvents = $calendar->getSubEvents()->toArray();
+
+        $changed = false;
+        foreach ($newSubEvents as $index => $newSubEvent) {
+            if (!$newSubEvent->getBookingInfo()->isEmpty()) {
+                continue;
+            }
+            if (!isset($existingSubEvents[$index])) {
+                continue;
+            }
+            $existingBookingInfo = $existingSubEvents[$index]->getBookingInfo();
+            if ($existingBookingInfo->isEmpty()) {
+                continue;
+            }
+            $newSubEvents[$index] = $newSubEvent->withBookingInfo($existingBookingInfo);
+            $changed = true;
+        }
+
+        if (!$changed) {
+            return $calendar;
+        }
+
+        $rebuilt = $calendar->getType()->sameAs(CalendarType::single())
+            ? new SingleSubEventCalendar($newSubEvents[0])
+            : new MultipleSubEventsCalendar(new SubEvents(...$newSubEvents));
+
+        return $rebuilt
+            ->withBookingAvailability($calendar->getBookingAvailability())
+            ->withStatus($calendar->getStatus());
     }
 
     public function updateType(Category $category): void

--- a/tests/Event/EventTest.php
+++ b/tests/Event/EventTest.php
@@ -2476,6 +2476,111 @@ class EventTest extends AggregateRootScenarioTestCase
     /**
      * @test
      */
+    public function it_preserves_sub_event_booking_info_when_updating_calendar_without_booking_info(): void
+    {
+        $bookingInfo = new BookingInfo(
+            new WebsiteLink(
+                new Url('https://www.domain.be/reservations/eventname'),
+                new TranslatedWebsiteLabel(
+                    new Language('nl'),
+                    new WebsiteLabel('Reserveer plaatsen')
+                )
+            )
+        );
+
+        $oldDateRange1 = new DateRange(
+            new \DateTimeImmutable('2021-05-17T08:00:00+00:00'),
+            new \DateTimeImmutable('2021-05-17T22:00:00+00:00')
+        );
+        $oldDateRange2 = new DateRange(
+            new \DateTimeImmutable('2021-05-18T08:00:00+00:00'),
+            new \DateTimeImmutable('2021-05-18T22:00:00+00:00')
+        );
+        $oldCalendar = new MultipleSubEventsCalendar(
+            new SubEvents(
+                SubEvent::createAvailable($oldDateRange1)->withBookingInfo($bookingInfo),
+                SubEvent::createAvailable($oldDateRange2)->withBookingInfo($bookingInfo)
+            )
+        );
+
+        $newDateRange1 = new DateRange(
+            new \DateTimeImmutable('2021-05-20T08:00:00+00:00'),
+            new \DateTimeImmutable('2021-05-20T22:00:00+00:00')
+        );
+        $newDateRange2 = new DateRange(
+            new \DateTimeImmutable('2021-05-21T08:00:00+00:00'),
+            new \DateTimeImmutable('2021-05-21T22:00:00+00:00')
+        );
+        $incomingCalendar = new MultipleSubEventsCalendar(
+            new SubEvents(
+                SubEvent::createAvailable($newDateRange1),
+                SubEvent::createAvailable($newDateRange2)
+            )
+        );
+
+        $expectedCalendar = new MultipleSubEventsCalendar(
+            new SubEvents(
+                SubEvent::createAvailable($newDateRange1)->withBookingInfo($bookingInfo),
+                SubEvent::createAvailable($newDateRange2)->withBookingInfo($bookingInfo)
+            )
+        );
+
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new CalendarUpdated(self::EVENT_ID, $oldCalendar),
+            ])
+            ->when(fn (Event $event) => $event->updateCalendar($incomingCalendar))
+            ->then([new CalendarUpdated(self::EVENT_ID, $expectedCalendar)]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_overrides_sub_event_booking_info_when_calendar_update_provides_one(): void
+    {
+        $oldBookingInfo = new BookingInfo(
+            new WebsiteLink(
+                new Url('https://www.domain.be/reservations/original'),
+                new TranslatedWebsiteLabel(
+                    new Language('nl'),
+                    new WebsiteLabel('Origineel')
+                )
+            )
+        );
+        $newBookingInfo = new BookingInfo(
+            new WebsiteLink(
+                new Url('https://www.domain.be/reservations/replaced'),
+                new TranslatedWebsiteLabel(
+                    new Language('nl'),
+                    new WebsiteLabel('Vervangen')
+                )
+            )
+        );
+
+        $dateRange = new DateRange(
+            new \DateTimeImmutable('2021-05-20T08:00:00+00:00'),
+            new \DateTimeImmutable('2021-05-20T22:00:00+00:00')
+        );
+        $oldCalendar = new SingleSubEventCalendar(
+            SubEvent::createAvailable($dateRange)->withBookingInfo($oldBookingInfo)
+        );
+        $newCalendar = new SingleSubEventCalendar(
+            SubEvent::createAvailable($dateRange)->withBookingInfo($newBookingInfo)
+        );
+
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new CalendarUpdated(self::EVENT_ID, $oldCalendar),
+            ])
+            ->when(fn (Event $event) => $event->updateCalendar($newCalendar))
+            ->then([new CalendarUpdated(self::EVENT_ID, $newCalendar)]);
+    }
+
+    /**
+     * @test
+     */
     public function it_preserves_overnight_on_unrelated_sub_event_updates(): void
     {
         $unavailable = new \CultuurNet\UDB3\Model\ValueObject\Calendar\Status(


### PR DESCRIPTION
### Fixed
-   A PUT /events/{eventId}/calendar request silently cleared any bookingInfo that was previously set on individual subEvents via PATCH /events/{eventId}/subEvents. Updating only the dates of an existing event should not wipe per-subEvent contact/booking data.
- Added a feature test to prove the fix works

---

Ticket: https://jira.uitdatabank.be/browse/III-7236
