### PR TITLE
Add search feature tests for filtering across age and birthdate

### DIFF
--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -300,7 +300,9 @@ Feature: Test the Search API v3 advanced queries on offers
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | q | id:%{eventId2020} AND typicalAgeRange:[0 TO 200] |
+      | q             | typicalAgeRange:[0 TO 5] |
+      | availableFrom | *                        |
+      | availableTo   | *                        |
     Then the JSON response at "totalItems" should be 1
     And the JSON response should include:
     """

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -308,6 +308,11 @@ Feature: Test the Search API v3 advanced queries on offers
     """
     %{eventId2020}
     """
+    When I send a GET request to "/events" with parameters:
+      | q             | typicalAgeRange:[2 TO 10] |
+      | availableFrom | *                         |
+      | availableTo   | *                         |
+    Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using an advanced query
     When I create a minimal place and save the "id" as "placeId"

--- a/features/search/advanced-queries-offers.feature
+++ b/features/search/advanced-queries-offers.feature
@@ -281,6 +281,20 @@ Feature: Test the Search API v3 advanced queries on offers
     %{eventIdWithAgeRange}
     """
 
+  @testIsolation
+  Scenario: Search by typical age range using an advanced query also matches events entered with a birthdate range
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
+    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | q | id:%{eventId2020} AND typicalAgeRange:[0 TO 200] |
+    Then the JSON response at "totalItems" should be 1
+    And the JSON response should include:
+    """
+    %{eventId2020}
+    """
+
   Scenario: Search for country using an advanced query
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -329,6 +329,25 @@ Feature: Test the Search API v3 url parameters on offers
     %{eventId2020}
     """
 
+  @testIsolation
+  Scenario: Search by a one-sided birthdate range using an url parameter
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-birthdate-range-in-2020.json" and save the "id" as "eventId2020"
+    And I wait for the event with url "/events/%{eventId2020}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2019-01-01        |
+      | q                  | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeTo | 2020-06-30        |
+      | q                | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2021-01-01        |
+      | q                  | id:%{eventId2020} |
+    Then the JSON response at "totalItems" should be 0
+
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -348,16 +348,19 @@ Feature: Test the Search API v3 url parameters on offers
     And I wait for the event with url "/events/%{eventId2020}" to be indexed
     And I am using the Search API v3 base URL
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeFrom | 2019-01-01        |
-      | q                  | id:%{eventId2020} |
+      | birthdateRangeFrom | 2019-01-01 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeTo | 2020-06-30        |
-      | q                | id:%{eventId2020} |
+      | birthdateRangeTo | 2020-06-30 |
+      | availableFrom    | *          |
+      | availableTo      | *          |
     Then the JSON response at "totalItems" should be 1
     When I send a GET request to "/events" with parameters:
-      | birthdateRangeFrom | 2021-01-01        |
-      | q                  | id:%{eventId2020} |
+      | birthdateRangeFrom | 2021-01-01 |
+      | availableFrom      | *          |
+      | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
 
   Scenario: Search for country using the common filters

--- a/features/search/url-parameters-offers.feature
+++ b/features/search/url-parameters-offers.feature
@@ -363,6 +363,36 @@ Feature: Test the Search API v3 url parameters on offers
       | availableTo        | *          |
     Then the JSON response at "totalItems" should be 0
 
+  @testIsolation
+  Scenario: An all ages event matches every birthdate range and is left out with allAges false
+    When I create a minimal place and save the "url" as "placeUrl"
+    And I create an event from "events/event-with-all-ages.json" and save the "id" as "eventId"
+    And I wait for the event with url "/events/%{eventId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+      | allAges            | false      |
+    Then the JSON response at "totalItems" should be 0
+
+  @testIsolation
+  Scenario: A place is never returned for a birthdate range search
+    When I create a place from "places/citadel.json" and save the "id" as "placeId"
+    And I publish the place at "/places/%{placeId}"
+    And I wait for the place with url "/places/%{placeId}" to be indexed
+    And I am using the Search API v3 base URL
+    When I send a GET request to "/offers" with parameters:
+      | allAges | true |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/offers" with parameters:
+      | birthdateRangeFrom | 2020-01-01 |
+      | birthdateRangeTo   | 2020-12-31 |
+    Then the JSON response at "totalItems" should be 0
+
   Scenario: Search for country using the common filters
     When I create a minimal place and save the "id" as "placeId"
     And I publish the place at "/places/%{placeId}"


### PR DESCRIPTION
### Added

Feature tests for the search filtering we get once both ranges are indexed and the query-time conversion is gone.

- A one open bound birthdate range. Only a from, or only a to, matches an event whose birthdate range overlaps it.
- A `typicalAgeRange` advanced query matches an event that was entered with a birthdate range.

Ticket: https://jira.publiq.be/browse/III-7367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
