### PR TITLE
Add search feature tests for converted age and birthdate ranges

### DIFF
--- a/features/Steps/EventSteps.php
+++ b/features/Steps/EventSteps.php
@@ -225,12 +225,11 @@ trait EventSteps
     }
 
     /**
-     * @When I get the typical age range for one born in :birthYear and keep it as :typicalAgeRange
+     * @When I get the typical age range for someone born in :birthYear as of :referenceYear and keep it as :typicalAgeRange
      */
-    public function iGetTheTypicalAgeRangeForOneBornIn(int $birthYear, string $typicalAgeRange): void
+    public function iGetTheTypicalAgeRangeForOneBornInAsOf(int $birthYear, int $referenceYear, string $typicalAgeRange): void
     {
-        $currentYear = (int) date('Y');
-        $maxAge = $currentYear - $birthYear;
+        $maxAge = $referenceYear - $birthYear;
         $minAge = $maxAge - 1;
         $this->variableState->setVariable(
             $typicalAgeRange,

--- a/features/data/events/event-with-age-and-birthdate-range-single.json
+++ b/features/data/events/event-with-age-and-birthdate-range-single.json
@@ -1,0 +1,25 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Single event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "single",
+  "startDate": "2017-04-22T10:00:00+00:00",
+  "endDate": "2017-04-22T18:00:00+00:00",
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "typicalAgeRange": "9-11",
+  "birthdateRange": {
+    "from": "2010-01-01",
+    "to": "2010-12-31"
+  }
+}

--- a/features/data/events/event-with-all-ages.json
+++ b/features/data/events/event-with-all-ages.json
@@ -1,0 +1,19 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Permanent event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "permanent",
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "typicalAgeRange": "-"
+}

--- a/features/data/events/event-with-birthdate-range-in-2020.json
+++ b/features/data/events/event-with-birthdate-range-in-2020.json
@@ -1,7 +1,7 @@
 {
   "mainLanguage": "nl",
   "name": {
-    "nl": "Permanent event"
+    "nl": "Single event"
   },
   "terms": [
     {
@@ -13,7 +13,9 @@
   "location": {
     "@id": "%{placeUrl}"
   },
-  "calendarType": "permanent",
+  "calendarType": "single",
+  "startDate": "2021-06-01T10:00:00+00:00",
+  "endDate": "2021-06-01T18:00:00+00:00",
   "workflowStatus": "READY_FOR_VALIDATION",
   "birthdateRange": {
     "from": "2020-01-31",

--- a/features/data/events/event-with-birthdate-range-in-2022.json
+++ b/features/data/events/event-with-birthdate-range-in-2022.json
@@ -1,7 +1,7 @@
 {
   "mainLanguage": "nl",
   "name": {
-    "nl": "Permanent event"
+    "nl": "Single event"
   },
   "terms": [
     {
@@ -13,7 +13,9 @@
   "location": {
     "@id": "%{placeUrl}"
   },
-  "calendarType": "permanent",
+  "calendarType": "single",
+  "startDate": "2023-06-01T10:00:00+00:00",
+  "endDate": "2023-06-01T18:00:00+00:00",
   "workflowStatus": "READY_FOR_VALIDATION",
   "birthdateRange": {
     "from": "2022-01-31",

--- a/features/data/events/event-with-birthdate-range-multiple.json
+++ b/features/data/events/event-with-birthdate-range-multiple.json
@@ -1,0 +1,32 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Multiple event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "multiple",
+  "subEvent": [
+    {
+      "startDate": "2017-04-22T10:00:00+00:00",
+      "endDate": "2017-04-22T18:00:00+00:00"
+    },
+    {
+      "startDate": "2017-06-22T10:00:00+00:00",
+      "endDate": "2017-06-22T18:00:00+00:00"
+    }
+  ],
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "birthdateRange": {
+    "from": "2010-01-01",
+    "to": "2010-12-31"
+  }
+}

--- a/features/data/events/event-with-birthdate-range-periodic.json
+++ b/features/data/events/event-with-birthdate-range-periodic.json
@@ -1,0 +1,42 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Periodic event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "periodic",
+  "startDate": "2017-04-22T10:00:00+00:00",
+  "endDate": "2017-12-31T18:00:00+00:00",
+  "openingHours": [
+    {
+      "opens": "10:00",
+      "closes": "16:00",
+      "dayOfWeek": [
+        "monday",
+        "tuesday"
+      ]
+    },
+    {
+      "opens": "09:00",
+      "closes": "17:00",
+      "dayOfWeek": [
+        "saturday",
+        "sunday"
+      ]
+    }
+  ],
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "birthdateRange": {
+    "from": "2010-01-01",
+    "to": "2010-12-31"
+  }
+}

--- a/features/data/events/event-with-birthdate-range-single.json
+++ b/features/data/events/event-with-birthdate-range-single.json
@@ -1,0 +1,24 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Single event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "single",
+  "startDate": "2017-04-22T10:00:00+00:00",
+  "endDate": "2017-04-22T18:00:00+00:00",
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "birthdateRange": {
+    "from": "2010-01-01",
+    "to": "2010-12-31"
+  }
+}

--- a/features/data/events/event-with-typical-age-range-single.json
+++ b/features/data/events/event-with-typical-age-range-single.json
@@ -1,0 +1,21 @@
+{
+  "mainLanguage": "nl",
+  "name": {
+    "nl": "Single event"
+  },
+  "terms": [
+    {
+      "id": "0.50.4.0.0",
+      "label": "Concert",
+      "domain": "eventtype"
+    }
+  ],
+  "location": {
+    "@id": "%{placeUrl}"
+  },
+  "calendarType": "single",
+  "startDate": "2017-04-22T10:00:00+00:00",
+  "endDate": "2017-04-22T18:00:00+00:00",
+  "workflowStatus": "READY_FOR_VALIDATION",
+  "typicalAgeRange": "6-7"
+}

--- a/features/data/events/event-with-variable-typical-age-range.json
+++ b/features/data/events/event-with-variable-typical-age-range.json
@@ -1,7 +1,7 @@
 {
   "mainLanguage": "nl",
   "name": {
-    "nl": "Permanent event"
+    "nl": "Single event"
   },
   "terms": [
     {
@@ -13,7 +13,9 @@
   "location": {
     "@id": "%{placeUrl}"
   },
-  "calendarType": "permanent",
+  "calendarType": "single",
+  "startDate": "2021-06-01T10:00:00+00:00",
+  "endDate": "2021-06-01T18:00:00+00:00",
   "workflowStatus": "READY_FOR_VALIDATION",
   "typicalAgeRange": "%{variableTypicalAgeRange}"
 }

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -300,7 +300,9 @@ Feature: Test the Search API v3 advanced queries on offers
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | q | id:%{eventId2020} AND typicalAgeRange:[0 TO 200] |
+      | q             | typicalAgeRange:[0 TO 5] |
+      | availableFrom | *                        |
+      | availableTo   | *                        |
     Then the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -224,17 +224,23 @@ Feature: Test the Search API v3 advanced queries on offers
     And I wait for the event with url "/events/%{eventId2022}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:[2019-01-01 TO 2019-12-31] |
+      | q             | birthdateRange:[2019-01-01 TO 2019-12-31] |
+      | availableFrom | *                                         |
+      | availableTo   | *                                         |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:[2020-01-01 TO 2020-12-31] |
+      | q             | birthdateRange:[2020-01-01 TO 2020-12-31] |
+      | availableFrom | *                                         |
+      | availableTo   | *                                         |
     Then the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
     %{eventId2020}
     """
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31]) |
+      | q             | birthdateRange:([2020-01-01 TO 2020-12-31] OR [2022-06-30 TO 2022-12-31]) |
+      | availableFrom | *                                                                        |
+      | availableTo   | *                                                                        |
     Then the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """
@@ -245,7 +251,9 @@ Feature: Test the Search API v3 advanced queries on offers
     %{eventId2022}
     """
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:[2020-01-01 TO 2020-12-31] OR birthdateRange:[2022-06-30 TO 2022-12-31] |
+      | q             | birthdateRange:[2020-01-01 TO 2020-12-31] OR birthdateRange:[2022-06-30 TO 2022-12-31] |
+      | availableFrom | *                                                                                     |
+      | availableTo   | *                                                                                     |
     Then the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """
@@ -262,15 +270,19 @@ Feature: Test the Search API v3 advanced queries on offers
     When I create a minimal place and save the "url" as "placeUrl"
     And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
-    And I get the typical age range for one born in 2020 and keep it as "variableTypicalAgeRange"
+    And I get the typical age range for someone born in 2020 as of 2021 and keep it as "variableTypicalAgeRange"
     And I create an event from "events/event-with-variable-typical-age-range.json" and save the "id" as "eventIdWithAgeRange"
     And I wait for the event with url "/events/%{eventIdWithAgeRange}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:[2018-01-01 TO 2018-12-31] |
+      | q             | birthdateRange:[2018-01-01 TO 2018-12-31] |
+      | availableFrom | *                                         |
+      | availableTo   | *                                         |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
-      | q | birthdateRange:[2020-01-01 TO 2020-12-31] |
+      | q             | birthdateRange:[2020-01-01 TO 2020-12-31] |
+      | availableFrom | *                                         |
+      | availableTo   | *                                         |
     Then the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -308,6 +308,11 @@ Feature: Test the Search API v3 advanced queries on offers
     """
     %{eventId2020}
     """
+    When I send a GET request to "/events" with parameters:
+      | q             | typicalAgeRange:[2 TO 10] |
+      | availableFrom | *                         |
+      | availableTo   | *                         |
+    Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using an advanced query
     When I create a minimal place and save the "id" as "placeId"

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -281,6 +281,20 @@ Feature: Test the Search API v3 advanced queries on offers
     %{eventIdWithAgeRange}
     """
 
+  @testIsolation
+  Scenario: Search by typical age range using an advanced query also matches events entered with a birthdate range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
+    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q | id:%{eventId2020} AND typicalAgeRange:[0 TO 200] |
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId2020}
+    """
+
   Scenario: Search for country using an advanced query
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -1,0 +1,86 @@
+@sapi3
+Feature: Test the Search API v3 converted typical age range and birthdate range on offers
+
+  Background:
+    Given I am using the UDB3 base URL
+    And I am using an UiTID v1 API key of consumer "uitdatabank"
+    And I am authorized as JWT provider user "centraal_beheerder"
+    And I send and accept "application/json"
+
+  @testIsolation
+  Scenario: A single event entered with a typical age range exposes the matching birthdate range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-typical-age-range-single.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q             | id:%{eventId} |
+      | embed         | true          |
+      | availableFrom | *             |
+      | availableTo   | *             |
+    Then the JSON response at "member/0/birthdateRangeConverted" should be:
+    """
+    {
+      "from": "2009-04-23",
+      "to": "2011-04-22"
+    }
+    """
+    And the JSON response should not include:
+    """
+    typicalAgeRangeConverted
+    """
+
+  @testIsolation
+  Scenario: A single event entered with a birthdate range exposes the matching typical age range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-single.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q             | id:%{eventId} |
+      | embed         | true          |
+      | availableFrom | *             |
+      | availableTo   | *             |
+    Then the JSON response at "member/0/typicalAgeRangeConverted" should be "6-7"
+    And the JSON response should not include:
+    """
+    birthdateRangeConverted
+    """
+
+  @testIsolation
+  Scenario: A permanent event converts against the indexing date, so only presence is asserted
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-age-range-6-to-12.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q     | id:%{eventId} |
+      | embed | true          |
+    Then the JSON response at "member/0" should include:
+    """
+    birthdateRangeConverted
+    """
+    And the JSON response at "member/0/birthdateRangeConverted" should have 2 entries
+    And the JSON response should not include:
+    """
+    typicalAgeRangeConverted
+    """
+
+  @testIsolation
+  Scenario: An all ages event exposes no converted ranges and keeps its typical age range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-all-ages.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q     | id:%{eventId} |
+      | embed | true          |
+    Then the JSON response at "member/0/typicalAgeRange" should be "-"
+    And the JSON response should not include:
+    """
+    typicalAgeRangeConverted
+    """
+    And the JSON response should not include:
+    """
+    birthdateRangeConverted
+    """

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -106,23 +106,20 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
     birthdateRangeConverted
     """
     When I send a GET request to "/events" with parameters:
-      | minAge        | 9             |
-      | maxAge        | 11            |
-      | availableFrom | *             |
-      | availableTo   | *             |
-      | q             | id:%{eventId} |
+      | minAge        | 9  |
+      | maxAge        | 11 |
+      | availableFrom | *  |
+      | availableTo   | *  |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | minAge        | 6             |
-      | maxAge        | 7             |
-      | availableFrom | *             |
-      | availableTo   | *             |
-      | q             | id:%{eventId} |
+      | minAge        | 6 |
+      | maxAge        | 7 |
+      | availableFrom | * |
+      | availableTo   | * |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeFrom | 2010-01-01    |
-      | birthdateRangeTo   | 2010-12-31    |
-      | availableFrom      | *             |
-      | availableTo        | *             |
-      | q                  | id:%{eventId} |
+      | birthdateRangeFrom | 2010-01-01 |
+      | birthdateRangeTo   | 2010-12-31 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 1

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -56,7 +56,7 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
     When I send a GET request to "/events" with parameters:
       | q     | id:%{eventId} |
       | embed | true          |
-    Then the JSON response at "member/0" should include:
+    Then the JSON response should include:
     """
     birthdateRangeConverted
     """

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -84,3 +84,45 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
     """
     birthdateRangeConverted
     """
+
+  @testIsolation
+  Scenario: An event entered with both a typical age range and a birthdate range keeps the entered age
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-age-and-birthdate-range-single.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q             | id:%{eventId} |
+      | embed         | true          |
+      | availableFrom | *             |
+      | availableTo   | *             |
+    Then the JSON response at "member/0/typicalAgeRange" should be "9-11"
+    And the JSON response should not include:
+    """
+    typicalAgeRangeConverted
+    """
+    And the JSON response should not include:
+    """
+    birthdateRangeConverted
+    """
+    When I send a GET request to "/events" with parameters:
+      | minAge        | 9             |
+      | maxAge        | 11            |
+      | availableFrom | *             |
+      | availableTo   | *             |
+      | q             | id:%{eventId} |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | minAge        | 6             |
+      | maxAge        | 7             |
+      | availableFrom | *             |
+      | availableTo   | *             |
+      | q             | id:%{eventId} |
+    Then the JSON response at "totalItems" should be 0
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2010-01-01    |
+      | birthdateRangeTo   | 2010-12-31    |
+      | availableFrom      | *             |
+      | availableTo        | *             |
+      | q                  | id:%{eventId} |
+    Then the JSON response at "totalItems" should be 1

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -123,3 +123,37 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
       | availableFrom      | *          |
       | availableTo        | *          |
     Then the JSON response at "totalItems" should be 1
+
+  @testIsolation
+  Scenario: A multiple event entered with a birthdate range converts against its first sub event
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-multiple.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q             | id:%{eventId} |
+      | embed         | true          |
+      | availableFrom | *             |
+      | availableTo   | *             |
+    Then the JSON response at "member/0/typicalAgeRangeConverted" should be "6-7"
+    And the JSON response should not include:
+    """
+    birthdateRangeConverted
+    """
+
+  @testIsolation
+  Scenario: A periodic event entered with a birthdate range converts against its start date
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-periodic.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q             | id:%{eventId} |
+      | embed         | true          |
+      | availableFrom | *             |
+      | availableTo   | *             |
+    Then the JSON response at "member/0/typicalAgeRangeConverted" should be "6-7"
+    And the JSON response should not include:
+    """
+    birthdateRangeConverted
+    """

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -315,19 +315,25 @@ Feature: Test the Search API v3 url parameters on offers
     """
 
   @testIsolation
-  Scenario: Search by age using an url parameter also matches events entered with a birthdate range
+  Scenario: Search by a specific age using an url parameter also matches an event entered with a birthdate range
     When I create a minimal place and save the "url" as "placeUrl"
-    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
-    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I create an event from "events/event-with-birthdate-range-single.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | minAge | 0                 |
-      | q      | id:%{eventId2020} |
+      | minAge        | 6             |
+      | maxAge        | 7             |
+      | allAges       | false         |
+      | availableFrom | *             |
+      | availableTo   | *             |
+      | q             | id:%{eventId} |
     Then the JSON response at "totalItems" should be 1
-    And the JSON response should include:
-    """
-    %{eventId2020}
-    """
+    When I send a GET request to "/events" with parameters:
+      | minAge        | 18            |
+      | availableFrom | *             |
+      | availableTo   | *             |
+      | q             | id:%{eventId} |
+    Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -314,6 +314,21 @@ Feature: Test the Search API v3 url parameters on offers
     %{eventIdWithAgeRange}
     """
 
+  @testIsolation
+  Scenario: Search by age using an url parameter also matches events entered with a birthdate range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
+    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | minAge | 0                 |
+      | q      | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId2020}
+    """
+
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -321,18 +321,16 @@ Feature: Test the Search API v3 url parameters on offers
     And I wait for the event with url "/events/%{eventId}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | minAge        | 6             |
-      | maxAge        | 7             |
-      | allAges       | false         |
-      | availableFrom | *             |
-      | availableTo   | *             |
-      | q             | id:%{eventId} |
+      | minAge        | 6     |
+      | maxAge        | 7     |
+      | allAges       | false |
+      | availableFrom | *     |
+      | availableTo   | *     |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | minAge        | 18            |
-      | availableFrom | *             |
-      | availableTo   | *             |
-      | q             | id:%{eventId} |
+      | minAge        | 18 |
+      | availableFrom | *  |
+      | availableTo   | *  |
     Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using the common filters

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -329,6 +329,25 @@ Feature: Test the Search API v3 url parameters on offers
     %{eventId2020}
     """
 
+  @testIsolation
+  Scenario: Search by a one-sided birthdate range using an url parameter
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
+    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2019-01-01        |
+      | q                  | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeTo | 2020-06-30        |
+      | q                | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2021-01-01        |
+      | q                  | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 0
+
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -278,10 +278,14 @@ Feature: Test the Search API v3 url parameters on offers
     When I send a GET request to "/events" with parameters:
       | birthdateRangeFrom | 2018-01-01 |
       | birthdateRangeTo   | 2018-12-31 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
       | birthdateRangeFrom | 2020-01-01 |
       | birthdateRangeTo   | 2020-12-31 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """
@@ -293,17 +297,21 @@ Feature: Test the Search API v3 url parameters on offers
     When I create a minimal place and save the "url" as "placeUrl"
     And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
-    And I get the typical age range for one born in 2020 and keep it as "variableTypicalAgeRange"
+    And I get the typical age range for someone born in 2020 as of 2021 and keep it as "variableTypicalAgeRange"
     And I create an event from "events/event-with-variable-typical-age-range.json" and save the "id" as "eventIdWithAgeRange"
     And I wait for the event with url "/events/%{eventIdWithAgeRange}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
       | birthdateRangeFrom | 2018-01-01 |
       | birthdateRangeTo   | 2018-12-31 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
       | birthdateRangeFrom | 2020-01-01 |
       | birthdateRangeTo   | 2020-12-31 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 2
     And the JSON response should include:
     """

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -348,16 +348,19 @@ Feature: Test the Search API v3 url parameters on offers
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeFrom | 2019-01-01        |
-      | q                  | id:%{eventId2020} |
+      | birthdateRangeFrom | 2019-01-01 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeTo | 2020-06-30        |
-      | q                | id:%{eventId2020} |
+      | birthdateRangeTo | 2020-06-30 |
+      | availableFrom    | *          |
+      | availableTo      | *          |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeFrom | 2021-01-01        |
-      | q                  | id:%{eventId2020} |
+      | birthdateRangeFrom | 2021-01-01 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using the common filters

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -363,6 +363,36 @@ Feature: Test the Search API v3 url parameters on offers
       | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
 
+  @testIsolation
+  Scenario: An all ages event matches every birthdate range and is left out with allAges false
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-all-ages.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+      | allAges            | false      |
+    Then the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: A place is never returned for a birthdate range search
+    When I create a place from "places/citadel.json" and save the "id" as "placeId"
+    And I publish the place at "/places/%{placeId}"
+    And I wait for the place with url "/places/%{placeId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/offers" with parameters:
+      | allAges | true |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/offers" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+    Then the JSON response at "totalItems" should be 0
+
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"


### PR DESCRIPTION
### Added

End to end feature tests for the age and birthdate conversion in Search API v3.

- A single event entered with a typical age range exposes the matching birthdate range, and the other way around. These use a fixed start date, so the converted values are asserted exactly.
- A permanent event converts against the indexing date, so its value shifts over time and only presence is asserted.
- An all ages event exposes no converted ranges and keeps its `typicalAgeRange` of `-`.
- An age filter also matches an event entered with a birthdate range.

Ticket: https://jira.publiq.be/browse/III-7367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
