### PR TITLE
II-7270 Polyfil the missing top-level booking info from identical sub-events

### DIFF
--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -54,6 +54,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                 $json = $this->polyfillStatus($json);
                 $json = $this->polyfillBookingAvailability($json);
                 $json = $this->polyfillSubEventProperties($json);
+                $json = $this->polyfillTopLevelBookingInfoFromSubEvents($json);
                 $json = $this->polyfillEmbeddedPlaceStatus($json);
                 $json = $this->polyfillEmbeddedPlaceBookingAvailability($json);
                 $json = $this->polyfillTypicalAgeRange($json);
@@ -156,6 +157,43 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
             $json['subEvent'],
             range(0, count($json['subEvent']) - 1)
         );
+
+        return $json;
+    }
+
+    /**
+     * Some offers received a bookingInfo on their sub events without a matching top level bookingInfo.
+     * When there is no top level bookingInfo and every sub event that has a bookingInfo carries the exact same one,
+     * we propagate it to the top level so consumers that only read the top level bookingInfo still get the data.
+     */
+    private function polyfillTopLevelBookingInfoFromSubEvents(array $json): array
+    {
+        if (!empty($json['bookingInfo']) && is_array($json['bookingInfo'])) {
+            return $json;
+        }
+
+        if (empty($json['subEvent']) || !is_array($json['subEvent'])) {
+            return $json;
+        }
+
+        $subEventBookingInfos = [];
+        foreach ($json['subEvent'] as $subEvent) {
+            if (is_array($subEvent) && !empty($subEvent['bookingInfo']) && is_array($subEvent['bookingInfo'])) {
+                $subEventBookingInfos[] = $subEvent['bookingInfo'];
+            }
+        }
+
+        if ($subEventBookingInfos === []) {
+            return $json;
+        }
+
+        foreach ($subEventBookingInfos as $subEventBookingInfo) {
+            if ($subEventBookingInfo != $subEventBookingInfos[0]) {
+                return $json;
+            }
+        }
+
+        $json['bookingInfo'] = $subEventBookingInfos[0];
 
         return $json;
     }

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -137,6 +137,209 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_propagates_sub_event_booking_info_to_top_level_for_a_single_sub_event(): void
+    {
+        $bookingInfo = [
+            'phone' => '044/1234567',
+            'email' => 'test@example.com',
+            'url' => 'https://www.publiq.be',
+        ];
+
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => $bookingInfo,
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentContains([
+                'bookingInfo' => $bookingInfo,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_propagates_sub_event_booking_info_to_top_level_when_all_sub_events_have_the_same(): void
+    {
+        $bookingInfo = [
+            'phone' => '044/1234567',
+        ];
+
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => $bookingInfo,
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-02T16:00:00+01:00',
+                        'endDate' => '2020-01-02T20:00:00+01:00',
+                        'bookingInfo' => $bookingInfo,
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentContains([
+                'bookingInfo' => $bookingInfo,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_propagates_sub_event_booking_info_when_only_some_sub_events_have_the_same(): void
+    {
+        $bookingInfo = [
+            'phone' => '044/1234567',
+        ];
+
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => $bookingInfo,
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-02T16:00:00+01:00',
+                        'endDate' => '2020-01-02T20:00:00+01:00',
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-03T16:00:00+01:00',
+                        'endDate' => '2020-01-03T20:00:00+01:00',
+                        'bookingInfo' => $bookingInfo,
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentContains([
+                'bookingInfo' => $bookingInfo,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_overwrite_an_existing_top_level_booking_info(): void
+    {
+        $topLevelBookingInfo = [
+            'phone' => '011/1111111',
+        ];
+
+        $this
+            ->given([
+                'bookingInfo' => $topLevelBookingInfo,
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => [
+                            'phone' => '022/2222222',
+                        ],
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentContains([
+                'bookingInfo' => $topLevelBookingInfo,
+            ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_propagate_when_the_single_sub_event_has_no_booking_info(): void
+    {
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentDoesNotContainKey('bookingInfo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_propagate_when_sub_events_have_different_booking_info(): void
+    {
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => [
+                            'phone' => '011/1111111',
+                        ],
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-02T16:00:00+01:00',
+                        'endDate' => '2020-01-02T20:00:00+01:00',
+                        'bookingInfo' => [
+                            'phone' => '022/2222222',
+                        ],
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentDoesNotContainKey('bookingInfo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_propagate_when_only_some_sub_events_are_filled_in_but_different(): void
+    {
+        $this
+            ->given([
+                'subEvent' => [
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-01T16:00:00+01:00',
+                        'endDate' => '2020-01-01T20:00:00+01:00',
+                        'bookingInfo' => [
+                            'phone' => '011/1111111',
+                        ],
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-02T16:00:00+01:00',
+                        'endDate' => '2020-01-02T20:00:00+01:00',
+                    ],
+                    [
+                        '@type' => 'Event',
+                        'startDate' => '2020-01-03T16:00:00+01:00',
+                        'endDate' => '2020-01-03T20:00:00+01:00',
+                        'bookingInfo' => [
+                            'phone' => '022/2222222',
+                        ],
+                    ],
+                ],
+            ])
+            ->assertReturnedDocumentDoesNotContainKey('bookingInfo');
+    }
+
+    /**
+     * @test
      * @dataProvider statusProvider
      */
     public function it_should_not_change_status_if_already_set_with_correct_format(array $status): void


### PR DESCRIPTION
### Added
- Polyfil the missing top-level booking info from identical sub-events. I did not write acceptance tests because this is temporary code to make sure booking info is shown on UiV.

### Note 
- This still needs a reindex of the events on SAPI3

---

Ticket: https://jira.uitdatabank.be/browse/III-7270
