### PR TITLE
III-7377 Make the typical age range replace the birthdate range

### DIFF
--- a/features/event/birthdate-range.feature
+++ b/features/event/birthdate-range.feature
@@ -120,6 +120,42 @@ Feature: Test birthdateRange on events
     And the JSON response at "birthdateRange/from" should be "2014-01-01"
     And the JSON response should not have "typicalAgeRange"
 
+  Scenario: Setting a typicalAgeRange removes an existing birthdateRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
+    And I get the event at "%{eventUrl}"
+    And the JSON response at "birthdateRange/from" should be "2014-01-01"
+    And I set the JSON request payload to:
+        """
+        { "typicalAgeRange": "6-12" }
+        """
+    When I send a PUT request to "%{eventUrl}/typicalAgeRange"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response should not have "birthdateRange"
+    And the JSON response at "typicalAgeRange" should be "6-12"
+
+  Scenario: Setting an all ages typicalAgeRange removes an existing birthdateRange
+    Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
+    And I set the JSON request payload to:
+        """
+        { "from": "2014-01-01", "to": "2020-12-31" }
+        """
+    And I send a PUT request to "%{eventUrl}/birthdate-range"
+    And I set the JSON request payload to:
+        """
+        { "typicalAgeRange": "-" }
+        """
+    When I send a PUT request to "%{eventUrl}/typicalAgeRange"
+    Then the response status should be "204"
+    And I get the event at "%{eventUrl}"
+    And the JSON response should not have "birthdateRange"
+    And the JSON response at "typicalAgeRange" should be "-"
+
   Scenario: Reject birthdateRange where from is greater than to
     Given I create an event from "events/event-minimal-permanent.json" and save the "url" as "eventUrl"
     And I set the JSON request payload to:

--- a/src/Event/ReadModel/JSONLD/EventLDProjector.php
+++ b/src/Event/ReadModel/JSONLD/EventLDProjector.php
@@ -89,6 +89,7 @@ use CultuurNet\UDB3\Model\ValueObject\Taxonomy\Category\CategoryDomain;
 use CultuurNet\UDB3\Model\ValueObject\Translation\Language;
 use CultuurNet\UDB3\Offer\Events\AbstractCalendarUpdated;
 use CultuurNet\UDB3\Offer\Events\AbstractTypeUpdated;
+use CultuurNet\UDB3\Offer\Events\AbstractTypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Offer\IriOfferIdentifierFactoryInterface;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferLDProjector;
 use CultuurNet\UDB3\Offer\ReadModel\JSONLD\OfferUpdate;
@@ -642,6 +643,18 @@ final class EventLDProjector extends OfferLDProjector implements
         if (!isset($jsonLD->typicalAgeRange)) {
             $jsonLD->typicalAgeRange = '-';
         }
+
+        return $document->withBody($jsonLD);
+    }
+
+    protected function applyTypicalAgeRangeUpdated(
+        AbstractTypicalAgeRangeUpdated $typicalAgeRangeUpdated
+    ): JsonDocument {
+        $document = $this->loadDocumentFromRepository($typicalAgeRangeUpdated);
+        $jsonLD = $document->getBody();
+
+        $jsonLD->typicalAgeRange = $typicalAgeRangeUpdated->getTypicalAgeRange()->toString();
+        unset($jsonLD->birthdateRange);
 
         return $document->withBody($jsonLD);
     }

--- a/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
+++ b/tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php
@@ -37,6 +37,7 @@ use CultuurNet\UDB3\Model\ValueObject\Faq\Question;
 use CultuurNet\UDB3\Model\ValueObject\Faq\TranslatedFaq;
 use CultuurNet\UDB3\Event\Events\ThemeUpdated;
 use CultuurNet\UDB3\Event\Events\TypeUpdated;
+use CultuurNet\UDB3\Event\Events\TypicalAgeRangeUpdated;
 use CultuurNet\UDB3\Geocoding\Coordinate\Coordinates;
 use CultuurNet\UDB3\Geocoding\Coordinate\Latitude;
 use CultuurNet\UDB3\Geocoding\Coordinate\Longitude;
@@ -62,6 +63,8 @@ use CultuurNet\UDB3\Iri\CallableIriGenerator;
 use CultuurNet\UDB3\Json;
 use CultuurNet\UDB3\Label\ReadModels\JSON\Repository\ReadRepositoryInterface;
 use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
+use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Audience\BirthdateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\BookingAvailability;
@@ -2278,6 +2281,42 @@ class EventLDProjectorTest extends OfferLDProjectorTestBase
 
         $this->assertFalse(property_exists($body, 'birthdateRange'));
         $this->assertEquals('6-12', $body->typicalAgeRange);
+    }
+
+    /**
+     * @test
+     * @dataProvider updatedAgeRangeProvider
+     */
+    public function it_removes_the_birthdate_range_when_a_typical_age_range_is_set(
+        AgeRange $typicalAgeRange,
+        string $expected
+    ): void {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $this->documentRepository->save(
+            new JsonDocument(
+                $eventId,
+                Json::encode(['birthdateRange' => ['from' => '2014-01-01', 'to' => '2020-12-31']])
+            )
+        );
+
+        $body = $this->project(
+            new TypicalAgeRangeUpdated($eventId, $typicalAgeRange),
+            $eventId,
+            null,
+            $this->recordedOn->toBroadwayDateTime()
+        );
+
+        $this->assertFalse(property_exists($body, 'birthdateRange'));
+        $this->assertEquals($expected, $body->typicalAgeRange);
+    }
+
+    public function updatedAgeRangeProvider(): array
+    {
+        return [
+            'a custom age range' => [new AgeRange(new Age(6), new Age(12)), '6-12'],
+            'all ages' => [new AgeRange(), '-'],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Context

Third step of making `typicalAgeRange` and `birthdateRange` mutually exclusive, on top of #2341. Setting an age now drops a birthdate range, the mirror of what #2341 does in the other direction. After this an event is always in exactly one of the three states.

### Changed

- `src/Event/ReadModel/JSONLD/EventLDProjector.php`: `applyTypicalAgeRangeUpdated` removes the `birthdateRange`. Written out in full rather than calling the parent, matching the existing `applyCalendarUpdated` and `applyTypeUpdated` overrides. Places are untouched, so `birthdateRange` stays out of `OfferLDProjector`.

### Added

- `tests/Event/ReadModel/JSONLD/EventLDProjectorTest.php`: A custom age and all ages both remove the birthdate range.
- `features/event/birthdate-range.feature`: Setting a `typicalAgeRange` removes an existing `birthdateRange`, for a custom age and for `-`.

### Related PR

- https://github.com/cultuurnet/udb3-search-service/pull/525

---

Ticket: https://jira.publiq.be/browse/III-7377

🤖 Generated with [Claude Code](https://claude.com/claude-code)