### PR TITLE
III-7307 Rework feature tests to make them ES8 ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-group:
 	docker compose exec php composer test -- --group=$(group)
 
 feature-init:
-	docker compose exec php composer feature -- --tags @init
+	docker compose exec php composer feature -- --suite=init
 
 feature-tag:
 	docker compose exec php composer feature -- --tags $(tag)

--- a/Makefile
+++ b/Makefile
@@ -54,16 +54,25 @@ feature-tag:
 	docker compose exec php composer feature -- --tags $(tag)
 
 feature-ci:
-	docker compose exec php composer feature -- --tags "~@init&&~@external&&~@wip" -f pretty -o std -f junit -o output/junit
+	docker compose exec php composer feature -- --suite=default -f pretty -o std -f junit -o output/junit
+
+feature-ci-es8:
+	docker compose exec php composer feature -- --profile=es8 --suite=default -f pretty -o std -f junit -o output/junit
 
 feature:
-	docker compose exec php composer feature -- --tags "~@init&&~@external&&~@wip"
+	docker compose exec php composer feature -- --suite=default
+
+feature-sapi3:
+	docker compose exec php composer feature -- --suite=sapi3
+
+feature-sapi3-es8:
+	docker compose exec php composer feature -- --profile=es8 --suite=sapi3
 
 feature-filter:
 	docker compose exec php composer feature -- $(path)
 
 feature-random:
-	docker compose exec php composer feature -- --order=random --tags "~@init&&~@external&&~@wip"
+	docker compose exec php composer feature -- --order=random --suite=default
 
 rector:
 	docker compose exec php composer rector

--- a/behat.php
+++ b/behat.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Config\Config;
+use Behat\Config\Filter\TagFilter;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withPaths('%paths.base%/features')
+                    ->withContexts('FeatureContext')
+                    ->withFilter(new TagFilter('~@init && ~@external && ~@wip'))
+            )
+            ->withSuite(
+                (new Suite('sapi3'))
+                    ->withPaths('%paths.base%/features')
+                    ->withContexts('FeatureContext')
+                    ->withFilter(new TagFilter('@sapi3 && ~@wip'))
+            )
+    )
+    ->withProfile(
+        (new Profile('es8'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withFilter(new TagFilter('~@init && ~@external && ~@wip && ~@negativeBoosting'))
+            )
+            ->withSuite(
+                (new Suite('sapi3'))
+                    ->withFilter(new TagFilter('@sapi3 && ~@wip && ~@negativeBoosting'))
+            )
+    );

--- a/behat.php
+++ b/behat.php
@@ -22,6 +22,12 @@ return (new Config())
                     ->withContexts('FeatureContext')
                     ->withFilter(new TagFilter('@sapi3 && ~@wip'))
             )
+            ->withSuite(
+                (new Suite('init'))
+                    ->withPaths('%paths.base%/features')
+                    ->withContexts('FeatureContext')
+                    ->withFilter(new TagFilter('@init'))
+            )
     )
     ->withProfile(
         (new Profile('es8'))
@@ -32,5 +38,9 @@ return (new Config())
             ->withSuite(
                 (new Suite('sapi3'))
                     ->withFilter(new TagFilter('@sapi3 && ~@wip && ~@negativeBoosting'))
+            )
+            ->withSuite(
+                (new Suite('init'))
+                    ->withFilter(new TagFilter('@init'))
             )
     );

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,9 +34,14 @@ make test-group group=integration            # Tests in specific group
 ## Acceptance Testing (Behat)
 
 ```bash
-make feature                                           # All feature tests
+make feature                                           # All feature tests (default suite)
+make feature-ci                                        # Default suite, CI output (junit)
+make feature-ci-es8                                    # Default suite, es8 profile (excludes @negativeBoosting)
+make feature-sapi3                                     # SAPI3 search integration tests only
+make feature-sapi3-es8                                 # SAPI3 tests, es8 profile (excludes @negativeBoosting)
 make feature-tag tag=@events                           # Feature tests by tag
-make feature-tag tag=@sapi3                            # SAPI3 search integration tests
 make feature-filter path=features/search/auth.feature  # All scenarios in a file
 make feature-filter path=features/search/auth.feature:25  # Single scenario by line number
 ```
+
+Suites and tag filters are defined in `behat.php`, not in the Makefile — see the `default` and `es8` profiles there for the exact tag expressions.

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -105,18 +105,6 @@ final class FeatureContext implements Context
     }
 
     /**
-     * @BeforeScenario @negativeBoosting
-     */
-    public function skipNegativeBoostingIfConfigured(BeforeScenarioScope $scope): void
-    {
-        if ($this->config['skip_negative_boosting'] ?? false) {
-            throw new \Behat\Behat\Tester\Exception\PendingException(
-                'Negative boosting is not supported on this Elasticsearch version'
-            );
-        }
-    }
-
-    /**
      * @AfterScenario @testIsolation
      */
     public function afterScenarioTestIsolation(AfterScenarioScope $scope): void


### PR DESCRIPTION
### Added
- Add a `behat.php` configuration defining `default` and `sapi3` Behat suites under a `default` profile matching the current feature-ci tag set, plus an `es8` profile that overrides both suites to exclude `@negativeBoosting` scenarios
- Add `feature-ci-es8`, `feature-sapi3` and `feature-sapi3-es8` make targets to run the new suite/profile combinations
- Document the new suite-based feature test commands in `docs/commands.md`

### Changed
- Replace inline tag expressions in the `feature-ci`, `feature` and `feature-random` make targets with `--suite=default`, moving tag-filtering knowledge out of the Makefile and into `behat.php`

### Removed
- Remove the dead `skipNegativeBoostingIfConfigured` before-scenario hook from `FeatureContext.php`, which threw a `PendingException` instead of cleanly skipping `@negativeBoosting` scenarios and therefore never produced a green ES8 run; this is now handled by tag filtering in the `es8` Behat profile

---
Ticket: https://jira.uitdatabank.be/browse/III-7307
