### PR TITLE
Print the error message on status code assert failure

### DIFF
--- a/features/Steps/ResponseSteps.php
+++ b/features/Steps/ResponseSteps.php
@@ -197,7 +197,11 @@ trait ResponseSteps
      */
     public function theResponseStatusShouldBe(int $statusCode): void
     {
-        assertEquals($statusCode, $this->responseState->getStatusCode());
+        assertEquals(
+            $statusCode,
+            $this->responseState->getStatusCode(),
+            $this->responseState->getContent()
+        );
     }
 
     /**


### PR DESCRIPTION
### Changed
- Print the error message on status code assert failure to improve troubleshooting failed acceptance tests
