### PR TITLE
III-7244 Create new UiTPASClient

### DIFF
--- a/app/UiTPAS/UiTPASClientServiceProvider.php
+++ b/app/UiTPAS/UiTPASClientServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS;
+
+use CultuurNet\UDB3\Cache\CacheFactory;
+use CultuurNet\UDB3\Container\AbstractServiceProvider;
+use CultuurNet\UDB3\Error\LoggerFactory;
+use CultuurNet\UDB3\Error\LoggerName;
+use CultuurNet\UDB3\UiTPAS\Client\RestUiTPASClient;
+use CultuurNet\UDB3\UiTPAS\Client\UiTPASClient;
+use CultuurNet\UDB3\User\Keycloak\KeycloakManagementTokenGenerator;
+use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
+use GuzzleHttp\Client;
+
+final class UiTPASClientServiceProvider extends AbstractServiceProvider
+{
+    public const TOKEN_PROVIDER = 'uitpas.rest_api.token_provider';
+
+    protected function getProvidedServiceNames(): array
+    {
+        return [
+            UiTPASClient::class,
+            self::TOKEN_PROVIDER,
+        ];
+    }
+
+    public function register(): void
+    {
+        $container = $this->getContainer();
+
+        $container->addShared(
+            self::TOKEN_PROVIDER,
+            function () use ($container): ManagementTokenProvider {
+                $config = $container->get('config')['uitpas']['rest_api'];
+
+                return new ManagementTokenProvider(
+                    new KeycloakManagementTokenGenerator(
+                        new Client(),
+                        rtrim($config['oauth_url'], '/'),
+                        $config['realm'],
+                        $config['client_id'],
+                        $config['client_secret']
+                    ),
+                    CacheFactory::create($container->get('app_cache'), 'uitpas-rest-api', 0)
+                );
+            }
+        );
+
+        $container->addShared(
+            UiTPASClient::class,
+            function () use ($container): UiTPASClient {
+                $config = $container->get('config')['uitpas']['rest_api'];
+                return new RestUiTPASClient(
+                    new Client(),
+                    $container->get(self::TOKEN_PROVIDER),
+                    $config['url'],
+                    LoggerFactory::create($container, LoggerName::forService('uitpas', 'rest'))
+                );
+            }
+        );
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -75,6 +75,7 @@ use CultuurNet\UDB3\Security\OfferSecurityServiceProvider;
 use CultuurNet\UDB3\Security\OrganizerSecurityServiceProvider;
 use CultuurNet\UDB3\Term\TermServiceProvider;
 use CultuurNet\UDB3\UDB2\UDB2EventServicesProvider;
+use CultuurNet\UDB3\UiTPAS\UiTPASClientServiceProvider;
 use CultuurNet\UDB3\UiTPAS\UiTPASIncomingEventServicesProvider;
 use CultuurNet\UDB3\UiTPASService\UiTPASServiceEventServiceProvider;
 use CultuurNet\UDB3\UiTPASService\UiTPASServiceLabelsServiceProvider;
@@ -174,6 +175,7 @@ $container->addServiceProvider(new LabelServiceProvider());
 $container->addServiceProvider(new BulkLabelOfferServiceProvider());
 
 /** Uitpas */
+$container->addServiceProvider(new UiTPASClientServiceProvider());
 $container->addServiceProvider(new UiTPASServiceLabelsServiceProvider());
 $container->addServiceProvider(new UiTPASServiceEventServiceProvider());
 $container->addServiceProvider(new UiTPASServiceOrganizerServiceProvider());

--- a/src/UiTPAS/Client/RestUiTPASClient.php
+++ b/src/UiTPAS/Client/RestUiTPASClient.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\Client;
+
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
+use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
+use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+final class RestUiTPASClient implements UiTPASClient
+{
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly ManagementTokenProvider $tokenProvider,
+        private readonly string $apiEndpoint,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    public function getEventCardSystems(string $eventId): array
+    {
+        $response = $this->client->sendRequest(
+            $this->authenticatedRequest('GET', 'events/' . $eventId . '/card-systems')
+        );
+
+        if ($response->getStatusCode() === 404) {
+            return [];
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->error('UiTPAS REST API returned non-200 status code for event card systems', [
+                'event_id' => $eventId,
+                'status_code' => $response->getStatusCode(),
+                'body' => $response->getBody()->getContents(),
+            ]);
+            return [];
+        }
+
+        $cardSystems = [];
+        foreach (Json::decodeAssociatively($response->getBody()->getContents()) as $cardSystem) {
+            $cardSystems[] = new CardSystem(
+                new Id((string) $cardSystem['id']),
+                $cardSystem['name']
+            );
+        }
+
+        return $cardSystems;
+    }
+
+    private function authenticatedRequest(string $method, string $path): Request
+    {
+        return new Request(
+            $method,
+            $this->apiEndpoint . $path,
+            [
+                'Authorization' => 'Bearer ' . $this->tokenProvider->token(),
+                'Accept' => 'application/json',
+            ]
+        );
+    }
+}

--- a/src/UiTPAS/Client/UiTPASClient.php
+++ b/src/UiTPAS/Client/UiTPASClient.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\Client;
+
+use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
+
+interface UiTPASClient
+{
+    /**
+     * @return CardSystem[]
+     */
+    public function getEventCardSystems(string $eventId): array;
+}

--- a/tests/UiTPAS/Client/RestUiTPASClientTest.php
+++ b/tests/UiTPAS/Client/RestUiTPASClientTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\Client;
+
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class RestUiTPASClientTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    private function createClient(LoggerInterface $logger): RestUiTPASClient
+    {
+        $this->mockHandler = new MockHandler();
+        $httpClient = new Client(['handler' => HandlerStack::create($this->mockHandler)]);
+
+        $tokenProvider = $this->createMock(ManagementTokenProvider::class);
+        $tokenProvider->method('token')->willReturn('token-abc');
+
+        return new RestUiTPASClient($httpClient, $tokenProvider, 'https://uitpas-test.publiq.be/', $logger);
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_event_card_systems_and_sends_a_bearer_token(): void
+    {
+        $client = $this->createClient(new NullLogger());
+        $this->mockHandler->append(
+            new Response(200, [], Json::encode([
+                ['id' => 1, 'name' => 'UiTPAS Dender', 'enabled' => true],
+                ['id' => 8, 'name' => 'UiTPAS Gent', 'enabled' => true],
+            ]))
+        );
+
+        $cardSystems = $client->getEventCardSystems('event-id-1');
+
+        $this->assertCount(2, $cardSystems);
+        $this->assertEquals('1', $cardSystems[0]->getId()->toNative());
+        $this->assertEquals('UiTPAS Dender', $cardSystems[0]->getName());
+        $this->assertEquals('8', $cardSystems[1]->getId()->toNative());
+
+        $request = $this->mockHandler->getLastRequest();
+        $this->assertEquals(
+            'https://uitpas-test.publiq.be/events/event-id-1/card-systems',
+            (string) $request->getUri()
+        );
+        $this->assertEquals('Bearer token-abc', $request->getHeaderLine('Authorization'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_list_on_404(): void
+    {
+        $client = $this->createClient(new NullLogger());
+        $this->mockHandler->append(new Response(404, [], ''));
+
+        $this->assertEquals([], $client->getEventCardSystems('unknown-event'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_and_returns_an_empty_list_on_an_unexpected_status(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $client = $this->createClient($logger);
+        $this->mockHandler->append(new Response(500, [], 'boom'));
+
+        $this->assertEquals([], $client->getEventCardSystems('event-id-1'));
+    }
+}


### PR DESCRIPTION
### Added
- Created new `UiTPASClient` interface and concrete `RestUiTPASClient`. For now, this has only one method called `getEventCardSystems` which is not yet used inside `GetCardSystemsFromEventRequestHandler`

---

Ticket: https://jira.uitdatabank.be/browse/III-7244
