### PR TITLE
III-7347 Allow searching for multiple birthdate ranges

### DIFF
--- a/features/place/create.feature
+++ b/features/place/create.feature
@@ -37,7 +37,7 @@ Feature: Test creating places
     """
     And the JSON response at "workflowStatus" should be "DRAFT"
     And the JSON response at "calendarType" should be "permanent"
-    And the JSON response at "completeness" should be 54
+    And the JSON response at "completeness" should be 53
 
   Scenario: Create a place with contact point with missing fields
     Given I create a place from "places/place-with-contact-point-with-missing-fields.json" and save the "url" as "placeUrl"
@@ -50,7 +50,7 @@ Feature: Test creating places
       "url": []
     }
     """
-    And the JSON response at "completeness" should be 56
+    And the JSON response at "completeness" should be 55
 
   Scenario: Create a place with workflowStatus set to APPROVED
     Given I create a place from "places/place-with-workflow-status-approved.json" and save the "url" as "placeUrl"
@@ -98,7 +98,7 @@ Feature: Test creating places
     """
     And the JSON response at "workflowStatus" should be "READY_FOR_VALIDATION"
     And the JSON response at "calendarType" should be "permanent"
-    And the JSON response at "completeness" should be 54
+    And the JSON response at "completeness" should be 53
 
   Scenario: Create a place with only the required fields and workflowStatus approved via legacy imports path
     Given I import a new place from "places/place-with-workflow-status-approved.json" and save the "url" as "placeUrl"

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -244,6 +244,17 @@ Feature: Test the Search API v3 advanced queries on offers
     """
     %{eventId2022}
     """
+    When I send a GET request to "/events" with parameters:
+      | q | birthdateRange:[2020-01-01 TO 2020-12-31] OR birthdateRange:[2022-06-30 TO 2022-12-31] |
+    Then the JSON response at "totalItems" should be 2
+    And the JSON response should include:
+    """
+    %{eventId2020}
+    """
+    And the JSON response should include:
+    """
+    %{eventId2022}
+    """
 
   @testIsolation
   Scenario: Search by birthdate range using an advanced query also matches events with the equivalent typical age range


### PR DESCRIPTION
### Added

### Changed

- `features/place/create.feature`: Fix failing acceptance tests.
- `features/search/advanced-queries-offers.feature`: Add acceptance test which uses format like uitinvlaanderen.be e.g., `birthdateRange:[yyyy-mm-dd TO yyyy-mm-dd] OR birthdateRange:[yyyy-mm-dd TO yyyy-mm-dd]`

### Fixed

- Allow searching for multiple separate birthdateRanges instead of just an `OR` parameter, which will be used on uitinvlaanderen.be

### Related PR

- https://github.com/cultuurnet/udb3-search-service/pull/503

---

Ticket: https://jira.publiq.be/browse/III-7347
