### PR TITLE
III-7246 Add acceptance tests for the dayOfWeek event search filter

### DIFF
--- a/features/search/day-of-week.feature
+++ b/features/search/day-of-week.feature
@@ -1,0 +1,336 @@
+@sapi3
+Feature: Test the dayOfWeek event search filter
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+    And I create a minimal place and save the "url" as "placeUrl"
+
+  @testIsolation
+  Scenario: Permanent event is matched by a weekday in its opening hours and not by another weekday
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["monday", "wednesday", "friday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | tuesday |
+      | disableDefaultFilters | true    |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: dayOfWeek matching is case-insensitive
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | Wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | WEDNESDAY |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wEdNeSdAy |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+
+  @testIsolation
+  Scenario: Multiple dayOfWeek values are OR-combined using the array syntax
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["sunday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # The event only occurs on Sunday, so a set that includes Sunday matches.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek[]           | friday   |
+      | dayOfWeek[]           | saturday |
+      | dayOfWeek[]           | sunday   |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # A set that does not include Sunday does not match.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek[]           | friday   |
+      | dayOfWeek[]           | saturday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Multiple dayOfWeek values are OR-combined using the comma-separated syntax
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["sunday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | friday,saturday,sunday |
+      | disableDefaultFilters | true                   |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | monday,tuesday |
+      | disableDefaultFilters | true           |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Periodic event spanning several months is matched based on its opening hours weekday
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-11-30T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["thursday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | thursday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | friday |
+      | disableDefaultFilters | true   |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Periodic event weekday is matched even when some of those weekdays are closed
+    # The event runs every Wednesday for several months, with two individual Wednesdays
+    # marked as closed. Closed days must be ignored, so dayOfWeek=wednesday still matches.
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-11-30T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday"]
+        }
+      ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-08-05",
+          "endDate": "2026-08-05",
+          "description": {"nl": "Gesloten"}
+        },
+        {
+          "startDate": "2026-08-12",
+          "endDate": "2026-08-12",
+          "description": {"nl": "Gesloten"}
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+
+  @testIsolation
+  Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by dayOfWeek
+    # The event runs on Wednesdays but only spans two weeks (2026-08-05 and 2026-08-12),
+    # so the weekday occurs fewer than the required minimum number of times (4).
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-08-16T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the dayOfWeek filter the event is returned, so it is searchable.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # With the dayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Multiple calendar event maps single-day sub-events to their weekday
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "multiple",
+      "startDate": "2026-08-05T10:00:00+02:00",
+      "endDate": "2026-08-26T18:00:00+02:00",
+      "subEvent": [
+        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"},
+        {"startDate": "2026-08-12T10:00:00+02:00", "endDate": "2026-08-12T18:00:00+02:00"},
+        {"startDate": "2026-08-19T10:00:00+02:00", "endDate": "2026-08-19T18:00:00+02:00"},
+        {"startDate": "2026-08-26T10:00:00+02:00", "endDate": "2026-08-26T18:00:00+02:00"}
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # All four sub-events fall on a Wednesday.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | thursday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Multiple calendar event expands multi-day sub-events to every weekday in their range
+    # Each sub-event runs Friday to Sunday, so it covers Friday, Saturday and Sunday.
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "multiple",
+      "startDate": "2026-09-04T10:00:00+02:00",
+      "endDate": "2026-09-27T18:00:00+02:00",
+      "subEvent": [
+        {"startDate": "2026-09-04T10:00:00+02:00", "endDate": "2026-09-06T18:00:00+02:00"},
+        {"startDate": "2026-09-11T10:00:00+02:00", "endDate": "2026-09-13T18:00:00+02:00"},
+        {"startDate": "2026-09-18T10:00:00+02:00", "endDate": "2026-09-20T18:00:00+02:00"},
+        {"startDate": "2026-09-25T10:00:00+02:00", "endDate": "2026-09-27T18:00:00+02:00"}
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Saturday sits in the middle of each Friday-to-Sunday range, so it must be part of the set.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | saturday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # The union OR-combines with the other days in the range too.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | friday,sunday |
+      | disableDefaultFilters | true          |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # No sub-event ever touches a Monday.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | monday |
+      | disableDefaultFilters | true   |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Single calendar event is out of scope and not matched by dayOfWeek
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "single",
+      "startDate": "2026-08-05T10:00:00+02:00",
+      "endDate": "2026-08-05T18:00:00+02:00",
+      "subEvent": [
+        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"}
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # The single event takes place on a Wednesday and is searchable without the dayOfWeek filter.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # But single calendar events are never matched by the dayOfWeek filter.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: An invalid weekday value is rejected with a validation error
+    When I am using the Search API v3 base URL
+    And I send a GET request to "/events" with parameters:
+      | dayOfWeek             | someday |
+      | disableDefaultFilters | true    |
+    Then the response status should be "404"

--- a/features/search/day-of-week.feature
+++ b/features/search/day-of-week.feature
@@ -161,32 +161,20 @@ Feature: Test the dayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Periodic event weekday is matched even when some of those weekdays are closed
-    # The event runs every Wednesday for several months, with two individual Wednesdays
-    # marked as closed. Closed days must be ignored, so dayOfWeek=wednesday still matches.
+  Scenario: Periodic event is matched when its weekday reaches the threshold exactly
+    # August 2026 contains exactly four Wednesdays (5, 12, 19 and 26), which is the minimum
+    # number of occurrences required, so wednesday is indexed and the event matches.
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
       "calendarType": "periodic",
       "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-11-30T23:59:59+02:00",
+      "endDate": "2026-08-31T23:59:59+02:00",
       "openingHours": [
         {
           "opens": "09:00",
           "closes": "17:00",
           "dayOfWeek": ["wednesday"]
-        }
-      ],
-      "openingHoursClosedDays": [
-        {
-          "startDate": "2026-08-05",
-          "endDate": "2026-08-05",
-          "description": {"nl": "Gesloten"}
-        },
-        {
-          "startDate": "2026-08-12",
-          "endDate": "2026-08-12",
-          "description": {"nl": "Gesloten"}
         }
       ]
     }
@@ -198,6 +186,46 @@ Feature: Test the dayOfWeek event search filter
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
+
+  @testIsolation
+  Scenario: A closed day drops a weekday below the threshold so the event is no longer matched
+    # Same August 2026 window as the previous scenario, but the Wednesday of 5 August is closed.
+    # That leaves three days the event is effectively open on a Wednesday, which is below the
+    # required minimum of four, so wednesday is not indexed.
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-08-31T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday"]
+        }
+      ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-08-05",
+          "endDate": "2026-08-05"
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the dayOfWeek filter the event is returned, so it is indexed and searchable.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # With the dayOfWeek filter it is not returned, because the closed day brings Wednesday down to three.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
 
   @testIsolation
   Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by dayOfWeek

--- a/features/search/day-of-week.feature
+++ b/features/search/day-of-week.feature
@@ -88,6 +88,43 @@ Feature: Test the dayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
+  Scenario: Multiple dayOfWeek values are AND-combined using the q parameter
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["monday", "wednesday", "friday"]
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # The dayOfWeek url parameter OR-combines its values, so a single matching weekday is enough.
+    When I send a GET request to "/events" with parameters:
+      | dayOfWeek             | monday,tuesday |
+      | disableDefaultFilters | true           |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # The same field is exposed in the q parameter, where AND logic can be expressed explicitly.
+    # Tuesday is not part of the opening hours, so requiring both weekdays excludes the event.
+    When I send a GET request to "/events" with parameters:
+      | q                     | dayOfWeek:(monday AND tuesday) |
+      | disableDefaultFilters | true                           |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+    # Both weekdays are part of the opening hours, so the AND query matches.
+    When I send a GET request to "/events" with parameters:
+      | q                     | dayOfWeek:(monday AND wednesday) |
+      | disableDefaultFilters | true                             |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+
+  @testIsolation
   Scenario: Periodic event spanning several months is matched based on its opening hours weekday
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """

--- a/features/search/day-of-week.feature
+++ b/features/search/day-of-week.feature
@@ -58,16 +58,6 @@ Feature: Test the dayOfWeek event search filter
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | WEDNESDAY |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wEdNeSdAy |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
 
   @testIsolation
   Scenario: Multiple dayOfWeek values are OR-combined using the comma-separated syntax

--- a/features/search/day-of-week.feature
+++ b/features/search/day-of-week.feature
@@ -70,39 +70,6 @@ Feature: Test the dayOfWeek event search filter
     And the JSON response at "totalItems" should be 1
 
   @testIsolation
-  Scenario: Multiple dayOfWeek values are OR-combined using the array syntax
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "permanent",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["sunday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    # The event only occurs on Sunday, so a set that includes Sunday matches.
-    When I send a GET request to "/events" with parameters:
-      | dayOfWeek[]           | friday   |
-      | dayOfWeek[]           | saturday |
-      | dayOfWeek[]           | sunday   |
-      | disableDefaultFilters | true     |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    # A set that does not include Sunday does not match.
-    When I send a GET request to "/events" with parameters:
-      | dayOfWeek[]           | friday   |
-      | dayOfWeek[]           | saturday |
-      | disableDefaultFilters | true     |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
   Scenario: Multiple dayOfWeek values are OR-combined using the comma-separated syntax
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -356,6 +356,37 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
+  Scenario: Multiple calendar event with fewer than four occurrences on a weekday is not matched by recurringOnDayOfWeek
+    # Only three sub-events, all on a Wednesday (2026-08-05, 2026-08-12 and 2026-08-19), so the
+    # weekday occurs fewer than the required minimum number of times (4).
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "multiple",
+      "startDate": "2026-08-05T10:00:00+02:00",
+      "endDate": "2026-08-19T18:00:00+02:00",
+      "subEvent": [
+        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"},
+        {"startDate": "2026-08-12T10:00:00+02:00", "endDate": "2026-08-12T18:00:00+02:00"},
+        {"startDate": "2026-08-19T10:00:00+02:00", "endDate": "2026-08-19T18:00:00+02:00"}
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the recurringOnDayOfWeek filter the event is returned, so it is searchable.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # With the recurringOnDayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
   Scenario: Single calendar event is out of scope and not matched by recurringOnDayOfWeek
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -356,3 +356,4 @@ Feature: Test the recurringOnDayOfWeek event search filter
       | recurringOnDayOfWeek  | someday |
       | disableDefaultFilters | true    |
     Then the response status should be "404"
+    And the JSON response at "detail" should include "someday"

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -222,6 +222,39 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
+  Scenario: A closed day that keeps a weekday above the threshold does not affect matching
+    # August and September 2026 together contain nine Wednesdays, so closing the one of 5 August still
+    # leaves eight, which is above the required minimum of four. Wednesday stays indexed.
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-09-30T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday"]
+        }
+      ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-08-05",
+          "endDate": "2026-08-05"
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+
+  @testIsolation
   Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by recurringOnDayOfWeek
     # The event runs on Wednesdays but only spans two weeks (2026-08-05 and 2026-08-12),
     # so the weekday occurs fewer than the required minimum number of times (4).

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -1,5 +1,5 @@
 @sapi3
-Feature: Test the recurringOnDayOfWeek event search filter
+Feature: Test the recurringOnDayOfWeek search filter
 
   Background:
     Given I am using the UDB3 base URL
@@ -250,9 +250,181 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: An invalid weekday value is rejected with a validation error
+  Scenario: Permanent place is matched on the weekdays of its opening hours
+    When I create a minimal place with overrides and save the "url" as "placeUrl"
+    """
+    {
+      "calendarType": "permanent",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["monday", "wednesday", "friday"]
+        }
+      ]
+    }
+    """
+    And I wait for the place with url "%{placeUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Matching is case-insensitive, so the capitalised weekday returns the same result.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | Wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Tuesday is not part of the opening hours.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | tuesday |
+      | disableDefaultFilters | true    |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+    # The comma-separated syntax OR-combines the weekdays, so friday alone is enough to match.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | saturday,friday |
+      | disableDefaultFilters | true            |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | tuesday,thursday |
+      | disableDefaultFilters | true             |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+    # The recurringOnDayOfWeek field is also exposed in the q parameter, where AND logic can be
+    # expressed explicitly instead of the OR-combining of the url parameter.
+    # Tuesday is not part of the opening hours, so requiring both weekdays excludes the place.
+    When I send a GET request to "/places" with parameters:
+      | q                     | recurringOnDayOfWeek:(monday AND tuesday) |
+      | disableDefaultFilters | true                                      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+    # Both weekdays are part of the opening hours, so the AND query matches.
+    When I send a GET request to "/places" with parameters:
+      | q                     | recurringOnDayOfWeek:(monday AND wednesday) |
+      | disableDefaultFilters | true                                        |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+
+  @testIsolation
+  Scenario: Permanent place without opening hours is not matched by recurringOnDayOfWeek
+    # A permanent place with no opening hours has no weekdays to derive the filter from.
+    Given I create a minimal place and save the "url" as "placeUrl"
+    And I wait for the place with url "%{placeUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the recurringOnDayOfWeek filter the place is returned, so it is indexed and searchable.
+    When I send a GET request to "/places" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | monday |
+      | disableDefaultFilters | true   |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Periodic place is only matched on weekdays that reach the minimum number of occurrences
+    # The period from 1 to 26 August 2026 contains four Wednesdays (5, 12, 19 and 26), which is
+    # exactly the required minimum, and three Thursdays (6, 13 and 20), which is one short.
+    When I create a minimal place with overrides and save the "url" as "placeUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-08-26T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday", "thursday"]
+        }
+      ]
+    }
+    """
+    And I wait for the place with url "%{placeUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the recurringOnDayOfWeek filter the place is returned, so it is indexed and searchable.
+    When I send a GET request to "/places" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Wednesday reaches the threshold exactly, so it is indexed.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Thursday stays one occurrence below the threshold, so it is not indexed.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | thursday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Closed days are subtracted from the occurrences of a weekday of a place
+    # The period from 1 August to 2 September 2026 contains five Wednesdays and five Saturdays.
+    # The closed period from 5 to 12 August removes the Wednesdays of 5 and 12 August, leaving three,
+    # which is below the required minimum of four. It also removes the Saturday of 8 August, leaving
+    # four, which still reaches the minimum.
+    When I create a minimal place with overrides and save the "url" as "placeUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-09-02T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday", "saturday"]
+        }
+      ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-08-05",
+          "endDate": "2026-08-12"
+        }
+      ]
+    }
+    """
+    And I wait for the place with url "%{placeUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the recurringOnDayOfWeek filter the place is returned, so it is indexed and searchable.
+    When I send a GET request to "/places" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Saturday keeps four occurrences, so the closed days do not affect matching.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | saturday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Wednesday drops to three occurrences, so it is no longer indexed.
+    When I send a GET request to "/places" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: An invalid weekday value is rejected with a validation error on the events endpoint
     When I am using the Search API v3 base URL
     And I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | someday |
+      | disableDefaultFilters | true    |
+    Then the response status should be "404"
+    And the JSON response at "detail" should include "someday"
+
+  @testIsolation
+  Scenario: An invalid weekday value is rejected with a validation error on the places endpoint
+    When I am using the Search API v3 base URL
+    And I send a GET request to "/places" with parameters:
       | recurringOnDayOfWeek  | someday |
       | disableDefaultFilters | true    |
     Then the response status should be "404"

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -1,5 +1,5 @@
 @sapi3
-Feature: Test the dayOfWeek event search filter
+Feature: Test the recurringOnDayOfWeek event search filter
 
   Background:
     Given I am using the UDB3 base URL
@@ -26,18 +26,18 @@ Feature: Test the dayOfWeek event search filter
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | tuesday |
+      | recurringOnDayOfWeek  | tuesday |
       | disableDefaultFilters | true    |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: dayOfWeek matching is case-insensitive
+  Scenario: recurringOnDayOfWeek matching is case-insensitive
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
@@ -54,13 +54,13 @@ Feature: Test the dayOfWeek event search filter
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | Wednesday |
+      | recurringOnDayOfWeek  | Wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
 
   @testIsolation
-  Scenario: Multiple dayOfWeek values are OR-combined using the comma-separated syntax
+  Scenario: Multiple recurringOnDayOfWeek values are OR-combined using the comma-separated syntax
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
@@ -77,18 +77,18 @@ Feature: Test the dayOfWeek event search filter
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | friday,saturday,sunday |
+      | recurringOnDayOfWeek  | friday,saturday,sunday |
       | disableDefaultFilters | true                   |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | monday,tuesday |
+      | recurringOnDayOfWeek  | monday,tuesday |
       | disableDefaultFilters | true           |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Multiple dayOfWeek values are AND-combined using the q parameter
+  Scenario: Multiple recurringOnDayOfWeek values are AND-combined using the q parameter
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
@@ -104,23 +104,23 @@ Feature: Test the dayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # The dayOfWeek url parameter OR-combines its values, so a single matching weekday is enough.
+    # The recurringOnDayOfWeek url parameter OR-combines its values, so a single matching weekday is enough.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | monday,tuesday |
+      | recurringOnDayOfWeek  | monday,tuesday |
       | disableDefaultFilters | true           |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     # The same field is exposed in the q parameter, where AND logic can be expressed explicitly.
     # Tuesday is not part of the opening hours, so requiring both weekdays excludes the event.
     When I send a GET request to "/events" with parameters:
-      | q                     | dayOfWeek:(monday AND tuesday) |
-      | disableDefaultFilters | true                           |
+      | q                     | recurringOnDayOfWeek:(monday AND tuesday) |
+      | disableDefaultFilters | true                                      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
     # Both weekdays are part of the opening hours, so the AND query matches.
     When I send a GET request to "/events" with parameters:
-      | q                     | dayOfWeek:(monday AND wednesday) |
-      | disableDefaultFilters | true                             |
+      | q                     | recurringOnDayOfWeek:(monday AND wednesday) |
+      | disableDefaultFilters | true                                        |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
 
@@ -144,12 +144,12 @@ Feature: Test the dayOfWeek event search filter
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | thursday |
+      | recurringOnDayOfWeek  | thursday |
       | disableDefaultFilters | true     |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | friday |
+      | recurringOnDayOfWeek  | friday |
       | disableDefaultFilters | true   |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
@@ -176,7 +176,7 @@ Feature: Test the dayOfWeek event search filter
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
@@ -209,20 +209,20 @@ Feature: Test the dayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # Without the dayOfWeek filter the event is returned, so it is indexed and searchable.
+    # Without the recurringOnDayOfWeek filter the event is returned, so it is indexed and searchable.
     When I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    # With the dayOfWeek filter it is not returned, because the closed day brings Wednesday down to three.
+    # With the recurringOnDayOfWeek filter it is not returned, because the closed day brings Wednesday down to three.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by dayOfWeek
+  Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by recurringOnDayOfWeek
     # The event runs on Wednesdays but only spans two weeks (2026-08-05 and 2026-08-12),
     # so the weekday occurs fewer than the required minimum number of times (4).
     When I create a minimal event with overrides and save the "url" as "eventUrl"
@@ -242,14 +242,14 @@ Feature: Test the dayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # Without the dayOfWeek filter the event is returned, so it is searchable.
+    # Without the recurringOnDayOfWeek filter the event is returned, so it is searchable.
     When I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    # With the dayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
+    # With the recurringOnDayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
@@ -274,12 +274,12 @@ Feature: Test the dayOfWeek event search filter
     And I am using the Search API v3 base URL
     # All four sub-events fall on a Wednesday.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | thursday |
+      | recurringOnDayOfWeek  | thursday |
       | disableDefaultFilters | true     |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
@@ -305,25 +305,25 @@ Feature: Test the dayOfWeek event search filter
     And I am using the Search API v3 base URL
     # Saturday sits in the middle of each Friday-to-Sunday range, so it must be part of the set.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | saturday |
+      | recurringOnDayOfWeek  | saturday |
       | disableDefaultFilters | true     |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     # The union OR-combines with the other days in the range too.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | friday,sunday |
+      | recurringOnDayOfWeek  | friday,sunday |
       | disableDefaultFilters | true          |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     # No sub-event ever touches a Monday.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | monday |
+      | recurringOnDayOfWeek  | monday |
       | disableDefaultFilters | true   |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Single calendar event is out of scope and not matched by dayOfWeek
+  Scenario: Single calendar event is out of scope and not matched by recurringOnDayOfWeek
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
@@ -337,14 +337,14 @@ Feature: Test the dayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # The single event takes place on a Wednesday and is searchable without the dayOfWeek filter.
+    # The single event takes place on a Wednesday and is searchable without the recurringOnDayOfWeek filter.
     When I send a GET request to "/events" with parameters:
       | disableDefaultFilters | true |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    # But single calendar events are never matched by the dayOfWeek filter.
+    # But single calendar events are never matched by the recurringOnDayOfWeek filter.
     When I send a GET request to "/events" with parameters:
-      | dayOfWeek             | wednesday |
+      | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
@@ -353,6 +353,6 @@ Feature: Test the dayOfWeek event search filter
   Scenario: An invalid weekday value is rejected with a validation error
     When I am using the Search API v3 base URL
     And I send a GET request to "/events" with parameters:
-      | dayOfWeek             | someday |
+      | recurringOnDayOfWeek  | someday |
       | disableDefaultFilters | true    |
     Then the response status should be "404"

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -6,10 +6,10 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And I am using an UiTID v1 API key of consumer "uitdatabank"
     And I am authorized as JWT provider user "centraal_beheerder"
     And I send and accept "application/json"
-    And I create a minimal place and save the "url" as "placeUrl"
 
   @testIsolation
-  Scenario: Permanent event is matched by a weekday in its opening hours and not by another weekday
+  Scenario: Permanent event is matched on the weekdays of its opening hours
+    Given I create a minimal place and save the "url" as "placeUrl"
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
@@ -30,80 +30,29 @@ Feature: Test the recurringOnDayOfWeek event search filter
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | tuesday |
-      | disableDefaultFilters | true    |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
-  Scenario: recurringOnDayOfWeek matching is case-insensitive
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "permanent",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["wednesday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
+    # Matching is case-insensitive, so the capitalised weekday returns the same result.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | Wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-
-  @testIsolation
-  Scenario: Multiple recurringOnDayOfWeek values are OR-combined using the comma-separated syntax
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "permanent",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["sunday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
+    # Tuesday is not part of the opening hours.
     When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | friday,saturday,sunday |
-      | disableDefaultFilters | true                   |
+      | recurringOnDayOfWeek  | tuesday |
+      | disableDefaultFilters | true    |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+    # The comma-separated syntax OR-combines the weekdays, so friday alone is enough to match.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | saturday,friday |
+      | disableDefaultFilters | true            |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | monday,tuesday |
-      | disableDefaultFilters | true           |
+      | recurringOnDayOfWeek  | tuesday,thursday |
+      | disableDefaultFilters | true             |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 0
-
-  @testIsolation
-  Scenario: Multiple recurringOnDayOfWeek values are AND-combined using the q parameter
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "permanent",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["monday", "wednesday", "friday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
     # The recurringOnDayOfWeek field is also exposed in the q parameter, where AND logic can be
     # expressed explicitly instead of the OR-combining of the url parameter.
     # Tuesday is not part of the opening hours, so requiring both weekdays excludes the event.
@@ -120,84 +69,21 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 1
 
   @testIsolation
-  Scenario: Periodic event spanning several months is matched based on its opening hours weekday
+  Scenario: Periodic event is only matched on weekdays that reach the minimum number of occurrences
+    # The period from 1 to 26 August 2026 contains four Wednesdays (5, 12, 19 and 26), which is
+    # exactly the required minimum, and three Thursdays (6, 13 and 20), which is one short.
+    Given I create a minimal place and save the "url" as "placeUrl"
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
       "calendarType": "periodic",
       "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-11-30T23:59:59+02:00",
+      "endDate": "2026-08-26T23:59:59+02:00",
       "openingHours": [
         {
           "opens": "09:00",
           "closes": "17:00",
-          "dayOfWeek": ["thursday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | thursday |
-      | disableDefaultFilters | true     |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | friday |
-      | disableDefaultFilters | true   |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
-  Scenario: Periodic event is matched when its weekday reaches the threshold exactly
-    # August 2026 contains exactly four Wednesdays (5, 12, 19 and 26), which is the minimum
-    # number of occurrences required, so wednesday is indexed and the event matches.
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "periodic",
-      "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-08-31T23:59:59+02:00",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["wednesday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | wednesday |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-
-  @testIsolation
-  Scenario: A closed day drops a weekday below the threshold so the event is no longer matched
-    # Same August 2026 window as the previous scenario, but the Wednesday of 5 August is closed.
-    # That leaves three days the event is effectively open on a Wednesday, which is below the
-    # required minimum of four, so wednesday is not indexed.
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "periodic",
-      "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-08-31T23:59:59+02:00",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["wednesday"]
-        }
-      ],
-      "openingHoursClosedDays": [
-        {
-          "startDate": "2026-08-05",
-          "endDate": "2026-08-05"
+          "dayOfWeek": ["wednesday", "thursday"]
         }
       ]
     }
@@ -209,103 +95,13 @@ Feature: Test the recurringOnDayOfWeek event search filter
       | disableDefaultFilters | true |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    # With the recurringOnDayOfWeek filter it is not returned, because the closed day brings Wednesday down to three.
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | wednesday |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
-  Scenario: A closed day that keeps a weekday above the threshold does not affect matching
-    # August and September 2026 together contain nine Wednesdays, so closing the one of 5 August still
-    # leaves eight, which is above the required minimum of four. Wednesday stays indexed.
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "periodic",
-      "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-09-30T23:59:59+02:00",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["wednesday"]
-        }
-      ],
-      "openingHoursClosedDays": [
-        {
-          "startDate": "2026-08-05",
-          "endDate": "2026-08-05"
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
+    # Wednesday reaches the threshold exactly, so it is indexed.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | wednesday |
       | disableDefaultFilters | true      |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-
-  @testIsolation
-  Scenario: Periodic event with fewer than four occurrences on a weekday is not matched by recurringOnDayOfWeek
-    # The event runs on Wednesdays but only spans two weeks (2026-08-05 and 2026-08-12),
-    # so the weekday occurs fewer than the required minimum number of times (4).
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "periodic",
-      "startDate": "2026-08-01T00:00:00+02:00",
-      "endDate": "2026-08-16T23:59:59+02:00",
-      "openingHours": [
-        {
-          "opens": "09:00",
-          "closes": "17:00",
-          "dayOfWeek": ["wednesday"]
-        }
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    # Without the recurringOnDayOfWeek filter the event is returned, so it is searchable.
-    When I send a GET request to "/events" with parameters:
-      | disableDefaultFilters | true |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    # With the recurringOnDayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | wednesday |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
-  Scenario: Multiple calendar event maps single-day sub-events to their weekday
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "multiple",
-      "startDate": "2026-08-05T10:00:00+02:00",
-      "endDate": "2026-08-26T18:00:00+02:00",
-      "subEvent": [
-        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"},
-        {"startDate": "2026-08-12T10:00:00+02:00", "endDate": "2026-08-12T18:00:00+02:00"},
-        {"startDate": "2026-08-19T10:00:00+02:00", "endDate": "2026-08-19T18:00:00+02:00"},
-        {"startDate": "2026-08-26T10:00:00+02:00", "endDate": "2026-08-26T18:00:00+02:00"}
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    # All four sub-events fall on a Wednesday.
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | wednesday |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
+    # Thursday stays one occurrence below the threshold, so it is not indexed.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | thursday |
       | disableDefaultFilters | true     |
@@ -313,15 +109,72 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Multiple calendar event expands multi-day sub-events to every weekday in their range
-    # Each sub-event runs Friday to Sunday, so it covers Friday, Saturday and Sunday.
+  Scenario: Closed days are subtracted from the occurrences of a weekday
+    # The period from 1 August to 2 September 2026 contains five Wednesdays and five Saturdays.
+    # The closed period from 5 to 12 August removes the Wednesdays of 5 and 12 August, leaving three,
+    # which is below the required minimum of four. It also removes the Saturday of 8 August, leaving
+    # four, which still reaches the minimum.
+    Given I create a minimal place and save the "url" as "placeUrl"
+    When I create a minimal event with overrides and save the "url" as "eventUrl"
+    """
+    {
+      "calendarType": "periodic",
+      "startDate": "2026-08-01T00:00:00+02:00",
+      "endDate": "2026-09-02T23:59:59+02:00",
+      "openingHours": [
+        {
+          "opens": "09:00",
+          "closes": "17:00",
+          "dayOfWeek": ["wednesday", "saturday"]
+        }
+      ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-08-05",
+          "endDate": "2026-08-12"
+        }
+      ]
+    }
+    """
+    And I wait for the event with url "%{eventUrl}" to be indexed
+    And I am using the Search API v3 base URL
+    # Without the recurringOnDayOfWeek filter the event is returned, so it is indexed and searchable.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Saturday keeps four occurrences, so the closed days do not affect matching.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | saturday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Wednesday drops to three occurrences, so it is no longer indexed.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: Multiple calendar event is matched on the weekdays covered by its sub-events
+    # Four single day sub-events on a Wednesday, four sub-events running from Friday to Sunday and
+    # three single day sub-events on a Thursday.
+    Given I create a minimal place and save the "url" as "placeUrl"
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {
       "calendarType": "multiple",
-      "startDate": "2026-09-04T10:00:00+02:00",
+      "startDate": "2026-08-05T10:00:00+02:00",
       "endDate": "2026-09-27T18:00:00+02:00",
       "subEvent": [
+        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"},
+        {"startDate": "2026-08-12T10:00:00+02:00", "endDate": "2026-08-12T18:00:00+02:00"},
+        {"startDate": "2026-08-19T10:00:00+02:00", "endDate": "2026-08-19T18:00:00+02:00"},
+        {"startDate": "2026-08-26T10:00:00+02:00", "endDate": "2026-08-26T18:00:00+02:00"},
+        {"startDate": "2026-08-06T10:00:00+02:00", "endDate": "2026-08-06T18:00:00+02:00"},
+        {"startDate": "2026-08-13T10:00:00+02:00", "endDate": "2026-08-13T18:00:00+02:00"},
+        {"startDate": "2026-08-20T10:00:00+02:00", "endDate": "2026-08-20T18:00:00+02:00"},
         {"startDate": "2026-09-04T10:00:00+02:00", "endDate": "2026-09-06T18:00:00+02:00"},
         {"startDate": "2026-09-11T10:00:00+02:00", "endDate": "2026-09-13T18:00:00+02:00"},
         {"startDate": "2026-09-18T10:00:00+02:00", "endDate": "2026-09-20T18:00:00+02:00"},
@@ -331,18 +184,36 @@ Feature: Test the recurringOnDayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # Saturday sits in the middle of each Friday-to-Sunday range, so it must be part of the set.
+    # Without the recurringOnDayOfWeek filter the event is returned, so it is indexed and searchable.
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # The four single day sub-events map to the weekday they take place on.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | wednesday |
+      | disableDefaultFilters | true      |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 1
+    # Saturday sits in the middle of each Friday to Sunday range, so multi-day sub-events are
+    # expanded to every weekday in their range.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | saturday |
       | disableDefaultFilters | true     |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
-    # The union OR-combines with the other days in the range too.
+    # The edges of those ranges are part of the set too.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | friday,sunday |
       | disableDefaultFilters | true          |
     Then the response status should be "200"
     And the JSON response at "totalItems" should be 1
+    # Thursday is only covered three times, which is below the required minimum of four.
+    When I send a GET request to "/events" with parameters:
+      | recurringOnDayOfWeek  | thursday |
+      | disableDefaultFilters | true     |
+    Then the response status should be "200"
+    And the JSON response at "totalItems" should be 0
     # No sub-event ever touches a Monday.
     When I send a GET request to "/events" with parameters:
       | recurringOnDayOfWeek  | monday |
@@ -351,38 +222,8 @@ Feature: Test the recurringOnDayOfWeek event search filter
     And the JSON response at "totalItems" should be 0
 
   @testIsolation
-  Scenario: Multiple calendar event with fewer than four occurrences on a weekday is not matched by recurringOnDayOfWeek
-    # Only three sub-events, all on a Wednesday (2026-08-05, 2026-08-12 and 2026-08-19), so the
-    # weekday occurs fewer than the required minimum number of times (4).
-    When I create a minimal event with overrides and save the "url" as "eventUrl"
-    """
-    {
-      "calendarType": "multiple",
-      "startDate": "2026-08-05T10:00:00+02:00",
-      "endDate": "2026-08-19T18:00:00+02:00",
-      "subEvent": [
-        {"startDate": "2026-08-05T10:00:00+02:00", "endDate": "2026-08-05T18:00:00+02:00"},
-        {"startDate": "2026-08-12T10:00:00+02:00", "endDate": "2026-08-12T18:00:00+02:00"},
-        {"startDate": "2026-08-19T10:00:00+02:00", "endDate": "2026-08-19T18:00:00+02:00"}
-      ]
-    }
-    """
-    And I wait for the event with url "%{eventUrl}" to be indexed
-    And I am using the Search API v3 base URL
-    # Without the recurringOnDayOfWeek filter the event is returned, so it is searchable.
-    When I send a GET request to "/events" with parameters:
-      | disableDefaultFilters | true |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    # With the recurringOnDayOfWeek filter it is not returned, because Wednesday occurs fewer than four times.
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | wednesday |
-      | disableDefaultFilters | true      |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 0
-
-  @testIsolation
   Scenario: Single calendar event is out of scope and not matched by recurringOnDayOfWeek
+    Given I create a minimal place and save the "url" as "placeUrl"
     When I create a minimal event with overrides and save the "url" as "eventUrl"
     """
     {

--- a/features/search/recurring-on-day-of-week.feature
+++ b/features/search/recurring-on-day-of-week.feature
@@ -104,13 +104,8 @@ Feature: Test the recurringOnDayOfWeek event search filter
     """
     And I wait for the event with url "%{eventUrl}" to be indexed
     And I am using the Search API v3 base URL
-    # The recurringOnDayOfWeek url parameter OR-combines its values, so a single matching weekday is enough.
-    When I send a GET request to "/events" with parameters:
-      | recurringOnDayOfWeek  | monday,tuesday |
-      | disableDefaultFilters | true           |
-    Then the response status should be "200"
-    And the JSON response at "totalItems" should be 1
-    # The same field is exposed in the q parameter, where AND logic can be expressed explicitly.
+    # The recurringOnDayOfWeek field is also exposed in the q parameter, where AND logic can be
+    # expressed explicitly instead of the OR-combining of the url parameter.
     # Tuesday is not part of the opening hours, so requiring both weekdays excludes the event.
     When I send a GET request to "/events" with parameters:
       | q                     | recurringOnDayOfWeek:(monday AND tuesday) |


### PR DESCRIPTION
### Added

- Add `features/search/recurring-on-day-of-week.feature`, a new `@sapi3` acceptance test suite covering the `recurringOnDayOfWeek` search filter for both events and places
- Cover permanent events and places, asserting that they are matched on every weekday listed in their opening hours and not on the weekdays that are absent from it
- Cover a permanent place without any opening hours, asserting that it stays searchable but is never matched by the `recurringOnDayOfWeek` filter
- Cover periodic events and places, asserting that a weekday is only matched once it reaches the minimum of four occurrences within the period and stays unmatched when it falls one occurrence short
- Cover `openingHoursClosedDays` for periodic events and places, asserting that closed days are subtracted from the occurrences of a weekday and can push a weekday below the minimum threshold while leaving another weekday above it
- Cover multiple calendar events, asserting that single day sub-events map to the weekday they take place on, that multi-day sub-events are expanded to every weekday in their range including both edges, and that a weekday covered fewer than four times is not matched
- Cover single calendar events, asserting that they remain searchable but are out of scope for the `recurringOnDayOfWeek` filter
- Assert that weekday matching is case-insensitive, so `Wednesday` returns the same result as `wednesday`
- Assert that the comma-separated url parameter syntax OR-combines the weekdays, while the `q` parameter exposes the same field for explicit AND logic
- Assert that an invalid weekday value is rejected with a 404 on both the `/events` and the `/places` endpoint, and that the rejected value is echoed back in the error detail

---
Ticket: https://jira.uitdatabank.be/browse/III-7246
