### PR TITLE
III-7360 Fix/expand childrenOnly tests

### DIFF
--- a/features/search/children-only.feature
+++ b/features/search/children-only.feature
@@ -18,7 +18,7 @@ Feature: Test the Search API v3 boa feature
     And I am not using an UiTID v1 API key
 
   # boa scope: no, childrenOnly param: not given
-  # -> I only see my own children only event, not the one created by someone else
+  # -> I see neither my own children only event, not the one created by someone else
   #    The normal event always shows up.
   Scenario: Without boa scope and without childrenOnly parameter I only find my own children only events
     When I am authorized with an OAuth client access token for "test_client"
@@ -31,15 +31,15 @@ Feature: Test the Search API v3 boa feature
       | q | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
     And the JSON response should include:
     """
-    %{myChildrenOnlyEventId}
-    """
-    And the JSON response should include:
-    """
     %{basicEventId}
     """
     And the JSON response should not include:
     """
     %{otherChildrenOnlyEventId}
+    """
+    And the JSON response should not include:
+    """
+    %{myChildrenOnlyEventId}
     """
 
   # boa scope: no, childrenOnly param: true
@@ -95,7 +95,7 @@ Feature: Test the Search API v3 boa feature
     """
 
   # boa scope: yes, childrenOnly param: not given
-  # -> I see every children only event, mine and the one created by someone else
+  # -> I see no children only events, neither mine nor the one created by someone else
   #    The normal event always shows up.
   Scenario: With boa scope and without childrenOnly parameter I find all children only events
     When I am authorized with an OAuth client access token for "boa_client"
@@ -106,11 +106,11 @@ Feature: Test the Search API v3 boa feature
     And I am using a x-client-id header for client "boa_client"
     When I send a GET request to "/events" with parameters:
       | q | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
-    And the JSON response should include:
+    And the JSON response should not include:
     """
     %{myChildrenOnlyEventId}
     """
-    And the JSON response should include:
+    And the JSON response should not include:
     """
     %{otherChildrenOnlyEventId}
     """

--- a/features/search/children-only.feature
+++ b/features/search/children-only.feature
@@ -94,6 +94,32 @@ Feature: Test the Search API v3 boa feature
     %{otherChildrenOnlyEventId}
     """
 
+  # boa scope: no, childrenOnly param: *
+  # -> I only see my own children only event, not the one created by someone else
+  #    The normal event also shows up.
+  Scenario: Without boa scope and with childrenOnly=* I find my own children only events and all regular events
+    When I am authorized with an OAuth client access token for "test_client"
+    And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
+    And I publish the event at "/events/%{myChildrenOnlyEventId}"
+    And I wait for the event with url "/events/%{myChildrenOnlyEventId}" to be indexed
+    And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "test_client"
+    When I send a GET request to "/events" with parameters:
+      | childrenOnly | *                                                                               |
+      | q            | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
+    And the JSON response should include:
+    """
+    %{basicEventId}
+    """
+    And the JSON response should include:
+    """
+    %{myChildrenOnlyEventId}
+    """
+    And the JSON response should not include:
+    """
+    %{otherChildrenOnlyEventId}
+    """
+
   # boa scope: yes, childrenOnly param: not given
   # -> I see no children only events, neither mine nor the one created by someone else
   #    The normal event always shows up.
@@ -169,6 +195,32 @@ Feature: Test the Search API v3 boa feature
     And the JSON response should not include:
     """
     %{otherChildrenOnlyEventId}
+    """
+
+  # boa scope: yes, childrenOnly param: *
+  # -> I see all children only events
+  #    The normal event also shows up.
+  Scenario: With boa scope and with childrenOnly=* I find all children only events and all regular events
+    When I am authorized with an OAuth client access token for "boa_client"
+    And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
+    And I publish the event at "/events/%{myChildrenOnlyEventId}"
+    And I wait for the event with url "/events/%{myChildrenOnlyEventId}" to be indexed
+    And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
+    When I send a GET request to "/events" with parameters:
+      | childrenOnly | *                                                                    |
+      | q | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
+    And the JSON response should include:
+    """
+    %{myChildrenOnlyEventId}
+    """
+    And the JSON response should include:
+    """
+    %{otherChildrenOnlyEventId}
+    """
+    And the JSON response should include:
+    """
+    %{basicEventId}
     """
 
   Scenario: With an UiTID v1 API that is not matched to a clientId I cannot find any children only events

--- a/features/search/children-only.feature
+++ b/features/search/children-only.feature
@@ -120,6 +120,32 @@ Feature: Test the Search API v3 boa feature
     %{otherChildrenOnlyEventId}
     """
 
+  # boa scope: no, disableDefaultFilters param: true
+  # -> I only see my own children only event, not the one created by someone else
+  #    The normal event also shows up.
+  Scenario: Without boa scope and with disableDefaultFilters=true I find my own children only events and all regular events
+    When I am authorized with an OAuth client access token for "test_client"
+    And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
+    And I publish the event at "/events/%{myChildrenOnlyEventId}"
+    And I wait for the event with url "/events/%{myChildrenOnlyEventId}" to be indexed
+    And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "test_client"
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                                                   |
+      | q            | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
+    And the JSON response should include:
+    """
+    %{basicEventId}
+    """
+    And the JSON response should include:
+    """
+    %{myChildrenOnlyEventId}
+    """
+    And the JSON response should not include:
+    """
+    %{otherChildrenOnlyEventId}
+    """
+
   # boa scope: yes, childrenOnly param: not given
   # -> I see no children only events, neither mine nor the one created by someone else
   #    The normal event always shows up.
@@ -209,6 +235,32 @@ Feature: Test the Search API v3 boa feature
     And I am using a x-client-id header for client "boa_client"
     When I send a GET request to "/events" with parameters:
       | childrenOnly | *                                                                    |
+      | q | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
+    And the JSON response should include:
+    """
+    %{myChildrenOnlyEventId}
+    """
+    And the JSON response should include:
+    """
+    %{otherChildrenOnlyEventId}
+    """
+    And the JSON response should include:
+    """
+    %{basicEventId}
+    """
+
+  # boa scope: yes, disableDefaultFilters param: true
+  # -> I see all children only events
+  #    The normal event also shows up.
+  Scenario: With boa scope and with disableDefaultFilters=true I find all children only events and all regular events
+    When I am authorized with an OAuth client access token for "boa_client"
+    And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
+    And I publish the event at "/events/%{myChildrenOnlyEventId}"
+    And I wait for the event with url "/events/%{myChildrenOnlyEventId}" to be indexed
+    And I am using the Search API v3 base URL
+    And I am using a x-client-id header for client "boa_client"
+    When I send a GET request to "/events" with parameters:
+      | disableDefaultFilters | true                                                        |
       | q | id:(%{otherChildrenOnlyEventId} OR %{myChildrenOnlyEventId} OR %{basicEventId}) |
     And the JSON response should include:
     """

--- a/features/search/children-only.feature
+++ b/features/search/children-only.feature
@@ -20,7 +20,7 @@ Feature: Test the Search API v3 boa feature
   # boa scope: no, childrenOnly param: not given
   # -> I see neither my own children only event, not the one created by someone else
   #    The normal event always shows up.
-  Scenario: Without boa scope and without childrenOnly parameter I only find my own children only events
+  Scenario: Without boa scope and without childrenOnly parameter I find no children only events
     When I am authorized with an OAuth client access token for "test_client"
     And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
     And I publish the event at "/events/%{myChildrenOnlyEventId}"
@@ -97,7 +97,7 @@ Feature: Test the Search API v3 boa feature
   # boa scope: yes, childrenOnly param: not given
   # -> I see no children only events, neither mine nor the one created by someone else
   #    The normal event always shows up.
-  Scenario: With boa scope and without childrenOnly parameter I find all children only events
+  Scenario: With boa scope and without childrenOnly parameter I find no children only events
     When I am authorized with an OAuth client access token for "boa_client"
     And I create an event from "events/event-children-only.json" and save the "id" as "myChildrenOnlyEventId"
     And I publish the event at "/events/%{myChildrenOnlyEventId}"


### PR DESCRIPTION
### Added

- Added tests for `childrenOnly=*`
- Added tests for `childrenOnly` when using `disableDefaultFilters=true`

### Changed

- Updated tests of no parameter being declared to work the same as `childrenOnly=false`

---

Ticket: https://jira.uitdatabank.be/browse/III-7360

⚠️ Only merge together with https://github.com/cultuurnet/udb3-search-service/pull/513

⚠️ When running the feature tests locally I always get failing tests inside `permissions.feature`, both on the branch of the childrenOnly changes (in udb3-backend + udb3-search-service), as well as on master/main of both repositories at the same time. So it seems unrelated and something to do with my local setup, but since the permissions do SearchAPI queries it would be good if someone would double check on their machine before merging all related PRs. > Verified by Koen ✅ 

⚠️ Converted back to draft while ticket is waiting on feedback
