### PR TITLE
III-7255 Extend bookingAvailability for periodic/permanent events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "predis/predis": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0",
-    "publiq/udb3-json-schemas": "dev-main",
+    "publiq/udb3-json-schemas": "dev-III-7255/extend-event-bookingAvailability",
     "ramsey/uuid": "^3.2.0",
     "rase/socket.io-emitter": "0.6.1",
     "sentry/sentry": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c63507a26e0648aea5c983f5729f6434",
+    "content-hash": "0d9328bd041d6b9dd3a763d08a82d56b",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6088,19 +6088,18 @@
         },
         {
             "name": "publiq/udb3-json-schemas",
-            "version": "dev-main",
+            "version": "dev-III-7255/extend-event-bookingAvailability",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "2891a3270c1e0df12dcd773a7dc47e5700ea18cd"
+                "reference": "043c9b11841b7e909153475105bbb62891bb71ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/2891a3270c1e0df12dcd773a7dc47e5700ea18cd",
-                "reference": "2891a3270c1e0df12dcd773a7dc47e5700ea18cd",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/043c9b11841b7e909153475105bbb62891bb71ef",
+                "reference": "043c9b11841b7e909153475105bbb62891bb71ef",
                 "shasum": ""
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6115,9 +6114,9 @@
             "description": "UiTdatabank JSON schemas, useful for validating JSON request bodies.",
             "support": {
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
-                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
+                "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/III-7255/extend-event-bookingAvailability"
             },
-            "time": "2026-06-11T09:21:36+00:00"
+            "time": "2026-06-18T07:30:05+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/features/event/booking-availability.feature
+++ b/features/event/booking-availability.feature
@@ -1,0 +1,125 @@
+Feature: Test setting capacity on top level event via bookingAvailability
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+    And I create a place from "places/place.json" and save the "url" as "placeUrl"
+    And I keep the value of the JSON response at "id" as "placeId"
+
+  Scenario: Set top-level capacity via PUT booking-availability on single calendar event
+    Given I create an event from "events/event-with-single-calendar.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "bookingAvailability" should be:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+
+  Scenario: Set top-level capacity via PUT booking-availability on multiple calendar event
+    Given I create an event from "events/event-with-multiple-calendar.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "bookingAvailability" should be:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+
+  Scenario: Set top-level capacity via PUT booking-availability on periodic calendar event
+    Given I create an event from "events/event-with-periodic-calendar-and-opening-hours.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "bookingAvailability" should be:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+
+  Scenario: Set top-level capacity via PUT booking-availability on permanent calendar event
+    Given I create an event from "events/event-with-permanent-calendar-and-opening-hours.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "bookingAvailability" should be:
+    """
+    {
+      "type": "Available",
+      "capacity": 100
+    }
+    """
+
+  Scenario: Sending remainingCapacity via PUT booking-availability on permanent calendar event returns 400
+    Given I create an event from "events/event-with-permanent-calendar-and-opening-hours.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100,
+      "remainingCapacity": 42
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "400"
+    And the JSON response at "type" should be "https://api.publiq.be/probs/uitdatabank/remaining-capacity-not-supported"
+
+  Scenario: Set top-level capacity and remainingCapacity via PUT booking-availability on periodic calendar event
+    Given I create an event from "events/event-with-periodic-calendar-and-opening-hours.json" and save the "url" as "eventUrl"
+    When I set the JSON request payload to:
+    """
+    {
+      "type": "Available",
+      "capacity": 100,
+      "remainingCapacity": 42
+    }
+    """
+    And I send a PUT request to "%{eventUrl}/booking-availability"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "bookingAvailability" should be:
+    """
+    {
+      "type": "Available",
+      "capacity": 100,
+      "remainingCapacity": 42
+    }
+    """


### PR DESCRIPTION
## Summary
- Bumps `publiq/udb3-json-schemas` to `dev-III-7255/extend-event-bookingAvailability` (companion PR in the schemas repo adds optional top-level `remainingCapacity` to `event-bookingAvailability.json`).
- Adds `features/event/booking-availability.feature` covering top-level capacity via `PUT /events/{id}/booking-availability` for all four calendar types (`single`, `multiple`, `periodic`, `permanent`), plus the new rules for periodic (`capacity` + `remainingCapacity`) and permanent (`capacity` only — sending `remainingCapacity` returns 400 `remaining-capacity-not-supported`).

## Domain changes still to land on this branch
- `Offer::updateBookingAvailability` guard widened to accept `PeriodicCalendar` / `PermanentCalendar`.
- Type forced to `Available` on periodic + permanent.
- New 400 problem type `https://api.publiq.be/probs/uitdatabank/remaining-capacity-not-supported` when a permanent event receives `remainingCapacity`.
- Existing unit tests `UpdateBookingAvailabilityHandlerTest::it_does_not_update_offers_with_permanent_calendar` and `::it_does_not_update_offers_with_periodic_calendar` need to be replaced with assertions for the new behavior.

## Test plan
- [ ] Push domain implementation onto this branch
- [ ] `make test` passes locally
- [ ] All scenarios in `features/event/booking-availability.feature` pass
- [ ] Existing `features/event/capacity.feature` still passes
- [ ] Merge order: schemas PR first, then this branch