### PR TITLE
[Aikido] Bump mtdowling/jmespath.php to 2.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "league/uri-components": "^2.4",
     "mailjet/mailjet-apiv3-php": "^1.6",
     "monolog/monolog": "~1.11",
+    "mtdowling/jmespath.php": "^2.9.1",
     "opis/json-schema": "^2.1",
     "php-amqplib/php-amqplib": "^3.6.0",
     "php-http/guzzle7-adapter": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
     "league/uri-components": "^2.4",
     "mailjet/mailjet-apiv3-php": "^1.6",
     "monolog/monolog": "~1.11",
-    "mtdowling/jmespath.php": "^2.9.1",
     "opis/json-schema": "^2.1",
     "php-amqplib/php-amqplib": "^3.6.0",
     "php-http/guzzle7-adapter": "^1.0",
@@ -87,6 +86,9 @@
     "phpunit/phpunit": "^9.5",
     "publiq/php-cs-fixer-config": "^2.0",
     "rector/rector": "^0.14.5"
+  },
+  "conflict": {
+    "mtdowling/jmespath.php": "<2.9.1"
   },
   "prefer-stable": true,
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c63507a26e0648aea5c983f5729f6434",
+    "content-hash": "c68a751c64a1c7abee1e92570ddecec2",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4094,16 +4094,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -4112,7 +4112,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -4120,7 +4120,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -4154,9 +4154,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c68a751c64a1c7abee1e92570ddecec2",
+    "content-hash": "aa1748b8fd5ef651c5b6fb14ecdd2e69",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
Upgrade jmespath.php to fix critical RCE vulnerabilities in CompilerRuntime where unescaped function names in generated PHP code allow arbitrary code execution via crafted JMESPath expressions.

<details>

<summary>✅ 2 CVEs resolved by this upgrade, including 2 critical 🚨 CVEs</summary>

<br>


This PR will resolve the following CVEs:

| Issue | Severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
| --- | --- | --- |
| <pre>[CVE-2026-54133](https://app.aikido.dev/issues/32060743/detail?groupId=9312#CVE-2026-54133)</pre> | <pre>🚨 CRITICAL</pre> | [mtdowling/jmespath.php] A vulnerability in the JMESPath compiler allows remote code execution when processing attacker-controlled JMESPath expressions due to insufficient escaping of function names in generated PHP code. An attacker can craft malicious expressions to inject executable PHP into cache files that are subsequently loaded and executed. |
| <pre>[AIKIDO-2026-928289](https://app.aikido.dev/issues/32060743/detail?groupId=9312#AIKIDO-2026-928289)</pre> | <pre>🚨 CRITICAL</pre> | [mtdowling/jmespath.php] A crafted JMESPath expression can break out of string literals in generated PHP code, allowing arbitrary PHP code execution when using the compiler runtime. An attacker who can control the expression string can inject malicious code into the compiled-expression cache file. |


</details>