### PR TITLE
III-7377 Make the birthdate range replace the typical age range

### DIFF
--- a/features/event/birthdate-range.feature
+++ b/features/event/birthdate-range.feature
@@ -81,13 +81,35 @@ Feature: Test birthdateRange on events
     And the JSON response should not have "birthdateRange"
     And the JSON response at "typicalAgeRange" should be "-"
 
-  Scenario: A custom typicalAgeRange is kept next to a birthdateRange
+  Scenario: Deleting a birthdateRange does not remove an existing typicalAgeRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "birthdateRange/from" should be "2014-01-01"
+    And I set the JSON request payload to:
+        """
+        { "typicalAgeRange": "6-12" }
+        """
+    And I send a PUT request to "%{eventUrl}/typicalAgeRange"
+    When I send a DELETE request to "%{eventUrl}/birthdate-range"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response should not have "birthdateRange"
+    And the JSON response at "typicalAgeRange" should be "6-12"
+
+  Scenario: Setting a birthdateRange removes a custom typicalAgeRange
     Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
     And I set the JSON request payload to:
         """
         { "typicalAgeRange": "6-12" }
         """
     And I send a PUT request to "%{eventUrl}/typicalAgeRange"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "typicalAgeRange" should be "6-12"
     And I set the JSON request payload to:
         """
         { "from": "2014-01-01", "to": "2020-12-31" }
@@ -96,7 +118,7 @@ Feature: Test birthdateRange on events
     Then the response status should be "204"
     And I get the event at "%{eventUrl}"
     And the JSON response at "birthdateRange/from" should be "2014-01-01"
-    And the JSON response at "typicalAgeRange" should be "6-12"
+    And the JSON response should not have "typicalAgeRange"
 
   Scenario: Reject birthdateRange where from is greater than to
     Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"

--- a/features/search/converted-age-and-birthdate.feature
+++ b/features/search/converted-age-and-birthdate.feature
@@ -86,7 +86,7 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
     """
 
   @testIsolation
-  Scenario: An event entered with both a typical age range and a birthdate range keeps the entered age
+  Scenario: An event entered with both a typical age range and a birthdate range keeps only the birthdate range
     When I create a minimal place and save the "url" as "placeUrl"
     And I create an event from "events/event-with-age-and-birthdate-range-single.json" and save the "id" as "eventId"
     And I wait for the event with url "/events/%{eventId}" to be indexed
@@ -96,26 +96,23 @@ Feature: Test the Search API v3 converted typical age range and birthdate range 
       | embed         | true          |
       | availableFrom | *             |
       | availableTo   | *             |
-    Then the JSON response at "member/0/typicalAgeRange" should be "9-11"
-    And the JSON response should not include:
-    """
-    typicalAgeRangeConverted
-    """
+    Then the JSON response should not have "member/0/typicalAgeRange"
+    And the JSON response at "member/0/typicalAgeRangeConverted" should be "6-7"
     And the JSON response should not include:
     """
     birthdateRangeConverted
     """
     When I send a GET request to "/events" with parameters:
-      | minAge        | 9  |
-      | maxAge        | 11 |
-      | availableFrom | *  |
-      | availableTo   | *  |
-    Then the JSON response at "totalItems" should be 1
-    When I send a GET request to "/events" with parameters:
       | minAge        | 6 |
       | maxAge        | 7 |
       | availableFrom | * |
       | availableTo   | * |
+    Then the JSON response at "totalItems" should be 1
+    When I send a GET request to "/events" with parameters:
+      | minAge        | 9  |
+      | maxAge        | 11 |
+      | availableFrom | *  |
+      | availableTo   | *  |
     Then the JSON response at "totalItems" should be 0
     When I send a GET request to "/events" with parameters:
       | birthdateRangeFrom | 2010-01-01 |

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -626,6 +626,7 @@ final class EventLDProjector extends OfferLDProjector implements
 
         $jsonLD->birthdateRange = (object) (new BirthdateRangeNormalizer())
             ->normalize($birthdateRangeUpdated->birthdateRange);
+        unset($jsonLD->typicalAgeRange);
 
         return $document->withBody($jsonLD);
     }
@@ -636,6 +637,11 @@ final class EventLDProjector extends OfferLDProjector implements
         $jsonLD = $document->getBody();
 
         unset($jsonLD->birthdateRange);
+
+        // A typicalAgeRange that is still set is newer than the birthdate range, so it stays.
+        if (!isset($jsonLD->typicalAgeRange)) {
+            $jsonLD->typicalAgeRange = '-';
+        }
 
         return $document->withBody($jsonLD);
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -2186,7 +2186,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
     /**
      * @test
-     * @dataProvider typicalAgeRangeBeforeBirthdateRangeDataProvider
+     * @dataProvider existingAgeRangeProvider
      */
     public function it_removes_the_typical_age_range_when_a_birthdate_range_is_set(
         string $typicalAgeRange
@@ -2214,7 +2214,7 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         $this->assertEquals('2014-01-01', $body->birthdateRange->from);
     }
 
-    public function typicalAgeRangeBeforeBirthdateRangeDataProvider(): array
+    public function existingAgeRangeProvider(): array
     {
         return [
             'the default age range' => ['-'],

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -2186,6 +2186,44 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
     /**
      * @test
+     * @dataProvider typicalAgeRangeBeforeBirthdateRangeDataProvider
+     */
+    public function it_removes_the_typical_age_range_when_a_birthdate_range_is_set(
+        string $typicalAgeRange
+    ): void {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $this->documentRepository->save(
+            new JsonDocument($eventId, Json::encode(['typicalAgeRange' => $typicalAgeRange]))
+        );
+
+        $body = $this->project(
+            new BirthdateRangeUpdated(
+                $eventId,
+                new BirthdateRange(
+                    new \DateTimeImmutable('2014-01-01'),
+                    new \DateTimeImmutable('2020-12-31')
+                )
+            ),
+            $eventId,
+            null,
+            $this->recordedOn->toBroadwayDateTime()
+        );
+
+        $this->assertFalse(property_exists($body, 'typicalAgeRange'));
+        $this->assertEquals('2014-01-01', $body->birthdateRange->from);
+    }
+
+    public function typicalAgeRangeBeforeBirthdateRangeDataProvider(): array
+    {
+        return [
+            'the default age range' => ['-'],
+            'a custom age range' => ['6-12'],
+        ];
+    }
+
+    /**
+     * @test
      */
     public function it_removes_birthdate_range_from_projection_when_deleted(): void
     {
@@ -2211,6 +2249,35 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
         );
 
         $this->assertFalse(property_exists($body, 'birthdateRange'));
+        $this->assertEquals('-', $body->typicalAgeRange);
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_a_custom_typical_age_range_when_the_birthdate_range_is_deleted(): void
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $this->documentRepository->save(
+            new JsonDocument(
+                $eventId,
+                Json::encode([
+                    'typicalAgeRange' => '6-12',
+                    'birthdateRange' => ['from' => '2014-01-01', 'to' => '2020-12-31'],
+                ])
+            )
+        );
+
+        $body = $this->project(
+            new BirthdateRangeDeleted($eventId),
+            $eventId,
+            null,
+            $this->recordedOn->toBroadwayDateTime()
+        );
+
+        $this->assertFalse(property_exists($body, 'birthdateRange'));
+        $this->assertEquals('6-12', $body->typicalAgeRange);
     }
 
     /**


### PR DESCRIPTION
### Context

Second step of making `typicalAgeRange` and `birthdateRange` mutually exclusive, on top of #2340. Moves the rule into the projector, so the saved document is right and not only the API response.

### Changed

- `src/Event/ReadModel/JSONLD/EventLDProjector.php`: Setting a `birthdateRange` removes the `typicalAgeRange`. Deleting one puts the default `-` back, unless an age is already set.
- `features/event/birthdate-range.feature`: Flipped the "a custom typicalAgeRange is kept" scenario from #2340.
- `features/search/converted-age-and-birthdate.feature`: An event sent with both ranges is now indexed as a birthdate event with a converted age.

### Added

- `tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php`: The age transitions on both birthdate range handlers.
- `features/event/birthdate-range.feature`: Setting a birthdate range removes a custom age; deleting one leaves an existing age alone.

### Related PR

- https://github.com/cultuurnet/udb3-search-service/pull/525

---

Ticket: https://jira.publiq.be/browse/III-7377

🤖 Generated with [Claude Code](https://claude.com/claude-code)