### PR TITLE
III-7260 Bootstrap getCardSystemsForEvent on UiTPAS REST API

### DIFF
--- a/app/Http/PsrRouterServiceProvider.php
+++ b/app/Http/PsrRouterServiceProvider.php
@@ -165,6 +165,7 @@ use CultuurNet\UDB3\UiTPASService\Controller\GetCardSystemsFromEventRequestHandl
 use CultuurNet\UDB3\UiTPASService\Controller\GetCardSystemsFromOrganizerRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\GetUiTPASDetailRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\GetUiTPASLabelsRequestHandler;
+use CultuurNet\UDB3\UiTPASService\Controller\LegacyGetCardSystemsFromEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\SetCardSystemsOnEventRequestHandler;
 use League\Route\RouteGroup;
 use League\Route\Router;
@@ -231,7 +232,10 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
 
                 $this->bindSavedSearches($router);
 
-                $this->bindUiTPASEvents($router);
+                $this->bindUiTPASEvents(
+                    $router,
+                    $container->get('config')['uitpas']['rest_api']['enabled'] ?? false
+                );
 
                 $this->bindUiTPASLabels($router);
 
@@ -601,12 +605,17 @@ final class PsrRouterServiceProvider extends AbstractServiceProvider
         });
     }
 
-    private function bindUiTPASEvents(Router $router): void
+    private function bindUiTPASEvents(Router $router, bool $useRestApi): void
     {
-        $router->group('uitpas/events', function (RouteGroup $routeGroup): void {
+        $router->group('uitpas/events', function (RouteGroup $routeGroup) use ($useRestApi): void {
             $routeGroup->get('{eventId}/', GetUiTPASDetailRequestHandler::class);
 
-            $routeGroup->get('{eventId}/card-systems/', GetCardSystemsFromEventRequestHandler::class);
+            $routeGroup->get(
+                '{eventId}/card-systems/',
+                $useRestApi
+                    ? GetCardSystemsFromEventRequestHandler::class
+                    : LegacyGetCardSystemsFromEventRequestHandler::class
+            );
 
             $routeGroup->put('{eventId}/card-systems/', SetCardSystemsOnEventRequestHandler::class);
 

--- a/app/UiTPASService/UiTPASServiceEventServiceProvider.php
+++ b/app/UiTPASService/UiTPASServiceEventServiceProvider.php
@@ -8,8 +8,10 @@ use CultuurNet\UDB3\Container\AbstractServiceProvider;
 use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\UiTPASService\Controller\AddCardSystemToEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\DeleteCardSystemFromEventRequestHandler;
+use CultuurNet\UDB3\UiTPAS\Client\UiTPASClient;
 use CultuurNet\UDB3\UiTPASService\Controller\GetCardSystemsFromEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\GetUiTPASDetailRequestHandler;
+use CultuurNet\UDB3\UiTPASService\Controller\LegacyGetCardSystemsFromEventRequestHandler;
 use CultuurNet\UDB3\UiTPASService\Controller\SetCardSystemsOnEventRequestHandler;
 
 final class UiTPASServiceEventServiceProvider extends AbstractServiceProvider
@@ -19,6 +21,7 @@ final class UiTPASServiceEventServiceProvider extends AbstractServiceProvider
         return [
             GetUiTPASDetailRequestHandler::class,
             GetCardSystemsFromEventRequestHandler::class,
+            LegacyGetCardSystemsFromEventRequestHandler::class,
             SetCardSystemsOnEventRequestHandler::class,
             AddCardSystemToEventRequestHandler::class,
             DeleteCardSystemFromEventRequestHandler::class,
@@ -47,7 +50,14 @@ final class UiTPASServiceEventServiceProvider extends AbstractServiceProvider
         $container->addShared(
             GetCardSystemsFromEventRequestHandler::class,
             function () use ($container) {
-                return new GetCardSystemsFromEventRequestHandler($container->get('uitpas'));
+                return new GetCardSystemsFromEventRequestHandler($container->get(UiTPASClient::class));
+            }
+        );
+
+        $container->addShared(
+            LegacyGetCardSystemsFromEventRequestHandler::class,
+            function () use ($container) {
+                return new LegacyGetCardSystemsFromEventRequestHandler($container->get('uitpas'));
             }
         );
 

--- a/src/UiTPAS/CardSystem/CardSystem.php
+++ b/src/UiTPAS/CardSystem/CardSystem.php
@@ -12,6 +12,10 @@ final class CardSystem
 
     private string $name;
 
+    /**
+     * @var DistributionKey[]
+     */
+    private array $distributionKeys = [];
 
     public function __construct(
         Id $id,
@@ -19,6 +23,16 @@ final class CardSystem
     ) {
         $this->id = $id;
         $this->name = $name;
+    }
+
+    /**
+     * @param DistributionKey[] $distributionKeys
+     */
+    public function withDistributionKeys(array $distributionKeys): self
+    {
+        $clone = clone $this;
+        $clone->distributionKeys = $distributionKeys;
+        return $clone;
     }
 
     public function getId(): Id
@@ -29,5 +43,13 @@ final class CardSystem
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @return DistributionKey[]
+     */
+    public function getDistributionKeys(): array
+    {
+        return $this->distributionKeys;
     }
 }

--- a/src/UiTPAS/CardSystem/DistributionKey.php
+++ b/src/UiTPAS/CardSystem/DistributionKey.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\CardSystem;
+
+use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
+
+final class DistributionKey
+{
+    private Id $id;
+
+    private ?string $name;
+
+    public function __construct(Id $id, ?string $name = null)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): Id
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/UiTPAS/Client/RestUiTPASClient.php
+++ b/src/UiTPAS/Client/RestUiTPASClient.php
@@ -28,6 +28,13 @@ final class RestUiTPASClient implements UiTPASClient
     {
         $cardSystems = [];
         foreach ($this->getEventCardSystemsData($eventId) as $cardSystemData) {
+            // The REST API returns the full master list (enabled and disabled), but consumers
+            // should only see the card systems that are active for the event, matching the
+            // legacy XML endpoint. The full list is kept in getEventCardSystemsData() for writes.
+            if (($cardSystemData['enabled'] ?? false) !== true) {
+                continue;
+            }
+
             $cardSystems[] = (new CardSystem(
                 new Id((string) $cardSystemData['id']),
                 $cardSystemData['name']
@@ -47,6 +54,11 @@ final class RestUiTPASClient implements UiTPASClient
     {
         $distributionKeys = [];
         foreach ($distributionKeysData as $distributionKeyData) {
+            // Same as card systems: only expose the distribution keys that are enabled for the event.
+            if (($distributionKeyData['enabled'] ?? false) !== true) {
+                continue;
+            }
+
             $distributionKeys[] = new DistributionKey(
                 new Id((string) $distributionKeyData['id']),
                 $distributionKeyData['name'] ?? null

--- a/src/UiTPAS/Client/RestUiTPASClient.php
+++ b/src/UiTPAS/Client/RestUiTPASClient.php
@@ -6,6 +6,7 @@ namespace CultuurNet\UDB3\UiTPAS\Client;
 
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
+use CultuurNet\UDB3\UiTPAS\CardSystem\DistributionKey;
 use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use CultuurNet\UDB3\User\ManagementToken\ManagementTokenProvider;
 use GuzzleHttp\Psr7\Request;
@@ -27,13 +28,32 @@ final class RestUiTPASClient implements UiTPASClient
     {
         $cardSystems = [];
         foreach ($this->getEventCardSystemsData($eventId) as $cardSystemData) {
-            $cardSystems[] = new CardSystem(
+            $cardSystems[] = (new CardSystem(
                 new Id((string) $cardSystemData['id']),
                 $cardSystemData['name']
+            ))->withDistributionKeys(
+                $this->mapDistributionKeys($cardSystemData['manualDistributionKeys'] ?? [])
             );
         }
 
         return $cardSystems;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $distributionKeysData
+     * @return DistributionKey[]
+     */
+    private function mapDistributionKeys(array $distributionKeysData): array
+    {
+        $distributionKeys = [];
+        foreach ($distributionKeysData as $distributionKeyData) {
+            $distributionKeys[] = new DistributionKey(
+                new Id((string) $distributionKeyData['id']),
+                $distributionKeyData['name'] ?? null
+            );
+        }
+
+        return $distributionKeys;
     }
 
     public function addCardSystemToEvent(string $eventId, int $cardSystemId, ?int $distributionKeyId = null): void

--- a/src/UiTPASService/Controller/LegacyGetCardSystemsFromEventRequestHandler.php
+++ b/src/UiTPASService/Controller/LegacyGetCardSystemsFromEventRequestHandler.php
@@ -4,28 +4,27 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPASService\Controller;
 
+use CultureFeed_Uitpas;
 use CultuurNet\UDB3\Http\Request\RouteParameters;
-use CultuurNet\UDB3\UiTPAS\Client\UiTPASClient;
 use CultuurNet\UDB3\UiTPASService\Controller\Response\CardSystemsJsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-final class GetCardSystemsFromEventRequestHandler implements RequestHandlerInterface
+final class LegacyGetCardSystemsFromEventRequestHandler implements RequestHandlerInterface
 {
-    private UiTPASClient $uitpasClient;
+    private CultureFeed_Uitpas $uitpas;
 
-    public function __construct(UiTPASClient $uitpasClient)
+    public function __construct(CultureFeed_Uitpas $uitpas)
     {
-        $this->uitpasClient = $uitpasClient;
+        $this->uitpas = $uitpas;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $eventId = (new RouteParameters($request))->getEventId();
 
-        return CardSystemsJsonResponse::fromCardSystems(
-            $this->uitpasClient->getEventCardSystems($eventId)
-        );
+        $cardSystems = $this->uitpas->getCardSystemsForEvent($eventId);
+        return new CardSystemsJsonResponse($cardSystems->objects);
     }
 }

--- a/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
+++ b/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
@@ -8,6 +8,7 @@ use CultureFeed_Uitpas_CardSystem;
 use CultureFeed_Uitpas_DistributionKey;
 use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use Slim\Psr7\Interfaces\HeadersInterface;
 
 class CardSystemsJsonResponse extends JsonResponse
@@ -25,6 +26,40 @@ class CardSystemsJsonResponse extends JsonResponse
         $content = Json::encode($data);
 
         parent::__construct($content, $status, $headers);
+    }
+
+    /**
+     * Builds the same JSON shape from the UiTPAS REST value objects instead of the legacy
+     * CultureFeed objects, so the response stays identical regardless of the client behind it.
+     *
+     * @param CardSystem[] $cardSystems
+     */
+    public static function fromCardSystems(
+        array $cardSystems,
+        int $status = 200,
+        ?HeadersInterface $headers = null
+    ): JsonResponse {
+        $data = [];
+        foreach ($cardSystems as $cardSystem) {
+            $id = (int) $cardSystem->getId()->toNative();
+
+            $distributionKeys = [];
+            foreach ($cardSystem->getDistributionKeys() as $distributionKey) {
+                $distributionKeyId = (int) $distributionKey->getId()->toNative();
+                $distributionKeys[$distributionKeyId] = [
+                    'id' => $distributionKeyId,
+                    'name' => $distributionKey->getName(),
+                ];
+            }
+
+            $data[$id] = [
+                'id' => $id,
+                'name' => $cardSystem->getName(),
+                'distributionKeys' => $distributionKeys,
+            ];
+        }
+
+        return new JsonResponse(Json::encode($data), $status, $headers);
     }
 
     private function convertCardSystemToArray(CultureFeed_Uitpas_CardSystem $cardSystem): array

--- a/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
+++ b/src/UiTPASService/Controller/Response/CardSystemsJsonResponse.php
@@ -10,6 +10,7 @@ use CultuurNet\UDB3\Http\Response\JsonResponse;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
 use Slim\Psr7\Interfaces\HeadersInterface;
+use UnexpectedValueException;
 
 class CardSystemsJsonResponse extends JsonResponse
 {
@@ -41,11 +42,11 @@ class CardSystemsJsonResponse extends JsonResponse
     ): JsonResponse {
         $data = [];
         foreach ($cardSystems as $cardSystem) {
-            $id = (int) $cardSystem->getId()->toNative();
+            $id = self::toIntId($cardSystem->getId()->toNative());
 
             $distributionKeys = [];
             foreach ($cardSystem->getDistributionKeys() as $distributionKey) {
-                $distributionKeyId = (int) $distributionKey->getId()->toNative();
+                $distributionKeyId = self::toIntId($distributionKey->getId()->toNative());
                 $distributionKeys[$distributionKeyId] = [
                     'id' => $distributionKeyId,
                     'name' => $distributionKey->getName(),
@@ -60,6 +61,21 @@ class CardSystemsJsonResponse extends JsonResponse
         }
 
         return new JsonResponse(Json::encode($data), $status, $headers);
+    }
+
+    /**
+     * UiTPAS ids are integers per the API spec, but the Id value object holds them as strings.
+     * Casting a non-numeric string with (int) would silently collapse to 0 and make all card
+     * systems (or keys) overwrite each other, so fail loudly if the type ever changes instead.
+     */
+    private static function toIntId(string $id): int
+    {
+        $intId = filter_var($id, FILTER_VALIDATE_INT);
+        if ($intId === false) {
+            throw new UnexpectedValueException(sprintf('Expected a numeric UiTPAS id but got "%s".', $id));
+        }
+
+        return $intId;
     }
 
     private function convertCardSystemToArray(CultureFeed_Uitpas_CardSystem $cardSystem): array

--- a/tests/UiTPAS/CardSystem/CardSystemTest.php
+++ b/tests/UiTPAS/CardSystem/CardSystemTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\CardSystem;
+
+use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
+use PHPUnit\Framework\TestCase;
+
+class CardSystemTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_id_and_name(): void
+    {
+        $cardSystem = new CardSystem(new Id('1'), 'UiTPAS Dender');
+
+        $this->assertEquals('1', $cardSystem->getId()->toNative());
+        $this->assertEquals('UiTPAS Dender', $cardSystem->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_no_distribution_keys_by_default(): void
+    {
+        $cardSystem = new CardSystem(new Id('1'), 'UiTPAS Dender');
+
+        $this->assertEquals([], $cardSystem->getDistributionKeys());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_new_instance_with_distribution_keys_without_mutating_the_original(): void
+    {
+        $original = new CardSystem(new Id('1'), 'UiTPAS Dender');
+
+        $distributionKeys = [
+            new DistributionKey(new Id('123'), '3 euro per dag'),
+            new DistributionKey(new Id('456')),
+        ];
+
+        $withKeys = $original->withDistributionKeys($distributionKeys);
+
+        $this->assertNotSame($original, $withKeys);
+        $this->assertEquals([], $original->getDistributionKeys());
+        $this->assertEquals($distributionKeys, $withKeys->getDistributionKeys());
+        $this->assertEquals('1', $withKeys->getId()->toNative());
+        $this->assertEquals('UiTPAS Dender', $withKeys->getName());
+    }
+}

--- a/tests/UiTPAS/CardSystem/DistributionKeyTest.php
+++ b/tests/UiTPAS/CardSystem/DistributionKeyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPAS\CardSystem;
+
+use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
+use PHPUnit\Framework\TestCase;
+
+class DistributionKeyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_exposes_its_id_and_name(): void
+    {
+        $distributionKey = new DistributionKey(new Id('123'), '3 euro per dag');
+
+        $this->assertEquals('123', $distributionKey->getId()->toNative());
+        $this->assertEquals('3 euro per dag', $distributionKey->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_a_missing_name(): void
+    {
+        $distributionKey = new DistributionKey(new Id('456'));
+
+        $this->assertEquals('456', $distributionKey->getId()->toNative());
+        $this->assertNull($distributionKey->getName());
+    }
+}

--- a/tests/UiTPAS/Client/RestUiTPASClientTest.php
+++ b/tests/UiTPAS/Client/RestUiTPASClientTest.php
@@ -47,6 +47,7 @@ final class RestUiTPASClientTest extends TestCase
         $this->assertCount(2, $cardSystems);
         $this->assertEquals('1', $cardSystems[0]->getId()->toNative());
         $this->assertEquals('UiTPAS Dender', $cardSystems[0]->getName());
+        $this->assertEquals([], $cardSystems[0]->getDistributionKeys());
         $this->assertEquals('8', $cardSystems[1]->getId()->toNative());
 
         $request = $this->mockHandler->getLastRequest();
@@ -55,6 +56,35 @@ final class RestUiTPASClientTest extends TestCase
             (string) $request->getUri()
         );
         $this->assertEquals('Bearer token-abc', $request->getHeaderLine('Authorization'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_maps_manual_distribution_keys_including_keys_without_a_name(): void
+    {
+        $client = $this->createClient(new NullLogger());
+        $this->mockHandler->append(
+            new Response(200, [], Json::encode([
+                [
+                    'id' => 1,
+                    'name' => 'UiTPAS Dender',
+                    'enabled' => true,
+                    'manualDistributionKeys' => [
+                        ['id' => 123, 'name' => '3 euro per dag', 'enabled' => true],
+                        ['id' => 456, 'enabled' => false],
+                    ],
+                ],
+            ]))
+        );
+
+        $distributionKeys = $client->getEventCardSystems('event-id-1')[0]->getDistributionKeys();
+
+        $this->assertCount(2, $distributionKeys);
+        $this->assertEquals('123', $distributionKeys[0]->getId()->toNative());
+        $this->assertEquals('3 euro per dag', $distributionKeys[0]->getName());
+        $this->assertEquals('456', $distributionKeys[1]->getId()->toNative());
+        $this->assertNull($distributionKeys[1]->getName());
     }
 
     /**

--- a/tests/UiTPAS/Client/RestUiTPASClientTest.php
+++ b/tests/UiTPAS/Client/RestUiTPASClientTest.php
@@ -72,7 +72,7 @@ final class RestUiTPASClientTest extends TestCase
                     'enabled' => true,
                     'manualDistributionKeys' => [
                         ['id' => 123, 'name' => '3 euro per dag', 'enabled' => true],
-                        ['id' => 456, 'enabled' => false],
+                        ['id' => 456, 'enabled' => true],
                     ],
                 ],
             ]))
@@ -85,6 +85,51 @@ final class RestUiTPASClientTest extends TestCase
         $this->assertEquals('3 euro per dag', $distributionKeys[0]->getName());
         $this->assertEquals('456', $distributionKeys[1]->getId()->toNative());
         $this->assertNull($distributionKeys[1]->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_disabled_card_systems(): void
+    {
+        $client = $this->createClient(new NullLogger());
+        $this->mockHandler->append(
+            new Response(200, [], Json::encode([
+                ['id' => 1, 'name' => 'UiTPAS Dender', 'enabled' => true],
+                ['id' => 8, 'name' => 'UiTPAS Gent', 'enabled' => false],
+            ]))
+        );
+
+        $cardSystems = $client->getEventCardSystems('event-id-1');
+
+        $this->assertCount(1, $cardSystems);
+        $this->assertEquals('1', $cardSystems[0]->getId()->toNative());
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_disabled_distribution_keys(): void
+    {
+        $client = $this->createClient(new NullLogger());
+        $this->mockHandler->append(
+            new Response(200, [], Json::encode([
+                [
+                    'id' => 1,
+                    'name' => 'UiTPAS Dender',
+                    'enabled' => true,
+                    'manualDistributionKeys' => [
+                        ['id' => 123, 'name' => '3 euro per dag', 'enabled' => true],
+                        ['id' => 456, 'name' => '5 euro per dag', 'enabled' => false],
+                    ],
+                ],
+            ]))
+        );
+
+        $distributionKeys = $client->getEventCardSystems('event-id-1')[0]->getDistributionKeys();
+
+        $this->assertCount(1, $distributionKeys);
+        $this->assertEquals('123', $distributionKeys[0]->getId()->toNative());
     }
 
     /**

--- a/tests/UiTPASService/Controller/GetCardSystemsFromEventRequestHandlerTest.php
+++ b/tests/UiTPASService/Controller/GetCardSystemsFromEventRequestHandlerTest.php
@@ -4,91 +4,88 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPASService\Controller;
 
-use CultureFeed_Uitpas;
-use CultureFeed_Uitpas_CardSystem;
-use CultureFeed_Uitpas_DistributionKey;
 use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
-use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
-use CultuurNet\UDB3\UiTPASService\Controller\Response\CardSystemsJsonResponse;
+use CultuurNet\UDB3\Json;
+use CultuurNet\UDB3\UiTPAS\CardSystem\CardSystem;
+use CultuurNet\UDB3\UiTPAS\CardSystem\DistributionKey;
+use CultuurNet\UDB3\UiTPAS\Client\UiTPASClient;
+use CultuurNet\UDB3\UiTPAS\ValueObject\Id;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class GetCardSystemsFromEventRequestHandlerTest extends TestCase
 {
-    use AssertJsonResponseTrait;
+    private UiTPASClient&MockObject $uitpasClient;
 
-    private \CultureFeed_Uitpas&MockObject $uitpas;
-
-    private GetCardSystemsFromEventRequestHandler $getCardSystemFromEventRequestHandler;
+    private GetCardSystemsFromEventRequestHandler $handler;
 
     protected function setUp(): void
     {
-        $this->uitpas = $this->createMock(CultureFeed_Uitpas::class);
+        $this->uitpasClient = $this->createMock(UiTPASClient::class);
 
-        $this->getCardSystemFromEventRequestHandler = new GetCardSystemsFromEventRequestHandler($this->uitpas);
+        $this->handler = new GetCardSystemsFromEventRequestHandler($this->uitpasClient);
     }
 
     /**
      * @test
      */
-    public function it_can_get_card_systems_of_an_event(): void
+    public function it_returns_the_card_systems_of_an_event_in_the_same_shape_as_the_legacy_endpoint(): void
     {
         $eventId = 'db93a8d0-331a-4575-a23d-2c78d4ceb925';
 
-        $cardSystem1 = new CultureFeed_Uitpas_CardSystem();
-        $cardSystem1->id = 1;
-        $cardSystem1->name = 'Card system 1';
-
-        $distributionKey1 = new CultureFeed_Uitpas_DistributionKey();
-        $distributionKey1->id = 1;
-        $distributionKey1->name = 'Distribution key 1';
-
-        $distributionKey2 = new CultureFeed_Uitpas_DistributionKey();
-        $distributionKey2->id = 2;
-        $distributionKey2->name = 'Distribution key 2';
-
-        $cardSystem1->distributionKeys = [
-            $distributionKey1,
-            $distributionKey2,
-        ];
-
-        $cardSystem2 = new CultureFeed_Uitpas_CardSystem();
-        $cardSystem2->id = 2;
-        $cardSystem2->name = 'Card system 2';
-
-        $distributionKey3 = new CultureFeed_Uitpas_DistributionKey();
-        $distributionKey3->id = 3;
-        $distributionKey3->name = 'Distribution key 3';
-
-        $distributionKey4 = new CultureFeed_Uitpas_DistributionKey();
-        $distributionKey4->id = 4;
-        $distributionKey4->name = 'Distribution key 4';
-
-        $cardSystem2->distributionKeys = [
-            $distributionKey3,
-            $distributionKey4,
-        ];
-
-        $cardSystems = [
-            $cardSystem1,
-            $cardSystem2,
-        ];
-
-        $resultSet = new \CultureFeed_ResultSet();
-        $resultSet->objects = $cardSystems;
-        $resultSet->total = 2;
-
-        $this->uitpas->expects($this->once())
-            ->method('getCardSystemsForEvent')
+        $this->uitpasClient->expects($this->once())
+            ->method('getEventCardSystems')
             ->with($eventId)
-            ->willReturn($resultSet);
+            ->willReturn([
+                (new CardSystem(new Id('1'), 'Card system 1'))->withDistributionKeys([
+                    new DistributionKey(new Id('1'), 'Distribution key 1'),
+                    new DistributionKey(new Id('2'), 'Distribution key 2'),
+                ]),
+                new CardSystem(new Id('2'), 'Card system 2'),
+            ]);
 
         $request = (new Psr7RequestBuilder())
             ->withRouteParameter('eventId', $eventId)
             ->build('GET');
 
-        $response = $this->getCardSystemFromEventRequestHandler->handle($request);
+        $response = $this->handler->handle($request);
 
-        $this->assertJsonResponse(new CardSystemsJsonResponse($cardSystems), $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            [
+                '1' => [
+                    'id' => 1,
+                    'name' => 'Card system 1',
+                    'distributionKeys' => [
+                        '1' => ['id' => 1, 'name' => 'Distribution key 1'],
+                        '2' => ['id' => 2, 'name' => 'Distribution key 2'],
+                    ],
+                ],
+                '2' => [
+                    'id' => 2,
+                    'name' => 'Card system 2',
+                    'distributionKeys' => [],
+                ],
+            ],
+            Json::decodeAssociatively((string) $response->getBody())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_json_object_when_the_event_has_no_card_systems(): void
+    {
+        $this->uitpasClient->expects($this->once())
+            ->method('getEventCardSystems')
+            ->willReturn([]);
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('eventId', 'db93a8d0-331a-4575-a23d-2c78d4ceb925')
+            ->build('GET');
+
+        $response = $this->handler->handle($request);
+
+        $this->assertEquals('[]', (string) $response->getBody());
     }
 }

--- a/tests/UiTPASService/Controller/GetCardSystemsFromEventRequestHandlerTest.php
+++ b/tests/UiTPASService/Controller/GetCardSystemsFromEventRequestHandlerTest.php
@@ -74,6 +74,46 @@ final class GetCardSystemsFromEventRequestHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_throws_when_a_card_system_id_is_not_numeric(): void
+    {
+        $this->uitpasClient->expects($this->once())
+            ->method('getEventCardSystems')
+            ->willReturn([
+                new CardSystem(new Id('not-a-number'), 'Card system 1'),
+            ]);
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('eventId', 'db93a8d0-331a-4575-a23d-2c78d4ceb925')
+            ->build('GET');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->handler->handle($request);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_a_distribution_key_id_is_not_numeric(): void
+    {
+        $this->uitpasClient->expects($this->once())
+            ->method('getEventCardSystems')
+            ->willReturn([
+                (new CardSystem(new Id('1'), 'Card system 1'))->withDistributionKeys([
+                    new DistributionKey(new Id('not-a-number'), 'Distribution key 1'),
+                ]),
+            ]);
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('eventId', 'db93a8d0-331a-4575-a23d-2c78d4ceb925')
+            ->build('GET');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->handler->handle($request);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_an_empty_json_object_when_the_event_has_no_card_systems(): void
     {
         $this->uitpasClient->expects($this->once())

--- a/tests/UiTPASService/Controller/LegacyGetCardSystemsFromEventRequestHandlerTest.php
+++ b/tests/UiTPASService/Controller/LegacyGetCardSystemsFromEventRequestHandlerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\UiTPASService\Controller;
+
+use CultureFeed_Uitpas;
+use CultureFeed_Uitpas_CardSystem;
+use CultureFeed_Uitpas_DistributionKey;
+use CultuurNet\UDB3\Http\Request\Psr7RequestBuilder;
+use CultuurNet\UDB3\Http\Response\AssertJsonResponseTrait;
+use CultuurNet\UDB3\UiTPASService\Controller\Response\CardSystemsJsonResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class LegacyGetCardSystemsFromEventRequestHandlerTest extends TestCase
+{
+    use AssertJsonResponseTrait;
+
+    private \CultureFeed_Uitpas&MockObject $uitpas;
+
+    private LegacyGetCardSystemsFromEventRequestHandler $getCardSystemFromEventRequestHandler;
+
+    protected function setUp(): void
+    {
+        $this->uitpas = $this->createMock(CultureFeed_Uitpas::class);
+
+        $this->getCardSystemFromEventRequestHandler = new LegacyGetCardSystemsFromEventRequestHandler($this->uitpas);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_card_systems_of_an_event(): void
+    {
+        $eventId = 'db93a8d0-331a-4575-a23d-2c78d4ceb925';
+
+        $cardSystem1 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem1->id = 1;
+        $cardSystem1->name = 'Card system 1';
+
+        $distributionKey1 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey1->id = 1;
+        $distributionKey1->name = 'Distribution key 1';
+
+        $distributionKey2 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey2->id = 2;
+        $distributionKey2->name = 'Distribution key 2';
+
+        $cardSystem1->distributionKeys = [
+            $distributionKey1,
+            $distributionKey2,
+        ];
+
+        $cardSystem2 = new CultureFeed_Uitpas_CardSystem();
+        $cardSystem2->id = 2;
+        $cardSystem2->name = 'Card system 2';
+
+        $distributionKey3 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey3->id = 3;
+        $distributionKey3->name = 'Distribution key 3';
+
+        $distributionKey4 = new CultureFeed_Uitpas_DistributionKey();
+        $distributionKey4->id = 4;
+        $distributionKey4->name = 'Distribution key 4';
+
+        $cardSystem2->distributionKeys = [
+            $distributionKey3,
+            $distributionKey4,
+        ];
+
+        $cardSystems = [
+            $cardSystem1,
+            $cardSystem2,
+        ];
+
+        $resultSet = new \CultureFeed_ResultSet();
+        $resultSet->objects = $cardSystems;
+        $resultSet->total = 2;
+
+        $this->uitpas->expects($this->once())
+            ->method('getCardSystemsForEvent')
+            ->with($eventId)
+            ->willReturn($resultSet);
+
+        $request = (new Psr7RequestBuilder())
+            ->withRouteParameter('eventId', $eventId)
+            ->build('GET');
+
+        $response = $this->getCardSystemFromEventRequestHandler->handle($request);
+
+        $this->assertJsonResponse(new CardSystemsJsonResponse($cardSystems), $response);
+    }
+}


### PR DESCRIPTION
### Added
- Added `DistributionKey` with a nullable name, as this field is not required
- Added optional `distributionKeys` to `CardSystem`
- Added named constructor `fromCardSystems` to `CardSystemsJsonResponse`

### Changed
- Refactored `getEventCardSystems` to take into account `manualDistributionKeys`
- Renamed existing `GetCardSystemsFromEventRequestHandler` to `LegacyGetCardSystemsFromEventRequestHandler`
- Refactored `GetCardSystemsFromEventRequestHandler` to interact with the REST API
- Bootstrapped `GetCardSystemsFromEventRequestHandler`based on config `uitpas.rest_api.enabled`

---

Ticket: https://jira.uitdatabank.be/browse/III-7260
