### PR TITLE
III-7244 Extend Keycloak token generator with realm

### DIFF
--- a/app/User/UserServiceProvider.php
+++ b/app/User/UserServiceProvider.php
@@ -86,6 +86,7 @@ final class UserServiceProvider extends AbstractServiceProvider
             new KeycloakManagementTokenGenerator(
                 new Client(),
                 $container->get('config')['keycloak']['domain'],
+                'master',
                 $container->get('config')['keycloak']['client_id'],
                 $container->get('config')['keycloak']['client_secret']
             ),

--- a/app/User/UserServiceProvider.php
+++ b/app/User/UserServiceProvider.php
@@ -86,7 +86,7 @@ final class UserServiceProvider extends AbstractServiceProvider
             new KeycloakManagementTokenGenerator(
                 new Client(),
                 $container->get('config')['keycloak']['domain'],
-                'master',
+                $container->get('config')['keycloak']['master_realm'],
                 $container->get('config')['keycloak']['client_id'],
                 $container->get('config')['keycloak']['client_secret']
             ),

--- a/src/User/Keycloak/KeycloakManagementTokenGenerator.php
+++ b/src/User/Keycloak/KeycloakManagementTokenGenerator.php
@@ -15,13 +15,20 @@ final class KeycloakManagementTokenGenerator implements ManagementTokenGenerator
 {
     private ClientInterface $client;
     private string $domain;
+    private string $realm;
     private string $clientId;
     private string $clientSecret;
 
-    public function __construct(ClientInterface $client, string $domain, string $clientId, string $clientSecret)
-    {
+    public function __construct(
+        ClientInterface $client,
+        string $domain,
+        string $realm,
+        string $clientId,
+        string $clientSecret
+    ) {
         $this->client = $client;
         $this->domain = $domain;
+        $this->realm = $realm;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
     }
@@ -30,7 +37,7 @@ final class KeycloakManagementTokenGenerator implements ManagementTokenGenerator
     {
         $request = new Request(
             'POST',
-            $this->domain . '/realms/master/protocol/openid-connect/token',
+            $this->domain . '/realms/' . $this->realm . '/protocol/openid-connect/token',
             [
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ],

--- a/tests/User/Keycloak/KeycloakManagementTokenGeneratorTest.php
+++ b/tests/User/Keycloak/KeycloakManagementTokenGeneratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\User\Keycloak;
+
+use CultuurNet\UDB3\Json;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+final class KeycloakManagementTokenGeneratorTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    private KeycloakManagementTokenGenerator $tokenGenerator;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $client = new Client(['handler' => HandlerStack::create($this->mockHandler)]);
+
+        $this->tokenGenerator = new KeycloakManagementTokenGenerator(
+            $client,
+            'https://account-test.uitid.be',
+            'master',
+            'my-client-id',
+            'my-client-secret'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_a_client_credentials_token_for_the_configured_realm(): void
+    {
+        $this->mockHandler->append(
+            new Response(200, [], Json::encode(['access_token' => 'token-abc', 'expires_in' => 3600]))
+        );
+
+        $token = $this->tokenGenerator->newToken();
+
+        $this->assertEquals('token-abc', $token->getToken());
+        $this->assertEquals(3600, $token->getExpiresIn());
+
+        $request = $this->mockHandler->getLastRequest();
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals(
+            'https://account-test.uitid.be/realms/master/protocol/openid-connect/token',
+            (string) $request->getUri()
+        );
+
+        parse_str((string) $request->getBody(), $body);
+        $this->assertEquals('client_credentials', $body['grant_type']);
+        $this->assertEquals('my-client-id', $body['client_id']);
+        $this->assertEquals('my-client-secret', $body['client_secret']);
+    }
+}


### PR DESCRIPTION
### Changed
- Extended Keycloak token generator with realm so this can also be used to create a token for UiTPAS on the `uitid` realm

---

Ticket: https://jira.uitdatabank.be/browse/III-7244
