### PR TITLE
fix unittest with uri regex

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6092,12 +6092,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/udb3-json-schemas.git",
-                "reference": "2891a3270c1e0df12dcd773a7dc47e5700ea18cd"
+                "reference": "94d6786596b8c4fc049b0ba0d4fb1b8fbc13041e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/2891a3270c1e0df12dcd773a7dc47e5700ea18cd",
-                "reference": "2891a3270c1e0df12dcd773a7dc47e5700ea18cd",
+                "url": "https://api.github.com/repos/cultuurnet/udb3-json-schemas/zipball/94d6786596b8c4fc049b0ba0d4fb1b8fbc13041e",
+                "reference": "94d6786596b8c4fc049b0ba0d4fb1b8fbc13041e",
                 "shasum": ""
             },
             "default-branch": true,
@@ -6117,7 +6117,7 @@
                 "issues": "https://github.com/cultuurnet/udb3-json-schemas/issues",
                 "source": "https://github.com/cultuurnet/udb3-json-schemas/tree/main"
             },
-            "time": "2026-06-11T09:21:36+00:00"
+            "time": "2026-06-11T13:09:50+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/tests/Http/Event/ImportEventRequestHandlerTest.php
+++ b/tests/Http/Event/ImportEventRequestHandlerTest.php
@@ -5981,7 +5981,7 @@ final class ImportEventRequestHandlerTest extends TestCase
             ),
             new SchemaError(
                 '/mediaObject/0/thumbnailUrl',
-                'The string should match pattern: ^http[s]?:\/\/'
+                'The string should match pattern: ^http[s]?:\/\/\w'
             ),
         ];
 
@@ -6386,7 +6386,7 @@ final class ImportEventRequestHandlerTest extends TestCase
         $expectedErrors = [
             new SchemaError(
                 '/image',
-                'The string should match pattern: ^http[s]?:\/\/'
+                'The string should match pattern: ^http[s]?:\/\/\w'
             ),
         ];
 


### PR DESCRIPTION
### Fixed
- Fixed 2 unit tests with outdated regex for URI validation

### Related
- https://github.com/cultuurnet/apidocs/pull/535/changes
