### PR TITLE
III-7325 ES8 tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ feature-tag:
 feature-ci:
 	docker compose exec php composer feature -- --suite=default -f pretty -o std -f junit -o output/junit
 
-feature-ci-es8:
-	docker compose exec php composer feature -- --profile=es8 --suite=default -f pretty -o std -f junit -o output/junit
+feature-ci-es5:
+	docker compose exec php composer feature -- --profile=es5 --suite=default -f pretty -o std -f junit -o output/junit
 
 feature:
 	docker compose exec php composer feature -- --suite=default
@@ -65,8 +65,8 @@ feature:
 feature-sapi3:
 	docker compose exec php composer feature -- --suite=sapi3
 
-feature-sapi3-es8:
-	docker compose exec php composer feature -- --profile=es8 --suite=sapi3
+feature-sapi3-es5:
+	docker compose exec php composer feature -- --profile=es5 --suite=sapi3
 
 feature-filter:
 	docker compose exec php composer feature -- $(path)

--- a/behat.php
+++ b/behat.php
@@ -14,13 +14,13 @@ return (new Config())
                 (new Suite('default'))
                     ->withPaths('%paths.base%/features')
                     ->withContexts('FeatureContext')
-                    ->withFilter(new TagFilter('~@init && ~@external && ~@wip'))
+                    ->withFilter(new TagFilter('~@init && ~@external && ~@negativeBoosting'))
             )
             ->withSuite(
                 (new Suite('sapi3'))
                     ->withPaths('%paths.base%/features')
                     ->withContexts('FeatureContext')
-                    ->withFilter(new TagFilter('@sapi3 && ~@wip'))
+                    ->withFilter(new TagFilter('@sapi3 && ~@negativeBoosting'))
             )
             ->withSuite(
                 (new Suite('init'))
@@ -30,14 +30,14 @@ return (new Config())
             )
     )
     ->withProfile(
-        (new Profile('es8'))
+        (new Profile('es5'))
             ->withSuite(
                 (new Suite('default'))
-                    ->withFilter(new TagFilter('~@init && ~@external && ~@wip && ~@negativeBoosting'))
+                    ->withFilter(new TagFilter('~@init && ~@external'))
             )
             ->withSuite(
                 (new Suite('sapi3'))
-                    ->withFilter(new TagFilter('@sapi3 && ~@wip && ~@negativeBoosting'))
+                    ->withFilter(new TagFilter('@sapi3'))
             )
             ->withSuite(
                 (new Suite('init'))

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,14 +34,14 @@ make test-group group=integration            # Tests in specific group
 ## Acceptance Testing (Behat)
 
 ```bash
-make feature                                           # All feature tests (default suite)
-make feature-ci                                        # Default suite, CI output (junit)
-make feature-ci-es8                                    # Default suite, es8 profile (excludes @negativeBoosting)
-make feature-sapi3                                     # SAPI3 search integration tests only
-make feature-sapi3-es8                                 # SAPI3 tests, es8 profile (excludes @negativeBoosting)
+make feature                                           # All feature tests (default suite, targets ES8)
+make feature-ci                                        # Default suite, CI output (junit), targets ES8
+make feature-ci-es5                                    # Default suite, es5 profile (includes @negativeBoosting)
+make feature-sapi3                                     # SAPI3 search integration tests only, targets ES8
+make feature-sapi3-es5                                 # SAPI3 tests, es5 profile (includes @negativeBoosting)
 make feature-tag tag=@events                           # Feature tests by tag
 make feature-filter path=features/search/auth.feature  # All scenarios in a file
 make feature-filter path=features/search/auth.feature:25  # Single scenario by line number
 ```
 
-Suites and tag filters are defined in `behat.php`, not in the Makefile — see the `default` and `es8` profiles there for the exact tag expressions.
+Suites and tag filters are defined in `behat.php`, not in the Makefile — see the `default` and `es5` profiles there for the exact tag expressions. The `default` profile now excludes `@negativeBoosting` scenarios (not yet supported on ES8); the `es5` profile keeps the old behavior for as long as ES5 stays in use.


### PR DESCRIPTION
### Changed
- Make ES8 the default acceptance test target: the `default` and `sapi3` suites in `behat.php` now exclude `@negativeBoosting` scenarios (not yet supported on ES8) instead of excluding `@wip`
- Rename the `es8` Behat profile to `es5`, which now targets ES5 and includes `@negativeBoosting` scenarios, preserving the old behavior for as long as ES5 stays in use
- Rename the `make feature-ci-es8` target to `make feature-ci-es5` and `make feature-sapi3-es8` to `make feature-sapi3-es5`
- Update `docs/commands.md` to document that the default suites target ES8 and that the `es5` profile keeps the legacy behavior including `@negativeBoosting`

---
Ticket: https://jira.uitdatabank.be/browse/III-7325
