### PR TITLE
Wait for the contributor to be indexed in the search tests

### DIFF
--- a/features/search/contributors.feature
+++ b/features/search/contributors.feature
@@ -45,6 +45,7 @@ Feature: Test the Search API v3 contributors
       | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | contributors:%{placeContributorEmail} |
+    And I wait until the response contains 1 result
     And the JSON response at "member/0/@id" should be "%{placeUrl}"
     But the JSON response should not have "member/0/contributors"
 
@@ -67,5 +68,6 @@ Feature: Test the Search API v3 contributors
       | embed                 | true |
       | disableDefaultFilters | true |
       | q                     | contributors:%{eventContributorEmail} |
+    And I wait until the response contains 1 result
     And the JSON response at "member/0/@id" should be "%{eventUrl}"
     But the JSON response should not have "member/0/contributors"


### PR DESCRIPTION
### Changed

The contributor search feature tests failed randomly because they asserted the result before the contributor was indexed.

Contributors are stored in a separate repository and do not bump the aggregate playhead, so the "wait for the place or event to be indexed" step does not wait for them. The tests now poll the search until the contributor shows up before asserting, the same way the rest of the suite waits for results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
