### PR TITLE
III-7190 Drop matchingBirthdateRanges assertions from the search features

### DIFF
--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -255,25 +255,6 @@ Feature: Test the Search API v3 advanced queries on offers
     """
     %{eventId2022}
     """
-    And the JSON response at "matchingBirthdateRanges" should be:
-    """
-    [
-      {
-         "from":"2020-01-01",
-         "to":"2020-12-31",
-         "matches":[
-            "http:\/\/io.uitdatabank.local:80\/events\/%{eventId2020}"
-         ]
-      },
-      {
-         "from":"2022-06-30",
-         "to":"2022-12-31",
-         "matches":[
-            "http:\/\/io.uitdatabank.local:80\/events\/%{eventId2022}"
-         ]
-      }
-    ]
-    """
 
 
   @testIsolation

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -287,18 +287,6 @@ Feature: Test the Search API v3 url parameters on offers
     """
     %{eventId2020}
     """
-    And the JSON response at "matchingBirthdateRanges" should be:
-    """
-    [
-      {
-         "from":"2020-01-01",
-         "to":"2020-12-31",
-         "matches":[
-            "http:\/\/io.uitdatabank.local:80\/events\/%{eventId2020}"
-         ]
-      }
-    ]
-    """
 
   @testIsolation
   Scenario: Search by birthdate range using an url parameter also matches events with the equivalent typical age range


### PR DESCRIPTION
## Summary
- Removes the two `matchingBirthdateRanges` assertion blocks, since the field is removed from the Search API in cultuurnet/udb3-search-service#517.
- Both scenarios keep their `totalItems` and "response should include" assertions, so birthdate range filtering itself stays covered — only the assertion on the removed response field goes.

Effectively this reverts #2325, the counterpart of cultuurnet/udb3-search-service#504.

## Related
- https://github.com/cultuurnet/udb3-search-service/pull/517

Needs to land together with the search-service PR: these scenarios run against a deployed Search API, so they only pass once the field is gone there.

## Ticket
https://jira.publiq.be/browse/III-7190

🤖 Generated with [Claude Code](https://claude.com/claude-code)