### PR TITLE
III-7377 Remove the default typical age range from birthdate events

### DIFF
--- a/features/event/birthdate-range.feature
+++ b/features/event/birthdate-range.feature
@@ -54,6 +54,50 @@ Feature: Test birthdateRange on events
     And I get the event at "%{eventUrl}"
     And the JSON response should not have "birthdateRange"
 
+  Scenario: Setting a birthdateRange removes the default typicalAgeRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "typicalAgeRange" should be "-"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "birthdateRange/from" should be "2014-01-01"
+    And the JSON response should not have "typicalAgeRange"
+
+  Scenario: Deleting the birthdateRange restores the default typicalAgeRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
+    When I send a DELETE request to "%{eventUrl}/birthdate-range"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response should not have "birthdateRange"
+    And the JSON response at "typicalAgeRange" should be "-"
+
+  Scenario: A custom typicalAgeRange is kept next to a birthdateRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+        """
+        { "typicalAgeRange": "6-12" }
+        """
+    And I send a PUT request to "%{eventUrl}/typicalAgeRange"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    When I send a PUT request to "%{eventUrl}/birthdate-range"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "birthdateRange/from" should be "2014-01-01"
+    And the JSON response at "typicalAgeRange" should be "6-12"
+
   Scenario: Reject birthdateRange where from is greater than to
     Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
     And I set the JSON request payload to:

--- a/features/event/create.feature
+++ b/features/event/create.feature
@@ -1073,6 +1073,7 @@ Feature: Test the UDB3 events API
     And the JSON response should have "birthdateRange"
     And the JSON response at "birthdateRange/from" should be "2020-01-31"
     And the JSON response at "birthdateRange/to" should be "2020-12-31"
+    And the JSON response should not have "typicalAgeRange"
 
   Scenario: Try creating an event with an invalid birthdate range
     When I create a place from "places/place.json" and save the "url" as "placeUrl"

--- a/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
+++ b/src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php
@@ -56,7 +56,7 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
                 $json = $this->polyfillSubEventProperties($json);
                 $json = $this->polyfillEmbeddedPlaceStatus($json);
                 $json = $this->polyfillEmbeddedPlaceBookingAvailability($json);
-                $json = $this->polyfillTypicalAgeRange($json);
+                $json = $this->polyfillDefaultTypicalAgeRange($json);
 
                 if ($this->offerType->sameAs(OfferType::event())) {
                     $json = $this->polyfillAttendanceMode($json);
@@ -125,11 +125,20 @@ final class PropertyPolyfillOfferRepository extends DocumentRepositoryDecorator
         return $json;
     }
 
-    private function polyfillTypicalAgeRange(array $json): array
+    private function polyfillDefaultTypicalAgeRange(array $json): array
     {
-        if (!isset($json['typicalAgeRange'])) {
-            $json['typicalAgeRange'] = '-';
+        // A custom typicalAgeRange is kept, because we cannot tell which of the two is more important.
+        if (isset($json['typicalAgeRange']) && $json['typicalAgeRange'] !== '-') {
+            return $json;
         }
+
+        if (isset($json['birthdateRange'])) {
+            unset($json['typicalAgeRange']);
+
+            return $json;
+        }
+
+        $json['typicalAgeRange'] = '-';
 
         return $json;
     }

--- a/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
+++ b/tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php
@@ -367,6 +367,57 @@ class PropertyPolyfillOfferRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_polyfill_typicalAgeRange_when_a_birthdateRange_is_set(): void
+    {
+        $this
+            ->given([
+                'birthdateRange' => [
+                    'from' => '2010-01-01',
+                    'to' => '2010-12-31',
+                ],
+            ])
+            ->assertReturnedDocumentDoesNotContainKey('typicalAgeRange');
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_the_default_typicalAgeRange_when_a_birthdateRange_is_set(): void
+    {
+        $this
+            ->given([
+                'typicalAgeRange' => '-',
+                'birthdateRange' => [
+                    'from' => '2010-01-01',
+                    'to' => '2010-12-31',
+                ],
+            ])
+            ->assertReturnedDocumentDoesNotContainKey('typicalAgeRange');
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_a_custom_typicalAgeRange_when_a_birthdateRange_is_set(): void
+    {
+        $this
+            ->given([
+                'typicalAgeRange' => '6-12',
+                'birthdateRange' => [
+                    'from' => '2010-01-01',
+                    'to' => '2010-12-31',
+                ],
+            ])
+            ->assertReturnedDocumentContains(
+                [
+                    'typicalAgeRange' => '6-12',
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_polyfill_a_default_booking_availability_if_not_set(): void
     {
         $this


### PR DESCRIPTION
### Context

An event entered with a `birthdateRange` also carries the default `typicalAgeRange` of `-`, which contradicts it: `-` reads as all ages.

First step of making the two mutually exclusive. Doing it in the read model rather than the projector fixes existing events straight away, without waiting for a replay. A custom `typicalAgeRange` is left alone, because we cannot tell which of the two is more important.

### Changed

- `src/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepository.php`: The default `typicalAgeRange` is no longer added, and a stored one is removed, when the offer has a `birthdateRange`. Renamed `polyfillTypicalAgeRange` to `polyfillDefaultTypicalAgeRange`, since it only ever deals with the default.

### Added

- `tests/Offer/ReadModel/JSONLD/PropertyPolyfillOfferRepositoryTest.php`: No polyfill when a `birthdateRange` is set, the default removed, a custom age kept.
- `features/event/birthdate-range.feature`: Setting a `birthdateRange` removes the default, deleting it restores the default, and a custom age survives next to it.
- `features/event/create.feature`: An event created with a `birthdateRange` has no `typicalAgeRange`.

### Related PR

- https://github.com/cultuurnet/udb3-search-service/pull/525

---

Ticket: https://jira.publiq.be/browse/III-7377

🤖 Generated with [Claude Code](https://claude.com/claude-code)